### PR TITLE
feat: Cache CORS preflight responses with Access-Control-Max-Age

### DIFF
--- a/config/http/middleware/handlers/cors.json
+++ b/config/http/middleware/handlers/cors.json
@@ -15,6 +15,7 @@
         "DELETE"
       ],
       "options_credentials": true,
+      "options_maxAge": 3600,
       "options_preflightContinue": false,
       "options_exposedHeaders": [
         "Accept-Patch",

--- a/test/integration/Middleware.test.ts
+++ b/test/integration/Middleware.test.ts
@@ -72,6 +72,7 @@ describe('An http server with middleware', (): void => {
     expect(res.header).toEqual(expect.objectContaining({
       'access-control-allow-origin': '*',
       'access-control-allow-headers': 'content-type',
+      'access-control-max-age': '3600',
       'x-powered-by': 'Community Solid Server',
     }));
     const { vary } = res.header;


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready)

#### 📁 Related issues

None yet — the upstream template requires a related issue, so one needs to be created on CommunitySolidServer/CommunitySolidServer before this is submitted there.

#### ✍️ Description

Browsers re-send a CORS preflight (`OPTIONS`) before almost every non-simple request to a Solid pod, because the server never returns `Access-Control-Max-Age` and preflight results are therefore cached only for the browser default of 5 seconds. For chatty Solid apps this roughly doubles request volume and adds a round-trip of latency per operation.

This sets `"options_maxAge": 3600` on the default `CorsHandler` middleware config (`config/http/middleware/handlers/cors.json`), so preflight responses include `Access-Control-Max-Age: 3600`. The `CorsHandler` component already exposes the `maxAge` option of the `cors` package; this change only enables it in the shipped configurations (they all import `config/http/middleware/default.json`), and deployments can still override the value in their own config. Browsers cap what they honour (Chromium at 2 hours, Firefox at 24 hours), so 3600 is within all caps.

Notes for reviewers:

* A change to the server's CORS policy (allowed methods/headers) can now take up to an hour to be picked up by a browser holding a cached preflight. The default CORS policy is static and permissive per Solid Protocol §8.1, so this is a safe trade for the default config, and the value remains configurable.
* The `cors` package adds the header to **every** `OPTIONS` response, not only true preflights; browsers ignore it outside preflights.

The existing `Middleware` integration test now also asserts the header on preflight responses.

There is no reproducible wall-clock benchmark for this change — the effect is deterministic rather than measured: without the header a browser repeats one preflight round-trip per non-simple request once its 5-second default cache expires; with the header, at most one per hour per cached preflight entry. The header itself reproduces against a server built from this branch (`config/default.json`; before: no `Access-Control-Max-Age` header, after: `3600`):

```text
$ curl -si -X OPTIONS -H 'Origin: http://example.com' -H 'Access-Control-Request-Method: PUT' localhost:3461/
HTTP/1.1 204 No Content
Access-Control-Allow-Origin: http://example.com
Access-Control-Allow-Credentials: true
Access-Control-Allow-Methods: GET,HEAD,OPTIONS,POST,PUT,PATCH,DELETE
Access-Control-Max-Age: 3600
```

Intended semver level, in prose since contributors cannot set the labels: **semver.minor** — a backwards-compatible behaviour addition to the shipped config. Because it changes shipped-config behaviour rather than fixing a bug, the upstream submission should target the latest `versions/*` branch (currently `versions/next-major`), not `main`.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
