### PR TITLE
perf: Scope KeyValueStorage entries enumeration to a key prefix

### DIFF
--- a/src/storage/keyvalue/ContainerPathStorage.ts
+++ b/src/storage/keyvalue/ContainerPathStorage.ts
@@ -15,8 +15,7 @@ export class ContainerPathStorage<T> extends PassthroughKeyValueStorage<T> {
   }
 
   public async* entries(matchPrefix?: string): AsyncIterableIterator<[string, T]> {
-    // Source keys are the input keys prepended with the base path,
-    // so the prefix can be forwarded by prepending it with the base path as well.
+    // Source keys start with the base path, so it is always forwarded to scope the source enumeration.
     for await (const [ key, value ] of this.source.entries(`${this.basePath}${matchPrefix ?? ''}`)) {
       // The only relevant entries for this storage are those that start with the base path
       if (!key.startsWith(this.basePath)) {

--- a/src/storage/keyvalue/ContainerPathStorage.ts
+++ b/src/storage/keyvalue/ContainerPathStorage.ts
@@ -14,8 +14,10 @@ export class ContainerPathStorage<T> extends PassthroughKeyValueStorage<T> {
     this.basePath = trimLeadingSlashes(ensureTrailingSlash(relativePath));
   }
 
-  public async* entries(): AsyncIterableIterator<[string, T]> {
-    for await (const [ key, value ] of this.source.entries()) {
+  public async* entries(matchPrefix?: string): AsyncIterableIterator<[string, T]> {
+    // Source keys are the input keys prepended with the base path,
+    // so the prefix can be forwarded by prepending it with the base path as well.
+    for await (const [ key, value ] of this.source.entries(`${this.basePath}${matchPrefix ?? ''}`)) {
       // The only relevant entries for this storage are those that start with the base path
       if (!key.startsWith(this.basePath)) {
         continue;

--- a/src/storage/keyvalue/JsonFileStorage.ts
+++ b/src/storage/keyvalue/JsonFileStorage.ts
@@ -47,9 +47,13 @@ export class JsonFileStorage implements KeyValueStorage<string, unknown> {
     });
   }
 
-  public async* entries(): AsyncIterableIterator<[ string, unknown ]> {
+  public async* entries(matchPrefix?: string): AsyncIterableIterator<[ string, unknown ]> {
     const json = await this.getJsonSafely();
-    yield* Object.entries(json);
+    for (const entry of Object.entries(json)) {
+      if (entry[0].startsWith(matchPrefix ?? '')) {
+        yield entry;
+      }
+    }
   }
 
   /**

--- a/src/storage/keyvalue/JsonResourceStorage.ts
+++ b/src/storage/keyvalue/JsonResourceStorage.ts
@@ -72,8 +72,16 @@ export class JsonResourceStorage<T> implements KeyValueStorage<string, T> {
     }
   }
 
-  public async* entries(): AsyncIterableIterator<[string, T]> {
-    yield* this.getResourceEntries({ path: this.container });
+  public async* entries(matchPrefix = ''): AsyncIterableIterator<[string, T]> {
+    // Matching entries can only be found in the container corresponding to the directory part of the prefix,
+    // so the recursive walk can start there instead of at the root container.
+    const directory = matchPrefix.slice(0, matchPrefix.lastIndexOf('/') + 1);
+    const identifier = { path: directory.length > 0 ? joinUrl(this.container, directory) : this.container };
+    for await (const entry of this.getResourceEntries(identifier)) {
+      if (entry[0].startsWith(matchPrefix)) {
+        yield entry;
+      }
+    }
   }
 
   /**

--- a/src/storage/keyvalue/JsonResourceStorage.ts
+++ b/src/storage/keyvalue/JsonResourceStorage.ts
@@ -73,8 +73,7 @@ export class JsonResourceStorage<T> implements KeyValueStorage<string, T> {
   }
 
   public async* entries(matchPrefix = ''): AsyncIterableIterator<[string, T]> {
-    // Matching entries can only be found in the container corresponding to the directory part of the prefix,
-    // so the recursive walk can start there instead of at the root container.
+    // Only the container matching the directory part of the prefix can contain matches, so the walk starts there.
     const directory = matchPrefix.slice(0, matchPrefix.lastIndexOf('/') + 1);
     const identifier = { path: directory.length > 0 ? joinUrl(this.container, directory) : this.container };
     for await (const entry of this.getResourceEntries(identifier)) {

--- a/src/storage/keyvalue/KeyValueStorage.ts
+++ b/src/storage/keyvalue/KeyValueStorage.ts
@@ -41,7 +41,7 @@ export interface KeyValueStorage<TKey, TValue> {
    * An iterable of entries in the storage.
    *
    * @param matchPrefix - If given, only entries whose key starts with this prefix may be yielded.
-   *   Implementations SHOULD use it to avoid enumerating non-matching entries.
+   *   Implementations should use it to avoid enumerating non-matching entries.
    *   Implementations with non-string keys ignore it.
    */
   entries: (matchPrefix?: string) => AsyncIterableIterator<[TKey, TValue]>;

--- a/src/storage/keyvalue/KeyValueStorage.ts
+++ b/src/storage/keyvalue/KeyValueStorage.ts
@@ -39,6 +39,10 @@ export interface KeyValueStorage<TKey, TValue> {
 
   /**
    * An iterable of entries in the storage.
+   *
+   * @param matchPrefix - If given, only entries whose key starts with this prefix may be yielded.
+   *   Implementations SHOULD use it to avoid enumerating non-matching entries.
+   *   Implementations with non-string keys ignore it.
    */
-  entries: () => AsyncIterableIterator<[TKey, TValue]>;
+  entries: (matchPrefix?: string) => AsyncIterableIterator<[TKey, TValue]>;
 }

--- a/src/storage/keyvalue/MaxKeyLengthStorage.ts
+++ b/src/storage/keyvalue/MaxKeyLengthStorage.ts
@@ -47,9 +47,20 @@ export class MaxKeyLengthStorage<T> implements KeyValueStorage<string, T> {
     return this.source.delete(this.getKey(key));
   }
 
-  public async* entries(): AsyncIterableIterator<[string, T]> {
-    for await (const [ , val ] of this.source.entries()) {
-      yield [ val.key, val.payload ];
+  public async* entries(matchPrefix?: string): AsyncIterableIterator<[string, T]> {
+    let sourcePrefix = matchPrefix;
+    if (typeof matchPrefix === 'string' && !matchPrefix.endsWith('/')) {
+      // Only the final segment of a key gets hashed,
+      // so a prefix containing a partial final segment might not match the corresponding hashed source keys.
+      // For that reason, only the part up to and including the last `/` gets forwarded.
+      sourcePrefix = matchPrefix.slice(0, matchPrefix.lastIndexOf('/') + 1);
+    }
+    for await (const [ , val ] of this.source.entries(sourcePrefix)) {
+      // The stored original keys still need to be filtered by the full prefix,
+      // as the source could only match on a part of it.
+      if (val.key.startsWith(matchPrefix ?? '')) {
+        yield [ val.key, val.payload ];
+      }
     }
   }
 

--- a/src/storage/keyvalue/MaxKeyLengthStorage.ts
+++ b/src/storage/keyvalue/MaxKeyLengthStorage.ts
@@ -50,14 +50,11 @@ export class MaxKeyLengthStorage<T> implements KeyValueStorage<string, T> {
   public async* entries(matchPrefix?: string): AsyncIterableIterator<[string, T]> {
     let sourcePrefix = matchPrefix;
     if (typeof matchPrefix === 'string' && !matchPrefix.endsWith('/')) {
-      // Only the final segment of a key gets hashed,
-      // so a prefix containing a partial final segment might not match the corresponding hashed source keys.
-      // For that reason, only the part up to and including the last `/` gets forwarded.
+      // Long final segments get hashed, so a prefix ending mid-segment might not match the source keys.
       sourcePrefix = matchPrefix.slice(0, matchPrefix.lastIndexOf('/') + 1);
     }
     for await (const [ , val ] of this.source.entries(sourcePrefix)) {
-      // The stored original keys still need to be filtered by the full prefix,
-      // as the source could only match on a part of it.
+      // The forwarded prefix can be shorter, so the stored original keys still need to match the full prefix.
       if (val.key.startsWith(matchPrefix ?? '')) {
         yield [ val.key, val.payload ];
       }

--- a/src/storage/keyvalue/MemoryMapStorage.ts
+++ b/src/storage/keyvalue/MemoryMapStorage.ts
@@ -27,9 +27,11 @@ export class MemoryMapStorage<TValue> implements KeyValueStorage<string, TValue>
     return this.data.delete(key);
   }
 
-  public async* entries(): AsyncIterableIterator<[string, TValue]> {
+  public async* entries(matchPrefix?: string): AsyncIterableIterator<[string, TValue]> {
     for (const entry of this.data.entries()) {
-      yield entry;
+      if (entry[0].startsWith(matchPrefix ?? '')) {
+        yield entry;
+      }
     }
   }
 }

--- a/src/storage/keyvalue/PassthroughKeyValueStorage.ts
+++ b/src/storage/keyvalue/PassthroughKeyValueStorage.ts
@@ -34,8 +34,7 @@ export abstract class PassthroughKeyValueStorage<TVal> implements KeyValueStorag
   }
 
   public async* entries(matchPrefix?: string): AsyncIterableIterator<[string, TVal]> {
-    // The prefix is not forwarded to the source storage,
-    // as the key transformation could invalidate it.
+    // The key transformation could invalidate the prefix, so it is not forwarded to the source.
     for await (const [ path, value ] of this.source.entries()) {
       const key = this.toOriginalKey(path);
       if (key.startsWith(matchPrefix ?? '')) {

--- a/src/storage/keyvalue/PassthroughKeyValueStorage.ts
+++ b/src/storage/keyvalue/PassthroughKeyValueStorage.ts
@@ -33,10 +33,14 @@ export abstract class PassthroughKeyValueStorage<TVal> implements KeyValueStorag
     return this.source.delete(path);
   }
 
-  public async* entries(): AsyncIterableIterator<[string, TVal]> {
+  public async* entries(matchPrefix?: string): AsyncIterableIterator<[string, TVal]> {
+    // The prefix is not forwarded to the source storage,
+    // as the key transformation could invalidate it.
     for await (const [ path, value ] of this.source.entries()) {
       const key = this.toOriginalKey(path);
-      yield [ key, value ];
+      if (key.startsWith(matchPrefix ?? '')) {
+        yield [ key, value ];
+      }
     }
   }
 

--- a/src/storage/keyvalue/WrappedExpiringStorage.ts
+++ b/src/storage/keyvalue/WrappedExpiringStorage.ts
@@ -55,9 +55,10 @@ export class WrappedExpiringStorage<TKey, TValue> implements ExpiringStorage<TKe
     return this.source.delete(key);
   }
 
-  public async* entries(): AsyncIterableIterator<[TKey, TValue]> {
+  public async* entries(matchPrefix?: string): AsyncIterableIterator<[TKey, TValue]> {
     // Not deleting expired entries here to prevent iterator issues
-    for await (const [ key, value ] of this.source.entries()) {
+    // Keys are stored unchanged in the source storage, so the prefix can be forwarded as-is
+    for await (const [ key, value ] of this.source.entries(matchPrefix)) {
       const { expires, payload } = this.toData(value);
       if (!this.isExpired(expires)) {
         yield [ key, payload ];

--- a/src/storage/keyvalue/WrappedExpiringStorage.ts
+++ b/src/storage/keyvalue/WrappedExpiringStorage.ts
@@ -57,7 +57,6 @@ export class WrappedExpiringStorage<TKey, TValue> implements ExpiringStorage<TKe
 
   public async* entries(matchPrefix?: string): AsyncIterableIterator<[TKey, TValue]> {
     // Not deleting expired entries here to prevent iterator issues
-    // Keys are stored unchanged in the source storage, so the prefix can be forwarded as-is
     for await (const [ key, value ] of this.source.entries(matchPrefix)) {
       const { expires, payload } = this.toData(value);
       if (!this.isExpired(expires)) {

--- a/test/unit/storage/keyvalue/ContainerPathStorage.test.ts
+++ b/test/unit/storage/keyvalue/ContainerPathStorage.test.ts
@@ -44,4 +44,35 @@ describe('An ContainerPathStorage', (): void => {
     expect(results).toHaveLength(1);
     expect(results[0]).toEqual([ 'key', data ]);
   });
+
+  it('forwards the prefix prepended with the base path to the source.', async(): Promise<void> => {
+    const data = 'data';
+    const mockedSource: jest.Mocked<KeyValueStorage<string, unknown>> = {
+      has: jest.fn(),
+      get: jest.fn(),
+      set: jest.fn(),
+      delete: jest.fn(),
+      entries: jest.fn(async function* (): AsyncIterableIterator<[string, unknown]> {
+        yield [ `${relativePath}key`, data ];
+        yield [ '/otherContainer/key2', data ];
+      }),
+    };
+    storage = new ContainerPathStorage(mockedSource, relativePath);
+
+    let results = [];
+    for await (const entry of storage.entries('ke')) {
+      results.push(entry);
+    }
+    expect(mockedSource.entries).toHaveBeenCalledTimes(1);
+    expect(mockedSource.entries).toHaveBeenLastCalledWith(`${relativePath}ke`);
+    expect(results).toEqual([[ 'key', data ]]);
+
+    results = [];
+    for await (const entry of storage.entries()) {
+      results.push(entry);
+    }
+    expect(mockedSource.entries).toHaveBeenCalledTimes(2);
+    expect(mockedSource.entries).toHaveBeenLastCalledWith(relativePath);
+    expect(results).toEqual([[ 'key', data ]]);
+  });
 });

--- a/test/unit/storage/keyvalue/JsonFileStorage.test.ts
+++ b/test/unit/storage/keyvalue/JsonFileStorage.test.ts
@@ -51,6 +51,16 @@ describe('A JsonFileStorage', (): void => {
     expect(JSON.parse(cache.data[jsonPath])).toEqual({ lemon: value2 });
   });
 
+  it('only returns entries matching the prefix if one is given.', async(): Promise<void> => {
+    await expect(storage.set('apple', { taste: 'sweet' })).resolves.toBe(storage);
+    await expect(storage.set('lemon', { taste: 'sour' })).resolves.toBe(storage);
+    const results = [];
+    for await (const entry of storage.entries('le')) {
+      results.push(entry);
+    }
+    expect(results).toEqual([[ 'lemon', { taste: 'sour' }]]);
+  });
+
   it('throws an error if something goes wrong reading the JSON.', async(): Promise<void> => {
     cache.data[jsonPath] = '} very invalid {';
     await expect(storage.get('anything')).rejects.toThrow(Error);

--- a/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
+++ b/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
@@ -125,4 +125,78 @@ describe('A JsonResourceStorage', (): void => {
       [ subPath, 'subDocument' ],
     ]);
   });
+
+  it('returns all entries when given an empty prefix.', async(): Promise<void> => {
+    await expect(storage.set(path1, 'path1')).resolves.toBe(storage);
+    await expect(storage.set(path2, 'path2')).resolves.toBe(storage);
+    data.set(containerIdentifier, '');
+
+    const entries = [];
+    for await (const entry of storage.entries('')) {
+      entries.push(entry);
+    }
+    expect(entries).toEqual([
+      [ path1, 'path1' ],
+      [ path2, 'path2' ],
+    ]);
+    expect(store.getRepresentation).toHaveBeenCalledWith({ path: containerIdentifier }, {});
+  });
+
+  it('starts iterating from the root container when given a prefix without a slash.', async(): Promise<void> => {
+    await expect(storage.set(path1, 'path1')).resolves.toBe(storage);
+    await expect(storage.set(path2, 'path2')).resolves.toBe(storage);
+    data.set(containerIdentifier, '');
+
+    const entries = [];
+    for await (const entry of storage.entries('fo')) {
+      entries.push(entry);
+    }
+    expect(entries).toEqual([[ path1, 'path1' ]]);
+    expect(store.getRepresentation).toHaveBeenCalledWith({ path: containerIdentifier }, {});
+  });
+
+  it('starts iterating from the container matching the directory part of the prefix.', async(): Promise<void> => {
+    await expect(storage.set(path1, 'path1')).resolves.toBe(storage);
+    await expect(storage.set(subPath, 'subDocument')).resolves.toBe(storage);
+    data.set(containerIdentifier, '');
+    data.set(subContainerIdentifier, '');
+
+    const entries = [];
+    for await (const entry of storage.entries('container/')) {
+      entries.push(entry);
+    }
+    expect(entries).toEqual([[ subPath, 'subDocument' ]]);
+    expect(store.getRepresentation).toHaveBeenCalledTimes(2);
+    expect(store.getRepresentation).toHaveBeenCalledWith({ path: subContainerIdentifier }, {});
+    expect(store.getRepresentation).not.toHaveBeenCalledWith({ path: containerIdentifier }, expect.anything());
+  });
+
+  it('only returns the entries in the subcontainer matching the full prefix.', async(): Promise<void> => {
+    await expect(storage.set(subPath, 'subDocument')).resolves.toBe(storage);
+    await expect(storage.set('container/other', 'other')).resolves.toBe(storage);
+    data.set(containerIdentifier, '');
+    data.set(subContainerIdentifier, '');
+
+    const entries = [];
+    for await (const entry of storage.entries('container/doc')) {
+      entries.push(entry);
+    }
+    expect(entries).toEqual([[ subPath, 'subDocument' ]]);
+    expect(store.getRepresentation).toHaveBeenCalledWith({ path: subContainerIdentifier }, {});
+    expect(store.getRepresentation).not.toHaveBeenCalledWith({ path: containerIdentifier }, expect.anything());
+  });
+
+  it('returns no entries if the container matching the prefix does not exist.', async(): Promise<void> => {
+    await expect(storage.set(path1, 'path1')).resolves.toBe(storage);
+    data.set(containerIdentifier, '');
+    store.getRepresentation.mockClear();
+
+    const entries = [];
+    for await (const entry of storage.entries('missing/document')) {
+      entries.push(entry);
+    }
+    expect(entries).toHaveLength(0);
+    expect(store.getRepresentation).toHaveBeenCalledTimes(1);
+    expect(store.getRepresentation).toHaveBeenLastCalledWith({ path: joinUrl(containerIdentifier, 'missing/') }, {});
+  });
 });

--- a/test/unit/storage/keyvalue/MaxKeyLengthStorage.test.ts
+++ b/test/unit/storage/keyvalue/MaxKeyLengthStorage.test.ts
@@ -72,10 +72,46 @@ describe('A MaxKeyLengthStorage', (): void => {
     for await (const entry of storage.entries()) {
       entries.push(entry);
     }
+    expect(source.entries).toHaveBeenCalledTimes(1);
+    expect(source.entries).toHaveBeenLastCalledWith(undefined);
     expect(entries).toEqual([
       [ key, payload ],
       [ longKey, payload ],
     ]);
+  });
+
+  it('forwards the prefix unchanged if it ends on a slash.', async(): Promise<void> => {
+    const entries = [];
+    for await (const entry of storage.entries('container/')) {
+      entries.push(entry);
+    }
+    expect(source.entries).toHaveBeenCalledTimes(1);
+    expect(source.entries).toHaveBeenLastCalledWith('container/');
+    expect(entries).toHaveLength(0);
+  });
+
+  it('only forwards the prefix up to and including the last slash.', async(): Promise<void> => {
+    source.entries.mockImplementationOnce(async function* (): AsyncIterableIterator<any> {
+      yield [ 'container/key', { key: 'container/key', payload }];
+      yield [ 'container/other', { key: 'container/other', payload }];
+    });
+    const entries = [];
+    for await (const entry of storage.entries('container/ke')) {
+      entries.push(entry);
+    }
+    expect(source.entries).toHaveBeenCalledTimes(1);
+    expect(source.entries).toHaveBeenLastCalledWith('container/');
+    expect(entries).toEqual([[ 'container/key', payload ]]);
+  });
+
+  it('forwards an empty prefix if the prefix contains no slash.', async(): Promise<void> => {
+    const entries = [];
+    for await (const entry of storage.entries('ke')) {
+      entries.push(entry);
+    }
+    expect(source.entries).toHaveBeenCalledTimes(1);
+    expect(source.entries).toHaveBeenLastCalledWith('');
+    expect(entries).toEqual([[ key, payload ]]);
   });
 
   it('errors trying to write with a key that has the hash prefix.', async(): Promise<void> => {

--- a/test/unit/storage/keyvalue/MemoryMapStorage.test.ts
+++ b/test/unit/storage/keyvalue/MemoryMapStorage.test.ts
@@ -42,4 +42,14 @@ describe('A MemoryMapStorage', (): void => {
     await expect(storage.set(identifier2, 'pear')).resolves.toBe(storage);
     await expect(storage.get(identifier1)).resolves.toBe('apple');
   });
+
+  it('only returns entries matching the prefix if one is given.', async(): Promise<void> => {
+    await expect(storage.set(identifier1, 'apple')).resolves.toBe(storage);
+    await expect(storage.set(identifier2, 'pear')).resolves.toBe(storage);
+    const results = [];
+    for await (const entry of storage.entries('http://test.com/f')) {
+      results.push(entry);
+    }
+    expect(results).toEqual([[ identifier1, 'apple' ]]);
+  });
 });

--- a/test/unit/storage/keyvalue/PassthroughKeyValueStorage.test.ts
+++ b/test/unit/storage/keyvalue/PassthroughKeyValueStorage.test.ts
@@ -59,4 +59,16 @@ describe('A PassthroughKeyValueStorage', (): void => {
     expect(results[0]).toEqual([ 'key', 'value' ]);
     expect(results[1]).toEqual([ 'key2', 'value2' ]);
   });
+
+  it('does not forward the prefix to the source and filters the transformed keys.', async(): Promise<void> => {
+    const map = new Map<string, string>([[ 'dummy-key', 'value' ], [ 'dummy-other', 'value2' ]]);
+    source.entries.mockReturnValue(map.entries() as unknown as AsyncIterableIterator<[string, string]>);
+    const results = [];
+    for await (const entry of storage.entries('ke')) {
+      results.push(entry);
+    }
+    expect(source.entries).toHaveBeenCalledTimes(1);
+    expect(source.entries).toHaveBeenLastCalledWith();
+    expect(results).toEqual([[ 'key', 'value' ]]);
+  });
 });

--- a/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
+++ b/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
@@ -115,6 +115,24 @@ describe('A WrappedExpiringStorage', (): void => {
     await expect(it.next()).resolves.toEqual(
       expect.objectContaining({ value: [ 'key3', 'data3' ]}),
     );
+    expect(source.entries).toHaveBeenCalledTimes(1);
+    expect(source.entries).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it('forwards the prefix unchanged to the source when iterating entries.', async(): Promise<void> => {
+    const data = [
+      [ 'key1', createExpires('data1', tomorrow) ],
+    ];
+    source.entries.mockImplementationOnce(function* (): any {
+      yield* data;
+    });
+    const results = [];
+    for await (const entry of storage.entries('key')) {
+      results.push(entry);
+    }
+    expect(source.entries).toHaveBeenCalledTimes(1);
+    expect(source.entries).toHaveBeenLastCalledWith('key');
+    expect(results).toEqual([[ 'key1', 'data1' ]]);
   });
 
   it('removes expired entries after a given time.', async(): Promise<void> => {


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming. Commits are unsigned (the agent has no signing key); re-sign when rebasing for upstream.

#### 📁 Related issues

None yet — the upstream PR template requires a linked issue, so one describing the sweep-enumeration cost below must be created on CommunitySolidServer/CommunitySolidServer before this is submitted there. Fork companions addressing other root causes of the same measured background IO: #22, #23.

#### ✍️ Description

The four `WrappedExpiringStorage` instances (cookies, forgot-password records, OIDC adapter data, ownership tokens) each run an hourly expiry sweep that calls `entries()` on a `ContainerPathStorage` wrapping the shared `/.internal/` `JsonResourceStorage`. `ContainerPathStorage#entries` enumerated **all** source entries and filtered afterwards, so every sweep recursively walked and JSON-parsed the **entire** `/.internal/` tree through the full locking `ResourceStore` — four times an hour, forever — even though each sweep only cares about its own subcontainer. With the disk locker of `main`, every touched resource additionally costs a physical lock-file `mkdir`/`rmdir` cycle.

`KeyValueStorage#entries` now takes an optional `matchPrefix` argument: when given, only entries whose key starts with the prefix may be yielded, and implementations should use it to avoid enumerating non-matching entries (implementations with non-string keys ignore it). Per implementation:

- `ContainerPathStorage` forwards `basePath + prefix`. The base path is forwarded even when no prefix is given — that alone is what scopes the sweeps, since its base path is the sweep's subcontainer.
- `JsonResourceStorage` starts its recursive walk at the container matching the prefix's directory part instead of at the root container; a missing start container yields an empty result.
- `MaxKeyLengthStorage` forwards the prefix only up to the last `/` (a prefix ending mid-segment might not match a hashed final segment) and filters the stored original keys by the full prefix.
- `PassthroughKeyValueStorage` (the safe default, also covering `Base64EncodingStorage`/`HashEncodingStorage`) does **not** forward — the key transformation could invalidate the prefix — and filters the yielded original keys locally.
- `WrappedExpiringStorage` forwards unchanged; `MemoryMapStorage`/`JsonFileStorage` filter during iteration.

With the default wiring (`WrappedExpiringStorage` → `ContainerPathStorage` → `MaxKeyLengthStorage` → `JsonResourceStorage`), each hourly sweep now walks only its own `/.internal/<subcontainer>/` subtree.

**Effect.** There is no reproducible wall-clock benchmark command for the hourly timer path; the evidence is the deterministic enumeration scope. Before: every sweep listed every container and read + JSON-parsed every document under `/.internal/` (including all account data). After: only those under the sweep's own subcontainer, each still through the locking `ResourceStore`. The unit tests pin the scoping (the `JsonResourceStorage` walk provably never touches the root container when given a subcontainer prefix).

**Branch target and semver.** This widens the signature of a method on the exported `KeyValueStorage` interface, so upstream it should target the latest `versions/*` branch (currently `versions/next-major`), not `main`. Intended level: **semver.minor** — the parameter is optional, so existing third-party implementations keep compiling and satisfying the interface (they simply do not get the optimization). If "changing interfaces" is read strictly it would be semver.major instead; either way the `versions/*` target covers it. (Contributors cannot set the semver labels.)

#### 📋 Notes for review

- All `KeyValueStorage` implementations and every `.entries(` call site were audited: `SingleContainerJsonStorage` inherits correctly; `WrappedIndexedStorage`/`BaseLoginAccountStorage` implement the unrelated `IndexedStorage.entries(type)` API; `ConfigPodInitializer`/`V6MigrationInitializer` intentionally enumerate everything; `BaseUrlRouterRule` matches in the opposite direction (the stored key is a prefix of the request identifier), so no prefix applies there.
- Tests assert the exact argument forwarded to (or withheld from) the source per class, including that the `JsonResourceStorage` walk starts at the subcontainer and never touches the root container, plus the missing-subcontainer branch.
- `npm run build`, lint, and the coverage-gated unit suite (100% thresholds on `./src`) are green.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
