### PR TITLE
feat: Keep resource locks in memory for the file-based configurations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,20 @@
 # Community Solid Server release notes
 
+## Unreleased
+
+### Configuration changes
+
+- The file-based configurations (`file.json`, `file-acp.json`, `file-root.json`, `file-root-pod.json`,
+  `example-https-file.json`, `https-file-cli.json`, `oidc.json`, `quota-file.json`, `restrict-idp.json`,
+  and `sparql-file-storage.json`) now import `css:config/util/resource-locker/in-memory.json`
+  instead of `css:config/util/resource-locker/file.json`,
+  so locks are no longer written to the file system.
+  This significantly reduces the number of file system operations per request.
+  Deployments that run with more than 1 worker thread need to import
+  `css:config/util/resource-locker/file.json` or `css:config/util/resource-locker/redis.json` instead,
+  as locks are no longer shared between processes with the new default;
+  the server will error on startup when this is required.
+
 ## v7.0.0
 
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,12 +8,34 @@
   `example-https-file.json`, `https-file-cli.json`, `oidc.json`, `quota-file.json`, `restrict-idp.json`,
   and `sparql-file-storage.json`) now import `css:config/util/resource-locker/in-memory.json`
   instead of `css:config/util/resource-locker/file.json`,
-  so locks are no longer written to the file system.
-  This significantly reduces the number of file system operations per request.
-  Deployments that run with more than 1 worker thread need to import
-  `css:config/util/resource-locker/file.json` or `css:config/util/resource-locker/redis.json` instead,
-  as locks are no longer shared between processes with the new default;
-  the server will error on startup when this is required.
+  so locks are kept in memory instead of being written to the file system.
+
+  **Recommendation: use the in-memory locker (the new default) for any single-process deployment,
+  and switch to the file-based or Redis locker only when you run more than one process.**
+
+  - **In-memory locker (`in-memory.json`, new default) — recommended for the standard single-process server.**
+    Acquiring and releasing a lock no longer touches the disk, which removes several file system
+    operations from every write and eliminates the disk polling a contended lock otherwise performs.
+    On the fork's benchmark (`config/file.json`, single process, write-heavy load),
+    LDP `PUT` dropped from ~48 to ~33 file system operations per request (about a third fewer),
+    with ~8% higher `PUT` throughput and ~24% lower p99 latency, while a run with 40 abandoned
+    writers went from ~1,200 idle file system operations per second (continuous lock-file polling)
+    to zero. Read-only and single-hot-resource workloads see little change, since their lock cost
+    is small and amortized. The trade-off is that these locks are per-process and non-durable:
+    they are not shared between workers or server instances. This is safe here because the file-based
+    configurations run single-process only and their locks are ephemeral (wiped on every start
+    regardless of the locker).
+
+  - **File-based locker (`file.json`) or Redis locker (`redis.json`) — required for multi-process deployments.**
+    Any deployment that runs with more than 1 worker thread, or multiple server instances sharing the
+    same file backend, must import `css:config/util/resource-locker/file.json` or
+    `css:config/util/resource-locker/redis.json` instead, because the in-memory locker does not
+    coordinate locks across processes. The file-based locker is safe across processes on shared
+    storage but does substantially more IO: it performs `mkdir`/`stat`/`rmdir` syscalls for every lock
+    acquire and release and polls the disk while waiting on a contended lock. Redis coordinates locks
+    across separate hosts at the cost of a network round-trip per lock operation.
+    To prevent silent corruption, the server errors on startup if the in-memory locker is used with
+    more than 1 worker, so an unsafe configuration cannot start unnoticed.
 
 ## v7.0.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,33 +9,10 @@
   and `sparql-file-storage.json`) now import `css:config/util/resource-locker/in-memory.json`
   instead of `css:config/util/resource-locker/file.json`,
   so locks are kept in memory instead of being written to the file system.
-
-  **Recommendation: use the in-memory locker (the new default) for any single-process deployment,
-  and switch to the file-based or Redis locker only when you run more than one process.**
-
-  - **In-memory locker (`in-memory.json`, new default) — recommended for the standard single-process server.**
-    Acquiring and releasing a lock no longer touches the disk, which removes several file system
-    operations from every write and eliminates the disk polling a contended lock otherwise performs.
-    On the fork's benchmark (`config/file.json`, single process, write-heavy load),
-    LDP `PUT` dropped from ~48 to ~33 file system operations per request (about a third fewer),
-    with ~8% higher `PUT` throughput and ~24% lower p99 latency, while a run with 40 abandoned
-    writers went from ~1,200 idle file system operations per second (continuous lock-file polling)
-    to zero. Read-only and single-hot-resource workloads see little change, since their lock cost
-    is small and amortized. The trade-off is that these locks are per-process and non-durable:
-    they are not shared between workers or server instances. This is safe here because the file-based
-    configurations run single-process only and their locks are ephemeral (wiped on every start
-    regardless of the locker).
-
-  - **File-based locker (`file.json`) or Redis locker (`redis.json`) — required for multi-process deployments.**
-    Any deployment that runs with more than 1 worker thread, or multiple server instances sharing the
-    same file backend, must import `css:config/util/resource-locker/file.json` or
-    `css:config/util/resource-locker/redis.json` instead, because the in-memory locker does not
-    coordinate locks across processes. The file-based locker is safe across processes on shared
-    storage but does substantially more IO: it performs `mkdir`/`stat`/`rmdir` syscalls for every lock
-    acquire and release and polls the disk while waiting on a contended lock. Redis coordinates locks
-    across separate hosts at the cost of a network round-trip per lock operation.
-    To prevent silent corruption, the server errors on startup if the in-memory locker is used with
-    more than 1 worker, so an unsafe configuration cannot start unnoticed.
+  Deployments that run more than 1 worker thread, or multiple server instances on the same file backend,
+  need to import `css:config/util/resource-locker/file.json` or `css:config/util/resource-locker/redis.json`
+  instead, as the in-memory locker does not coordinate locks across processes.
+  The server refuses to start when the in-memory locker is used with more than 1 worker.
 
 ## v7.0.0
 

--- a/config/example-https-file.json
+++ b/config/example-https-file.json
@@ -30,7 +30,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/file.json",
+    "css:config/util/resource-locker/in-memory.json",
     "css:config/util/variables/default.json",
 
     "css:config/http/server-factory/configurator/default.json"

--- a/config/file-acp.json
+++ b/config/file-acp.json
@@ -30,7 +30,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/file.json",
+    "css:config/util/resource-locker/in-memory.json",
     "css:config/util/variables/default.json"
   ],
   "@graph": [

--- a/config/file-root-pod.json
+++ b/config/file-root-pod.json
@@ -30,7 +30,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/file.json",
+    "css:config/util/resource-locker/in-memory.json",
     "css:config/util/variables/default.json"
   ],
   "@graph": [

--- a/config/file-root.json
+++ b/config/file-root.json
@@ -30,7 +30,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/file.json",
+    "css:config/util/resource-locker/in-memory.json",
     "css:config/util/variables/default.json"
   ],
   "@graph": [

--- a/config/file.json
+++ b/config/file.json
@@ -30,7 +30,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/file.json",
+    "css:config/util/resource-locker/in-memory.json",
     "css:config/util/variables/default.json"
   ],
   "@graph": [

--- a/config/https-file-cli.json
+++ b/config/https-file-cli.json
@@ -30,7 +30,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/file.json",
+    "css:config/util/resource-locker/in-memory.json",
     "css:config/util/variables/default.json"
   ],
   "@graph": [

--- a/config/oidc.json
+++ b/config/oidc.json
@@ -30,7 +30,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/file.json",
+    "css:config/util/resource-locker/in-memory.json",
     "css:config/util/variables/default.json"
   ],
   "@graph": [

--- a/config/quota-file.json
+++ b/config/quota-file.json
@@ -30,7 +30,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/file.json",
+    "css:config/util/resource-locker/in-memory.json",
     "css:config/util/variables/default.json"
   ],
   "@graph": [

--- a/config/restrict-idp.json
+++ b/config/restrict-idp.json
@@ -30,7 +30,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/file.json",
+    "css:config/util/resource-locker/in-memory.json",
     "css:config/util/variables/default.json"
   ],
   "@graph": [

--- a/config/sparql-file-storage.json
+++ b/config/sparql-file-storage.json
@@ -30,7 +30,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/file.json",
+    "css:config/util/resource-locker/in-memory.json",
     "css:config/util/variables/default.json",
 
     "css:config/storage/backend/data-accessors/file.json",

--- a/config/util/resource-locker/in-memory.json
+++ b/config/util/resource-locker/in-memory.json
@@ -2,10 +2,7 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
   "@graph": [
     {
-      "comment": [
-        "Allows multiple simultaneous read operations. Locks are kept in memory, so no file system operations are needed to acquire or release locks.",
-        "Locks expire after inactivity. This locker can not be used with worker threads: use file.json or redis.json for multi-process deployments."
-      ],
+      "comment": "Allows multiple simultaneous read operations. Locks are stored in memory. Locks expire after inactivity. This locker is not threadsafe: use file.json or redis.json for multi-process deployments.",
       "@id": "urn:solid-server:default:ResourceLocker",
       "@type": "WrappedExpiringReadWriteLocker",
       "locker": {

--- a/config/util/resource-locker/in-memory.json
+++ b/config/util/resource-locker/in-memory.json
@@ -1,0 +1,18 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": [
+        "Allows multiple simultaneous read operations. Locks are kept in memory, so no file system operations are needed to acquire or release locks.",
+        "Locks expire after inactivity. This locker can not be used with worker threads: use file.json or redis.json for multi-process deployments."
+      ],
+      "@id": "urn:solid-server:default:ResourceLocker",
+      "@type": "WrappedExpiringReadWriteLocker",
+      "locker": {
+        "@type": "PartialReadWriteLocker",
+        "locker": { "@type": "MemoryResourceLocker" }
+      },
+      "expiration": 6000
+    }
+  ]
+}

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -65,6 +65,13 @@ to some commonly used settings:
 | `--mainModulePath, -m`  |                            | Path from where Components.js will start its lookup when initializing configurations.                                                         |
 | `--workers, -w`         | `1`                        | Run in multithreaded mode using workers. Special values are `-1` (scale to `num_cores-1`), `0` (scale to `num_cores`) and 1 (singlethreaded). |
 
+When using more than 1 worker together with a file-based configuration,
+the configuration needs to import `css:config/util/resource-locker/file.json`,
+or `css:config/util/resource-locker/redis.json`,
+instead of the default `css:config/util/resource-locker/in-memory.json`,
+as the in-memory locker does not synchronize locks across processes.
+The server will refuse to start otherwise.
+
 Parameters can also be passed through environment variables.
 
 They are prefixed with `CSS_` and converted from `camelCase` to `CAMEL_CASE`


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — an upstream issue describing the file-locker overhead in the single-process configurations still needs to be created before submission (the upstream template requires one).

Companion PR: #23 fixes the file locker's unbounded disk-retry loop itself; this PR removes the file locker from the single-process default configurations.

#### ✍️ Description

The file-based configurations imported `resource-locker/file.json` (`FileSystemResourceLocker`, backed by `proper-lockfile`), which costs 3 file system syscalls (`mkdir` + `stat` + `rmdir`) per lock cycle, a `utimes` touch every 5 s per held lock, and 1–2 syscalls per 50–80 ms per *waiting* acquisition. Neither of the file locker's selling points applies in these configurations: persistence buys nothing because locks are wiped at every startup (`CleanupInitializer`), and cross-process safety is moot because `config/file.json` with `--workers 2` already refuses to start on `main` (`StreamingHttpMap, WebSocketMap` are not threadsafe — verified). The disk locker is pure overhead in every bootable file-based config.

This adds `config/util/resource-locker/in-memory.json` and switches the 10 file-based configurations to it. The new config keeps the exact composition the file locker used (`WrappedExpiringReadWriteLocker` → `PartialReadWriteLocker`) and swaps only the leaf locker for `MemoryResourceLocker`, so the locking semantics are otherwise unchanged. The existing `resource-locker/memory.json` was not reused because it composes a different read-write coordination (`GreedyReadWriteLocker` over the `LockStorage` key-value store); keeping the file configuration's composition limits the change to where locks are stored.

The trade-off: in-memory locks are per-process and non-durable — they are not shared between workers or server instances. That is safe here because these configurations are single-process only and their locks are ephemeral regardless of the locker. Multi-process deployments (which must already customize the notification config) keep using `resource-locker/file.json` or `redis.json`, as documented in `usage/starting-server.md` and the release notes. Because `MemoryResourceLocker` implements `SingleThreaded`, the new default with `--workers > 1` still fails fast at startup, so an unsafe combination cannot start unnoticed.

#### 📈 Performance

Instrumented A/B (this branch vs `main`, `config/file.json`, quiet M-series Mac), measured with the fs-op-counting harness from #28. Reproduce with (per its README):

```bash
node scripts/perf/runner.js --serverDir ../css-main --label main --wedge --out main.json
node scripts/perf/runner.js --serverDir ../css-pr --label pr --wedge --out pr.json
node scripts/perf/report.js main.json pr.json
```

| Metric | `main` | this PR |
| --- | --- | --- |
| fs ops/request, `PUT` small turtle (20 concurrent) | 48.2 | **33.1** |
| fs ops/request, `GET` spread resources | 26.1 | **20.0** |
| Idle fs ops/s with 1 slow reader + 40 abandoned writers | 1,211 (sustained indefinitely) | **0** |

The fs-op counts are deterministic; wall-clock throughput/latency on a local SSD was unchanged within noise (read-only and single-hot-resource workloads barely touch the locker, and a local SSD absorbs the rest). The wedge row reproduces the idle-IO problem: lock waiters poll the disk at ~30 ops/s each and survive client disconnects, so `.internal/locks` churn continues on an outwardly idle server (#23 addresses that retry loop itself).

#### 📋 Notes for review

- This is a configuration behaviour change: the intended semver level is **major**, and on upstreaming it should target the latest `versions/*` branch (currently `versions/next-major`), not `main`. Contributors cannot set labels, so both are left to the maintainer.
- The release-notes entry sits under an `Unreleased` heading; its placement follows the target branch on upstreaming.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
