### PR TITLE
perf: Cache compiled templates in the template engines

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -545,6 +545,10 @@ export * from './storage/ResourceSet';
 export * from './storage/ResourceStore';
 export * from './storage/RoutingResourceStore';
 
+// Util/Caching
+export * from './util/caching/CachedDecorator';
+export * from './util/caching/PromiseCache';
+
 // Util/Errors
 export * from './util/errors/BadRequestHttpError';
 export * from './util/errors/ConflictHttpError';

--- a/src/util/caching/CachedDecorator.ts
+++ b/src/util/caching/CachedDecorator.ts
@@ -1,0 +1,73 @@
+import type { PromiseCacheStore } from './PromiseCache';
+import { PromiseCache } from './PromiseCache';
+
+/**
+ * Options for the {@link cached} method decorator.
+ *
+ * @typeParam TThis - Type of the instance the decorated method belongs to.
+ * @typeParam TArgs - Argument tuple of the decorated method.
+ */
+export interface CachedOptions<TThis, TArgs extends unknown[]> {
+  /**
+   * Derives the cache key from the arguments of the decorated method.
+   * Defaults to using the first argument as key.
+   */
+  readonly key?: (this: TThis, ...args: TArgs) => unknown;
+  /**
+   * Whether to back the per-instance cache with a `WeakMap` instead of a `Map`.
+   * A `WeakMap` keys entries on object identity and lets them be garbage collected once the key is unreachable,
+   * which requires the cache key to be an object and is the memory-safe choice for request-scoped keys.
+   * Defaults to `false`, using a `Map` that caches for the lifetime of the instance.
+   */
+  readonly weak?: boolean;
+  /**
+   * Whether an entry whose promise rejects is evicted so the call is retried next time.
+   * Defaults to `true`.
+   */
+  readonly evictOnError?: boolean;
+}
+
+/**
+ * Method decorator that memoizes an asynchronous method with a {@link PromiseCache},
+ * making the widely repeated "look up a cached promise, otherwise compute and cache it" pattern
+ * a single, minimally invasive annotation.
+ *
+ * Each instance gets its own cache, so instances never share cached results.
+ * The returned promise is cached (not just its resolved value),
+ * so concurrent calls with the same key deduplicate onto a single in-flight computation.
+ *
+ * By default the first argument is used as cache key and entries live for the lifetime of the instance;
+ * use {@link CachedOptions.key} to derive the key differently
+ * and {@link CachedOptions.weak} to instead key entries on object identity in a `WeakMap`.
+ *
+ * @param options - {@link CachedOptions} controlling the key, backing store, and error eviction.
+ *
+ * @returns A decorator applying the described caching to the method.
+ *
+ * @typeParam TThis - Type of the instance the decorated method belongs to.
+ * @typeParam TArgs - Argument tuple of the decorated method.
+ * @typeParam TValue - Value the decorated method's promise resolves to.
+ */
+export function cached<TThis extends object, TArgs extends unknown[], TValue>(
+  options: CachedOptions<TThis, TArgs> = {},
+): (target: (this: TThis, ...args: TArgs) => Promise<TValue>) => (this: TThis, ...args: TArgs) => Promise<TValue> {
+  // One cache per instance, keyed on the instance itself so instances never share results.
+  const caches = new WeakMap<TThis, PromiseCache<unknown, TValue>>();
+
+  return (target: (this: TThis, ...args: TArgs) => Promise<TValue>):
+  (this: TThis, ...args: TArgs) => Promise<TValue> =>
+    async function(this: TThis, ...args: TArgs): Promise<TValue> {
+      let cache = caches.get(this);
+      if (!cache) {
+        // A WeakMap only accepts object keys, which the caller opts into via `weak`;
+        // the cast mirrors that the key type is only known to be an object at that call site.
+        const store = options.weak ?
+          new WeakMap<object, Promise<TValue>>() as unknown as PromiseCacheStore<unknown, Promise<TValue>> :
+          new Map<unknown, Promise<TValue>>();
+        cache = new PromiseCache<unknown, TValue>(store, { evictOnError: options.evictOnError });
+        caches.set(this, cache);
+      }
+      const key = options.key ? options.key.apply(this, args) : args[0];
+      return cache.getOrCreate(key, async(): Promise<TValue> => target.apply(this, args));
+    };
+}

--- a/src/util/caching/CachedDecorator.ts
+++ b/src/util/caching/CachedDecorator.ts
@@ -3,9 +3,6 @@ import { PromiseCache } from './PromiseCache';
 
 /**
  * Options for the {@link cached} method decorator.
- *
- * @typeParam TThis - Type of the instance the decorated method belongs to.
- * @typeParam TArgs - Argument tuple of the decorated method.
  */
 export interface CachedOptions<TThis, TArgs extends unknown[]> {
   /**
@@ -14,10 +11,9 @@ export interface CachedOptions<TThis, TArgs extends unknown[]> {
    */
   readonly key?: (this: TThis, ...args: TArgs) => unknown;
   /**
-   * Whether to back the per-instance cache with a `WeakMap` instead of a `Map`.
-   * A `WeakMap` keys entries on object identity and lets them be garbage collected once the key is unreachable,
-   * which requires the cache key to be an object and is the memory-safe choice for request-scoped keys.
-   * Defaults to `false`, using a `Map` that caches for the lifetime of the instance.
+   * Whether to back the cache with a `WeakMap` instead of a `Map`,
+   * which requires object keys and lets entries be garbage collected once their key is unreachable.
+   * Defaults to `false`.
    */
   readonly weak?: boolean;
   /**
@@ -28,30 +24,16 @@ export interface CachedOptions<TThis, TArgs extends unknown[]> {
 }
 
 /**
- * Method decorator that memoizes an asynchronous method with a {@link PromiseCache},
- * making the widely repeated "look up a cached promise, otherwise compute and cache it" pattern
- * a single, minimally invasive annotation.
- *
- * Each instance gets its own cache, so instances never share cached results.
- * The returned promise is cached (not just its resolved value),
- * so concurrent calls with the same key deduplicate onto a single in-flight computation.
- *
- * By default the first argument is used as cache key and entries live for the lifetime of the instance;
- * use {@link CachedOptions.key} to derive the key differently
- * and {@link CachedOptions.weak} to instead key entries on object identity in a `WeakMap`.
+ * Method decorator that memoizes an asynchronous method with a per-instance {@link PromiseCache}.
+ * The promise is cached rather than its resolved value,
+ * so concurrent calls with the same key share a single in-flight computation.
+ * By default the first argument is used as cache key; see {@link CachedOptions} for alternatives.
  *
  * @param options - {@link CachedOptions} controlling the key, backing store, and error eviction.
- *
- * @returns A decorator applying the described caching to the method.
- *
- * @typeParam TThis - Type of the instance the decorated method belongs to.
- * @typeParam TArgs - Argument tuple of the decorated method.
- * @typeParam TValue - Value the decorated method's promise resolves to.
  */
 export function cached<TThis extends object, TArgs extends unknown[], TValue>(
   options: CachedOptions<TThis, TArgs> = {},
 ): (target: (this: TThis, ...args: TArgs) => Promise<TValue>) => (this: TThis, ...args: TArgs) => Promise<TValue> {
-  // One cache per instance, keyed on the instance itself so instances never share results.
   const caches = new WeakMap<TThis, PromiseCache<unknown, TValue>>();
 
   return (target: (this: TThis, ...args: TArgs) => Promise<TValue>):
@@ -59,8 +41,7 @@ export function cached<TThis extends object, TArgs extends unknown[], TValue>(
     async function(this: TThis, ...args: TArgs): Promise<TValue> {
       let cache = caches.get(this);
       if (!cache) {
-        // A WeakMap only accepts object keys, which the caller opts into via `weak`;
-        // the cast mirrors that the key type is only known to be an object at that call site.
+        // The cast is safe since callers setting `weak` commit to object keys
         const store = options.weak ?
           new WeakMap<object, Promise<TValue>>() as unknown as PromiseCacheStore<unknown, Promise<TValue>> :
           new Map<unknown, Promise<TValue>>();

--- a/src/util/caching/PromiseCache.ts
+++ b/src/util/caching/PromiseCache.ts
@@ -1,10 +1,5 @@
 /**
  * The subset of the `Map`/`WeakMap` API that a {@link PromiseCache} uses to store its entries.
- * Both `Map` and `WeakMap` structurally satisfy this interface,
- * which lets a cache be backed by either of them:
- * a `Map` keeps its entries for as long as the cache exists (process-lifetime caching of a bounded key space),
- * while a `WeakMap` keyed on object identity lets entries be garbage collected
- * once their key object becomes unreachable, avoiding unbounded growth.
  */
 export interface PromiseCacheStore<TKey, TValue> {
   get: (key: TKey) => TValue | undefined;
@@ -17,36 +12,25 @@ export interface PromiseCacheStore<TKey, TValue> {
  */
 export interface PromiseCacheOptions {
   /**
-   * Whether an entry whose promise rejects is removed from the cache as soon as it rejects,
-   * so the failed computation is retried on the next call instead of being remembered.
+   * Whether an entry whose promise rejects is evicted so the computation is retried on the next call.
    * Defaults to `true`.
    */
   readonly evictOnError?: boolean;
 }
 
 /**
- * A small, reusable cache for asynchronous, keyed computations.
- *
- * The *promise* returned by the factory is cached rather than its resolved value,
- * so concurrent callers requesting the same key share a single in-flight computation and deduplicate,
- * instead of each starting their own.
- *
- * The cache is backed by an injected {@link PromiseCacheStore}, allowing the caller to pick the lifetime:
- * a `Map` (the default) caches for the lifetime of this object, which suits a bounded set of keys,
- * whereas a `WeakMap` keyed on object identity lets entries be collected once their key is unreachable,
- * which suits keys scoped to, for example, a single request.
- *
- * By default an entry whose promise rejects is evicted (see {@link PromiseCacheOptions.evictOnError}),
- * so transient failures are retried rather than cached.
+ * Caches the promises of asynchronous, keyed computations,
+ * so concurrent callers requesting the same key share a single in-flight computation.
+ * The backing {@link PromiseCacheStore} determines the lifetime of the entries:
+ * a `Map` (the default) caches them for the lifetime of this object,
+ * while a `WeakMap` keyed on object identity lets them be garbage collected once their key is unreachable.
  */
 export class PromiseCache<TKey, TValue> {
   private readonly store: PromiseCacheStore<TKey, Promise<TValue>>;
   private readonly evictOnError: boolean;
 
   /**
-   * @param store - Backing store for the cached promises. Defaults to a new `Map`, which caches
-   *                entries for the lifetime of this object. Pass a `WeakMap` to instead key entries
-   *                on object identity and let them be garbage collected once the key is unreachable.
+   * @param store - Backing store for the cached promises. Defaults to a new `Map`.
    * @param options - Additional {@link PromiseCacheOptions}.
    */
   public constructor(
@@ -59,12 +43,10 @@ export class PromiseCache<TKey, TValue> {
 
   /**
    * Returns the cached promise for the given key,
-   * or, on a cache miss, creates a new promise with the provided factory, caches it, and returns it.
+   * creating and caching it with the provided factory on a cache miss.
    *
    * @param key - Key to look up.
-   * @param createPromise - Factory generating the promise on a cache miss. It receives the key.
-   *
-   * @returns The cached or newly created promise.
+   * @param createPromise - Factory generating the promise on a cache miss.
    */
   public async getOrCreate(key: TKey, createPromise: (key: TKey) => Promise<TValue>): Promise<TValue> {
     const cached = this.store.get(key);
@@ -75,7 +57,6 @@ export class PromiseCache<TKey, TValue> {
     const promise = createPromise(key);
     this.store.set(key, promise);
     if (this.evictOnError) {
-      // Evict a rejected entry so the failed computation is retried on the next call.
       promise.catch((): void => {
         this.store.delete(key);
       });

--- a/src/util/caching/PromiseCache.ts
+++ b/src/util/caching/PromiseCache.ts
@@ -1,0 +1,85 @@
+/**
+ * The subset of the `Map`/`WeakMap` API that a {@link PromiseCache} uses to store its entries.
+ * Both `Map` and `WeakMap` structurally satisfy this interface,
+ * which lets a cache be backed by either of them:
+ * a `Map` keeps its entries for as long as the cache exists (process-lifetime caching of a bounded key space),
+ * while a `WeakMap` keyed on object identity lets entries be garbage collected
+ * once their key object becomes unreachable, avoiding unbounded growth.
+ */
+export interface PromiseCacheStore<TKey, TValue> {
+  get: (key: TKey) => TValue | undefined;
+  set: (key: TKey, value: TValue) => unknown;
+  delete: (key: TKey) => unknown;
+}
+
+/**
+ * Options for a {@link PromiseCache}.
+ */
+export interface PromiseCacheOptions {
+  /**
+   * Whether an entry whose promise rejects is removed from the cache as soon as it rejects,
+   * so the failed computation is retried on the next call instead of being remembered.
+   * Defaults to `true`.
+   */
+  readonly evictOnError?: boolean;
+}
+
+/**
+ * A small, reusable cache for asynchronous, keyed computations.
+ *
+ * The *promise* returned by the factory is cached rather than its resolved value,
+ * so concurrent callers requesting the same key share a single in-flight computation and deduplicate,
+ * instead of each starting their own.
+ *
+ * The cache is backed by an injected {@link PromiseCacheStore}, allowing the caller to pick the lifetime:
+ * a `Map` (the default) caches for the lifetime of this object, which suits a bounded set of keys,
+ * whereas a `WeakMap` keyed on object identity lets entries be collected once their key is unreachable,
+ * which suits keys scoped to, for example, a single request.
+ *
+ * By default an entry whose promise rejects is evicted (see {@link PromiseCacheOptions.evictOnError}),
+ * so transient failures are retried rather than cached.
+ */
+export class PromiseCache<TKey, TValue> {
+  private readonly store: PromiseCacheStore<TKey, Promise<TValue>>;
+  private readonly evictOnError: boolean;
+
+  /**
+   * @param store - Backing store for the cached promises. Defaults to a new `Map`, which caches
+   *                entries for the lifetime of this object. Pass a `WeakMap` to instead key entries
+   *                on object identity and let them be garbage collected once the key is unreachable.
+   * @param options - Additional {@link PromiseCacheOptions}.
+   */
+  public constructor(
+    store: PromiseCacheStore<TKey, Promise<TValue>> = new Map<TKey, Promise<TValue>>(),
+    options: PromiseCacheOptions = {},
+  ) {
+    this.store = store;
+    this.evictOnError = options.evictOnError ?? true;
+  }
+
+  /**
+   * Returns the cached promise for the given key,
+   * or, on a cache miss, creates a new promise with the provided factory, caches it, and returns it.
+   *
+   * @param key - Key to look up.
+   * @param createPromise - Factory generating the promise on a cache miss. It receives the key.
+   *
+   * @returns The cached or newly created promise.
+   */
+  public async getOrCreate(key: TKey, createPromise: (key: TKey) => Promise<TValue>): Promise<TValue> {
+    const cached = this.store.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const promise = createPromise(key);
+    this.store.set(key, promise);
+    if (this.evictOnError) {
+      // Evict a rejected entry so the failed computation is retried on the next call.
+      promise.catch((): void => {
+        this.store.delete(key);
+      });
+    }
+    return promise;
+  }
+}

--- a/src/util/templates/EjsTemplateEngine.ts
+++ b/src/util/templates/EjsTemplateEngine.ts
@@ -13,13 +13,9 @@ export class EjsTemplateEngine<T extends Dict<unknown> = Dict<unknown>> extends 
   private readonly baseUrl: string;
 
   /**
-   * Compiled templates, cached for the lifetime of this engine.
-   *
-   * A {@link Map} (rather than a {@link WeakMap}) is deliberate: templates are keyed on their resolved
-   * file path, or on the template string for string-based templates, and both are primitives that a
-   * {@link WeakMap} cannot hold. Since the set of templates is fixed by the server configuration, the
-   * key space is bounded and caching for the process lifetime is safe. The trade-off is that editing a
-   * template file requires a server restart.
+   * Compiled templates, keyed on their resolved file path, or on the template string for string templates.
+   * The server configuration determines the set of templates, so the cache is bounded,
+   * but editing a template file requires a server restart to take effect.
    */
   private readonly cache: PromiseCache<string, TemplateFunction>;
 
@@ -46,7 +42,6 @@ export class EjsTemplateEngine<T extends Dict<unknown> = Dict<unknown>> extends 
    * @param template - Template to compile.
    */
   private async getCompiledTemplate(filename?: string, template?: Template): Promise<TemplateFunction> {
-    // File-based templates are cached on their resolved file path, string-based templates on their contents
     const key = filename ?? await readTemplate(template);
     return this.cache.getOrCreate(key, async(): Promise<TemplateFunction> => {
       // For string-based templates the cache key already contains the template contents

--- a/src/util/templates/EjsTemplateEngine.ts
+++ b/src/util/templates/EjsTemplateEngine.ts
@@ -1,6 +1,8 @@
-import { render } from 'ejs';
+import type { TemplateFunction } from 'ejs';
+import { compile } from 'ejs';
+import { PromiseCache } from '../caching/PromiseCache';
 import { ExtensionBasedTemplateEngine } from './ExtensionBasedTemplateEngine';
-import type { TemplateEngineInput } from './TemplateEngine';
+import type { Template, TemplateEngineInput } from './TemplateEngine';
 import { getTemplateFilePath, readTemplate } from './TemplateUtil';
 import Dict = NodeJS.Dict;
 
@@ -11,16 +13,45 @@ export class EjsTemplateEngine<T extends Dict<unknown> = Dict<unknown>> extends 
   private readonly baseUrl: string;
 
   /**
+   * Compiled templates, cached for the lifetime of this engine.
+   *
+   * A {@link Map} (rather than a {@link WeakMap}) is deliberate: templates are keyed on their resolved
+   * file path, or on the template string for string-based templates, and both are primitives that a
+   * {@link WeakMap} cannot hold. Since the set of templates is fixed by the server configuration, the
+   * key space is bounded and caching for the process lifetime is safe. The trade-off is that editing a
+   * template file requires a server restart.
+   */
+  private readonly cache: PromiseCache<string, TemplateFunction>;
+
+  /**
    * @param baseUrl - Base URL of the server.
    * @param supportedExtensions - The extensions that are supported by this template engine (defaults to 'ejs').
    */
   public constructor(baseUrl: string, supportedExtensions = [ 'ejs' ]) {
     super(supportedExtensions);
     this.baseUrl = baseUrl;
+    this.cache = new PromiseCache();
   }
 
   public async handle({ contents, template }: TemplateEngineInput<T>): Promise<string> {
-    const options = { ...contents, filename: getTemplateFilePath(template), baseUrl: this.baseUrl };
-    return render(await readTemplate(template), options);
+    const filename = getTemplateFilePath(template);
+    const applyTemplate = await this.getCompiledTemplate(filename, template);
+    return applyTemplate({ ...contents, filename, baseUrl: this.baseUrl });
+  }
+
+  /**
+   * Returns the compiled template, compiling and caching it first if necessary.
+   *
+   * @param filename - Resolved path of the template file, if the template is file-based.
+   * @param template - Template to compile.
+   */
+  private async getCompiledTemplate(filename?: string, template?: Template): Promise<TemplateFunction> {
+    // File-based templates are cached on their resolved file path, string-based templates on their contents
+    const key = filename ?? await readTemplate(template);
+    return this.cache.getOrCreate(key, async(): Promise<TemplateFunction> => {
+      // For string-based templates the cache key already contains the template contents
+      const contents = filename ? await readTemplate(template) : key;
+      return compile(contents, { filename });
+    });
   }
 }

--- a/src/util/templates/HandlebarsTemplateEngine.ts
+++ b/src/util/templates/HandlebarsTemplateEngine.ts
@@ -1,7 +1,9 @@
+import type { TemplateDelegate } from 'handlebars';
 import { compile } from 'handlebars';
+import { PromiseCache } from '../caching/PromiseCache';
 import { ExtensionBasedTemplateEngine } from './ExtensionBasedTemplateEngine';
-import type { TemplateEngineInput } from './TemplateEngine';
-import { readTemplate } from './TemplateUtil';
+import type { Template, TemplateEngineInput } from './TemplateEngine';
+import { getTemplateFilePath, readTemplate } from './TemplateUtil';
 import Dict = NodeJS.Dict;
 
 /**
@@ -11,16 +13,44 @@ export class HandlebarsTemplateEngine<T extends Dict<unknown> = Dict<unknown>> e
   private readonly baseUrl: string;
 
   /**
+   * Compiled templates, cached for the lifetime of this engine.
+   *
+   * A {@link Map} (rather than a {@link WeakMap}) is deliberate: templates are keyed on their resolved
+   * file path, or on the template string for string-based templates, and both are primitives that a
+   * {@link WeakMap} cannot hold. Since the set of templates is fixed by the server configuration, the
+   * key space is bounded and caching for the process lifetime is safe. The trade-off is that editing a
+   * template file requires a server restart.
+   */
+  private readonly cache: PromiseCache<string, TemplateDelegate>;
+
+  /**
    * @param baseUrl - Base URL of the server.
    * @param supportedExtensions - The extensions that are supported by this template engine (defaults to 'hbs').
    */
   public constructor(baseUrl: string, supportedExtensions = [ 'hbs' ]) {
     super(supportedExtensions);
     this.baseUrl = baseUrl;
+    this.cache = new PromiseCache();
   }
 
   public async handle({ contents, template }: TemplateEngineInput<T>): Promise<string> {
-    const applyTemplate = compile(await readTemplate(template));
+    const applyTemplate = await this.getCompiledTemplate(template);
     return applyTemplate({ ...contents, baseUrl: this.baseUrl });
+  }
+
+  /**
+   * Returns the compiled template, compiling and caching it first if necessary.
+   *
+   * @param template - Template to compile.
+   */
+  private async getCompiledTemplate(template?: Template): Promise<TemplateDelegate> {
+    const filePath = getTemplateFilePath(template);
+    // File-based templates are cached on their resolved file path, string-based templates on their contents
+    const key = filePath ?? await readTemplate(template);
+    return this.cache.getOrCreate(key, async(): Promise<TemplateDelegate> => {
+      // For string-based templates the cache key already contains the template contents
+      const contents = filePath ? await readTemplate(template) : key;
+      return compile(contents);
+    });
   }
 }

--- a/src/util/templates/HandlebarsTemplateEngine.ts
+++ b/src/util/templates/HandlebarsTemplateEngine.ts
@@ -13,13 +13,9 @@ export class HandlebarsTemplateEngine<T extends Dict<unknown> = Dict<unknown>> e
   private readonly baseUrl: string;
 
   /**
-   * Compiled templates, cached for the lifetime of this engine.
-   *
-   * A {@link Map} (rather than a {@link WeakMap}) is deliberate: templates are keyed on their resolved
-   * file path, or on the template string for string-based templates, and both are primitives that a
-   * {@link WeakMap} cannot hold. Since the set of templates is fixed by the server configuration, the
-   * key space is bounded and caching for the process lifetime is safe. The trade-off is that editing a
-   * template file requires a server restart.
+   * Compiled templates, keyed on their resolved file path, or on the template string for string templates.
+   * The server configuration determines the set of templates, so the cache is bounded,
+   * but editing a template file requires a server restart to take effect.
    */
   private readonly cache: PromiseCache<string, TemplateDelegate>;
 
@@ -45,7 +41,6 @@ export class HandlebarsTemplateEngine<T extends Dict<unknown> = Dict<unknown>> e
    */
   private async getCompiledTemplate(template?: Template): Promise<TemplateDelegate> {
     const filePath = getTemplateFilePath(template);
-    // File-based templates are cached on their resolved file path, string-based templates on their contents
     const key = filePath ?? await readTemplate(template);
     return this.cache.getOrCreate(key, async(): Promise<TemplateDelegate> => {
       // For string-based templates the cache key already contains the template contents

--- a/test/unit/util/caching/CachedDecorator.test.ts
+++ b/test/unit/util/caching/CachedDecorator.test.ts
@@ -1,0 +1,115 @@
+import { cached } from '../../../../src/util/caching/CachedDecorator';
+
+describe('The cached decorator', (): void => {
+  it('caches a method result per instance based on the first argument.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Counter {
+      private count = 0;
+
+      @cached()
+      public async get(key: string): Promise<number> {
+        spy(key);
+        const value = this.count;
+        this.count += 1;
+        return value;
+      }
+    }
+    const instance = new Counter();
+    await expect(instance.get('a')).resolves.toBe(0);
+    await expect(instance.get('a')).resolves.toBe(0);
+    await expect(instance.get('b')).resolves.toBe(1);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(1, 'a');
+    expect(spy).toHaveBeenNthCalledWith(2, 'b');
+  });
+
+  it('gives each instance its own cache.', async(): Promise<void> => {
+    class Counter {
+      private count = 0;
+
+      @cached()
+      public async get(): Promise<number> {
+        const value = this.count;
+        this.count += 1;
+        return value;
+      }
+    }
+    const first = new Counter();
+    const second = new Counter();
+    await expect(first.get()).resolves.toBe(0);
+    await expect(second.get()).resolves.toBe(0);
+    await expect(first.get()).resolves.toBe(0);
+  });
+
+  it('can key a WeakMap-backed cache on object identity.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Store {
+      private count = 0;
+
+      @cached({ weak: true })
+      public async get(key: object): Promise<number> {
+        spy(key);
+        const value = this.count;
+        this.count += 1;
+        return value;
+      }
+    }
+    const store = new Store();
+    const key1 = {};
+    const key2 = {};
+    await expect(store.get(key1)).resolves.toBe(0);
+    await expect(store.get(key1)).resolves.toBe(0);
+    await expect(store.get(key2)).resolves.toBe(1);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('supports deriving the cache key from all arguments.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Store {
+      @cached({ key: (a: string, b: string): string => `${a}:${b}` })
+      public async get(a: string, b: string): Promise<string> {
+        spy();
+        return `${a}${b}`;
+      }
+    }
+    const store = new Store();
+    await expect(store.get('a', 'b')).resolves.toBe('ab');
+    await expect(store.get('a', 'b')).resolves.toBe('ab');
+    await expect(store.get('a', 'c')).resolves.toBe('ac');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates concurrent calls onto a single computation.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Store {
+      @cached()
+      public async get(key: string): Promise<string> {
+        spy();
+        return key;
+      }
+    }
+    const store = new Store();
+    const [ first, second ] = await Promise.all([ store.get('a'), store.get('a') ]);
+    expect(first).toBe('a');
+    expect(second).toBe('a');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries the method after a rejection by default.', async(): Promise<void> => {
+    let calls = 0;
+    class Store {
+      @cached()
+      public async get(key: string): Promise<number> {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error(`fail-${key}`);
+        }
+        return 5;
+      }
+    }
+    const store = new Store();
+    await expect(store.get('a')).rejects.toThrow('fail-a');
+    await expect(store.get('a')).resolves.toBe(5);
+    expect(calls).toBe(2);
+  });
+});

--- a/test/unit/util/caching/PromiseCache.test.ts
+++ b/test/unit/util/caching/PromiseCache.test.ts
@@ -1,0 +1,80 @@
+import { PromiseCache } from '../../../../src/util/caching/PromiseCache';
+
+describe('A PromiseCache', (): void => {
+  it('computes and caches a value on a miss and reuses it on a hit.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    const factory = jest.fn(async(): Promise<number> => 1);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(1);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(1);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the key to the factory.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, string>();
+    const factory = jest.fn(async(key: string): Promise<string> => `v:${key}`);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe('v:a');
+    expect(factory).toHaveBeenLastCalledWith('a');
+  });
+
+  it('caches separate values for separate keys.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    let count = 0;
+    const factory = jest.fn(async(): Promise<number> => {
+      const value = count;
+      count += 1;
+      return value;
+    });
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(0);
+    await expect(cache.getOrCreate('b', factory)).resolves.toBe(1);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(0);
+  });
+
+  it('deduplicates concurrent calls for the same key onto a single computation.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    const factory = jest.fn(async(): Promise<number> => 42);
+    const [ first, second ] = await Promise.all([ cache.getOrCreate('a', factory), cache.getOrCreate('a', factory) ]);
+    expect(first).toBe(42);
+    expect(second).toBe(42);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports a WeakMap backing store keyed on object identity.', async(): Promise<void> => {
+    const cache = new PromiseCache<object, number>(new WeakMap());
+    const key1 = {};
+    const key2 = {};
+    let count = 0;
+    const factory = jest.fn(async(): Promise<number> => {
+      const value = count;
+      count += 1;
+      return value;
+    });
+    await expect(cache.getOrCreate(key1, factory)).resolves.toBe(0);
+    await expect(cache.getOrCreate(key1, factory)).resolves.toBe(0);
+    await expect(cache.getOrCreate(key2, factory)).resolves.toBe(1);
+  });
+
+  it('evicts an entry whose promise rejects so it is retried.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    let calls = 0;
+    const factory = jest.fn(async(): Promise<number> => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error('fail');
+      }
+      return 5;
+    });
+    await expect(cache.getOrCreate('a', factory)).rejects.toThrow('fail');
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(5);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a rejected entry cached when evictOnError is disabled.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>(new Map(), { evictOnError: false });
+    const factory = jest.fn(async(): Promise<number> => {
+      throw new Error('fail');
+    });
+    await expect(cache.getOrCreate('a', factory)).rejects.toThrow('fail');
+    await expect(cache.getOrCreate('a', factory)).rejects.toThrow('fail');
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/util/templates/EjsTemplateEngine.test.ts
+++ b/test/unit/util/templates/EjsTemplateEngine.test.ts
@@ -1,9 +1,18 @@
+import { compile } from 'ejs';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
 import { EjsTemplateEngine } from '../../../../src/util/templates/EjsTemplateEngine';
+import { readTemplate } from '../../../../src/util/templates/TemplateUtil';
+
+jest.mock('ejs', (): any => ({
+  ...jest.requireActual('ejs'),
+  compile: jest.fn((template: string, opts?: unknown): unknown => jest.requireActual('ejs').compile(template, opts)),
+}));
 
 jest.mock('../../../../src/util/templates/TemplateUtil', (): any => ({
-  getTemplateFilePath: jest.fn((template): string => template),
-  readTemplate: jest.fn(async(): Promise<string> => `<%= detail %>`),
+  getTemplateFilePath: jest.fn((template): string | undefined =>
+    typeof template === 'string' ? template : undefined),
+  readTemplate: jest.fn(async(template): Promise<string> =>
+    typeof template === 'object' ? template.templateString : `<%= detail %>`),
 }));
 
 describe('A EjsTemplateEngine', (): void => {
@@ -11,6 +20,7 @@ describe('A EjsTemplateEngine', (): void => {
   let templateEngine: EjsTemplateEngine;
 
   beforeEach((): void => {
+    jest.clearAllMocks();
     templateEngine = new EjsTemplateEngine('http://localhost:3000');
   });
 
@@ -27,5 +37,32 @@ describe('A EjsTemplateEngine', (): void => {
   it('throws an exception if no template was passed.', async(): Promise<void> => {
     await expect(templateEngine.handleSafe({ contents }))
       .rejects.toThrow(NotImplementedHttpError);
+  });
+
+  it('only reads and compiles a template once when rendering it multiple times.', async(): Promise<void> => {
+    await expect(templateEngine.handleSafe({ contents, template: 'someTemplate.ejs' }))
+      .resolves.toBe('a&amp;b');
+    await expect(templateEngine.handleSafe({ contents, template: 'someTemplate.ejs' }))
+      .resolves.toBe('a&amp;b');
+    expect(readTemplate).toHaveBeenCalledTimes(1);
+    expect(compile).toHaveBeenCalledTimes(1);
+    expect(compile).toHaveBeenLastCalledWith('<%= detail %>', { filename: 'someTemplate.ejs' });
+  });
+
+  it('caches compiled templates separately per template.', async(): Promise<void> => {
+    await expect(templateEngine.handleSafe({ contents, template: 'someTemplate.ejs' }))
+      .resolves.toBe('a&amp;b');
+    await expect(templateEngine.handleSafe({ contents, template: 'otherTemplate.ejs' }))
+      .resolves.toBe('a&amp;b');
+    expect(readTemplate).toHaveBeenCalledTimes(2);
+    expect(compile).toHaveBeenCalledTimes(2);
+  });
+
+  it('only compiles a string template once when rendering it multiple times.', async(): Promise<void> => {
+    const template = { templateString: '<%= detail %>' };
+    await expect(templateEngine.handle({ contents, template })).resolves.toBe('a&amp;b');
+    await expect(templateEngine.handle({ contents, template })).resolves.toBe('a&amp;b');
+    expect(compile).toHaveBeenCalledTimes(1);
+    expect(compile).toHaveBeenLastCalledWith('<%= detail %>', { filename: undefined });
   });
 });

--- a/test/unit/util/templates/HandlebarsTemplateEngine.test.ts
+++ b/test/unit/util/templates/HandlebarsTemplateEngine.test.ts
@@ -1,9 +1,18 @@
+import { compile } from 'handlebars';
 import { NotImplementedHttpError } from '../../../../src';
 import { HandlebarsTemplateEngine } from '../../../../src/util/templates/HandlebarsTemplateEngine';
+import { readTemplate } from '../../../../src/util/templates/TemplateUtil';
+
+jest.mock('handlebars', (): any => ({
+  ...jest.requireActual('handlebars'),
+  compile: jest.fn((template: string): unknown => jest.requireActual('handlebars').compile(template)),
+}));
 
 jest.mock('../../../../src/util/templates/TemplateUtil', (): any => ({
-  getTemplateFilePath: jest.fn((template): string => template),
-  readTemplate: jest.fn(async(): Promise<string> => `{{detail}}`),
+  getTemplateFilePath: jest.fn((template): string | undefined =>
+    typeof template === 'string' ? template : undefined),
+  readTemplate: jest.fn(async(template): Promise<string> =>
+    typeof template === 'object' ? template.templateString : `{{detail}}`),
 }));
 
 describe('A HandlebarsTemplateEngine', (): void => {
@@ -11,6 +20,7 @@ describe('A HandlebarsTemplateEngine', (): void => {
   let templateEngine: HandlebarsTemplateEngine;
 
   beforeEach((): void => {
+    jest.clearAllMocks();
     templateEngine = new HandlebarsTemplateEngine('http://localhost:3000/');
   });
 
@@ -27,5 +37,30 @@ describe('A HandlebarsTemplateEngine', (): void => {
   it('throws an exception if no template was passed.', async(): Promise<void> => {
     await expect(templateEngine.handleSafe({ contents }))
       .rejects.toThrow(NotImplementedHttpError);
+  });
+
+  it('only reads and compiles a template once when rendering it multiple times.', async(): Promise<void> => {
+    await expect(templateEngine.handleSafe({ contents, template: 'someTemplate.hbs' }))
+      .resolves.toBe('a&amp;b');
+    await expect(templateEngine.handleSafe({ contents, template: 'someTemplate.hbs' }))
+      .resolves.toBe('a&amp;b');
+    expect(readTemplate).toHaveBeenCalledTimes(1);
+    expect(compile).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches compiled templates separately per template.', async(): Promise<void> => {
+    await expect(templateEngine.handleSafe({ contents, template: 'someTemplate.hbs' }))
+      .resolves.toBe('a&amp;b');
+    await expect(templateEngine.handleSafe({ contents, template: 'otherTemplate.hbs' }))
+      .resolves.toBe('a&amp;b');
+    expect(readTemplate).toHaveBeenCalledTimes(2);
+    expect(compile).toHaveBeenCalledTimes(2);
+  });
+
+  it('only compiles a string template once when rendering it multiple times.', async(): Promise<void> => {
+    const template = { templateString: '{{detail}}' };
+    await expect(templateEngine.handle({ contents, template })).resolves.toBe('a&amp;b');
+    await expect(templateEngine.handle({ contents, template })).resolves.toBe('a&amp;b');
+    expect(compile).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — the upstream PR template requires a linked issue, so an issue describing the repeated
template recompilation needs to be created on CommunitySolidServer before this is submitted upstream.

#### ✍️ Description

`HandlebarsTemplateEngine` and `EjsTemplateEngine` re-read the template file from disk and recompiled it
on every `handle()` call. These engines sit on rendered-output hot paths (IdP login/consent pages, error
pages, HTML views, emails), so every render paid one file read plus a full template compile.

Both engines now cache the compiled template function through a new `PromiseCache` utility
(`src/util/caching/`):

- File-based templates are keyed on their resolved file path (`getTemplateFilePath`); string-based
  templates on the template string itself (no file I/O involved there; only the compile is skipped on a hit).
- The promise is cached rather than the resolved value, so concurrent first renders of the same template
  share a single read + compile.
- A `Map` backs the cache rather than a `WeakMap`: the keys are strings (which a `WeakMap` cannot hold),
  and since the server configuration fixes the template set, the key space is bounded and process-lifetime
  caching is safe. The deliberate trade-off — noted in the TSDoc — is that editing a template file now
  requires a server restart to take effect.
- `EjsTemplateEngine` switches from `ejs.render()` to `ejs.compile()` with `{ filename }` as the compile
  option; the compiled function receives the same data object as before (`{ ...contents, filename, baseUrl }`),
  so no template-visible variables change. One nuance: `render(str, data)` treats certain data keys
  (`delimiter`, `cache`, `async`, …) as *options*, which `compile` no longer would. No CSS call site passes
  such keys (all call sites checked: `HtmlViewHandler`, `ForgotPasswordHandler`, `BaseResourcesGenerator`,
  `DynamicJsonToTemplateConverter`, `ErrorToTemplateConverter`, `MarkdownToHtmlConverter`,
  `ContainerToTemplateConverter`, `StaticTemplateEngine`), so behaviour is unchanged in practice.

The PR also adds a `cached()` method decorator over the same `PromiseCache`. Nothing in this PR uses it —
the engines use `PromiseCache` directly — so it is strictly extra public surface; happy to drop it from
this PR to keep the change minimal.

**Reproducible before/after (deterministic op counts, per render of one template):**

| Per render          | Before | After (first) | After (subsequent) |
| ------------------- | ------ | ------------- | ------------------ |
| Template file reads | 1      | 1             | 0                  |
| Template compiles   | 1      | 1             | 0                  |

The unit tests assert these counts: `npm run jest -- test/unit/util/templates`. The repository has no
reproducible wall-clock benchmark command, so no timing numbers are claimed.

**Branch target / semver:** this adds new exported classes (`PromiseCache`, `cached`) and an observable
behaviour change (template edits need a restart), so upstream it should target the latest `versions/*`
branch (currently `versions/next-major`), not `main` — it is based on `main` here only for fork-internal
review. Intended semver level, in prose since contributors cannot set labels: **semver.minor**
(backwards-compatible feature addition).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
