### PR TITLE
chore: Add a performance benchmarking and instrumentation harness

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,4 +3,14 @@ import opinionated from 'opinionated-eslint-config';
 export default opinionated().append({
   // Don't want to lint test assets
   ignores: [ 'test/assets/*', 'componentsjs-error-state.json', '.data/**' ],
+}).append({
+  // The performance harness consists of standalone CLI tools:
+  // console output is their interface, synchronous fs calls and process.exit are fine there,
+  // and fs-count.js must stay dependency-free CommonJS as it is preloaded into the measured server process.
+  files: [ 'scripts/perf/**/*.js' ],
+  rules: {
+    'no-console': 'off',
+    'no-sync': 'off',
+    'unicorn/no-process-exit': 'off',
+  },
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,9 +4,7 @@ export default opinionated().append({
   // Don't want to lint test assets
   ignores: [ 'test/assets/*', 'componentsjs-error-state.json', '.data/**' ],
 }).append({
-  // The performance harness consists of standalone CLI tools:
-  // console output is their interface, synchronous fs calls and process.exit are fine there,
-  // and fs-count.js must stay dependency-free CommonJS as it is preloaded into the measured server process.
+  // The performance harness scripts are standalone CLI tools
   files: [ 'scripts/perf/**/*.js' ],
   rules: {
     'no-console': 'off',

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,92 @@
+# CSS performance harness
+
+Dependency-free tooling to measure the performance of a Community Solid Server build:
+throughput, latency percentiles, file-system operations (total, per request, per second,
+per call site, per path pattern), CPU time, RSS, and cold-boot cost.
+
+It was built to produce the A/B numbers for the performance PR series and is meant to be
+run against **two checkouts** (baseline and candidate) so results are always comparative.
+
+## Contents
+
+| File | Purpose |
+| --- | --- |
+| `fs-count.js` | Preload (`node --require`) that counts every `fs`/`fs.promises` call in the server process |
+| `runner.js` | Boots a server with the preload and drives the scenario suite against it |
+| `loadgen.js` | Minimal `fetch`-based load generator (used by the runner, also standalone) |
+| `bench-setup.js` | Creates an account, pod, client credentials and public benchmark containers |
+| `report.js` | Renders one or more result files as a markdown comparison table |
+
+## Quick start
+
+```bash
+# In two builds of the server (e.g. main and your branch):
+node scripts/perf/runner.js --serverDir ../css-baseline --label baseline --out baseline.json
+node scripts/perf/runner.js --serverDir ../css-candidate --label candidate --out candidate.json
+
+# Markdown A/B report (first file is the baseline for the % deltas):
+node scripts/perf/report.js baseline.json candidate.json
+```
+
+The `--serverDir` must be a **built** checkout (`bin/server.js` and `node_modules` present);
+`jose` is resolved from that checkout to sign the DPoP tokens used during setup.
+
+## Options
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--serverDir` | (required) | Path to the built CSS checkout to benchmark |
+| `--config` | `config/file.json` | Server configuration to boot |
+| `--port` | `3460` | Port to bind |
+| `--label` | `run` | Label used in the output and the console log |
+| `--out` | `<label>.json` | Result file |
+| `--seconds` | `10` | Duration of each load scenario |
+| `--conc` | `20` | Concurrent workers per load scenario |
+| `--wedge` | off | Also run the abandoned-lock-waiter reproduction (see below) |
+| `--bootRuns` | off | Only measure `N` cold boots (time, fs ops, RSS, CPU), no load scenarios |
+
+## Scenarios
+
+1. `static-get` — `GET /` (StaticAssetHandler path).
+2. `ldp-get-hot` — repeated `GET` of one small turtle resource.
+3. `ldp-get-spread` — `GET` of a distinct resource per worker.
+4. `ldp-put` — `PUT` of a distinct small turtle resource per worker.
+5. `container-listing-100` — `GET` of a container with 100 children.
+6. `idle-20s` — no requests; measures background fs activity (timer sweeps, watchers).
+7. `wedge-*` (with `--wedge`) — uploads a 100 MB resource, holds its read lock with a
+   trickling reader, fires 40 `PUT`s whose clients abort, then measures the *idle* fs-op
+   rate for 30 s and the drain after the reader disconnects. On builds affected by the
+   lock-polling bug this shows thousands of fs ops per second on an outwardly idle server.
+
+Every scenario records: requests, errors, status codes, req/s, p50/p90/p99/max latency (ms),
+fs ops (total, per request, per second), CPU seconds (user+system, from `/proc`, Linux only),
+CPU ms per request, and RSS after a forced GC.
+
+## How the fs counting works
+
+`fs-count.js` is injected with `--require` before any application module loads, so wrappers
+such as `graceful-fs`/`fs-extra` capture the counting functions. It aggregates counts per
+operation, per call site (first non-internal stack frame), and per anonymized path pattern
+(hashes, UUIDs and long numbers are collapsed so identical access patterns aggregate).
+A snapshot is written to `FS_COUNT_OUT` every 5 s, on exit, and synchronously on `SIGUSR2`
+(the runner uses `SIGUSR2` at scenario boundaries; the forced GC keeps RSS numbers honest).
+
+It can be used on its own against any config:
+
+```bash
+FS_COUNT_OUT=/tmp/counts.json node --expose-gc --require ./scripts/perf/fs-count.js \
+  bin/server.js -c config/file.json -f /tmp/pod-data
+watch -n 5 "python3 -m json.tool /tmp/counts.json | head -50"
+```
+
+## Caveats — read before quoting numbers
+
+- The load generator runs **on the same machine** as the server and `fetch` (undici)
+  pools connections per origin: results are for A/B comparison between two builds on the
+  same host, not absolute capacity statements.
+- Scenario order is fixed and caches are deliberately warm (except `--bootRuns`);
+  cold-cache behaviour is only covered by the boot measurements.
+- CPU time uses `/proc/<pid>/stat` and assumes 100 Hz ticks; on non-Linux platforms the
+  CPU columns are simply omitted.
+- The pod setup uses a **public** ACL so the measured request path contains no token
+  signing; authenticated-request performance is not covered (yet).

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -44,6 +44,7 @@ The `--serverDir` must be a **built** checkout (`bin/server.js` and `node_module
 | `--conc` | `20` | Concurrent workers per load scenario |
 | `--wedge` | off | Also run the abandoned-lock-waiter reproduction (see below) |
 | `--bootRuns` | off | Only measure `N` cold boots (time, fs ops, RSS, CPU), no load scenarios |
+| `--serverArgs` | none | Extra whitespace-separated arguments appended to the server command line |
 
 ## Scenarios
 

--- a/scripts/perf/bench-setup.js
+++ b/scripts/perf/bench-setup.js
@@ -1,20 +1,12 @@
 'use strict';
 /**
- * Prepares a booted CSS instance for benchmarking:
+ * Prepares a booted CSS instance for benchmarking: creates an account with a pod,
+ * obtains a DPoP-bound access token through client credentials, and creates the requested
+ * containers with a public read/write ACL, so the measured request path contains no token signing.
+ * The `jose` argument of `setupPod` must be resolved from the measured server's dependency tree;
+ * `authed` in the result performs a fetch authenticated as the pod owner.
  *
- * 1. creates an account with a password login and a pod
- * 2. creates client credentials and obtains a DPoP-bound access token
- * 3. creates the requested containers in the pod with a public read/write ACL
- *
- * As a module: `const { setupPod } = require('./bench-setup');`
- *   setupPod({ baseUrl, podName, jose, containers })
- *     → { podRoot, webId, email, accessToken, containers, authed }
- *   `jose` must be the `jose` library instance resolved from the *server's* dependency tree.
- *   `authed(url, init?)` performs a fetch authenticated as the pod owner (DPoP-bound token).
- * As a CLI: node bench-setup.js <baseUrl> [podName]  (requires `jose` resolvable from cwd; prints JSON)
- *
- * The public ACL means the load generator can hit the created containers without
- * authentication, keeping token signing out of the measured request path.
+ * CLI usage: node bench-setup.js <baseUrl> [podName]
  */
 const { randomUUID } = require('node:crypto');
 

--- a/scripts/perf/bench-setup.js
+++ b/scripts/perf/bench-setup.js
@@ -1,0 +1,130 @@
+'use strict';
+/**
+ * Prepares a booted CSS instance for benchmarking:
+ *
+ * 1. creates an account with a password login and a pod
+ * 2. creates client credentials and obtains a DPoP-bound access token
+ * 3. creates the requested containers in the pod with a public read/write ACL
+ *
+ * As a module: `const { setupPod } = require('./bench-setup');`
+ *   setupPod({ baseUrl, podName, jose, containers }) → { podRoot, webId, email, accessToken, containers }
+ *   `jose` must be the `jose` library instance resolved from the *server's* dependency tree.
+ * As a CLI: node bench-setup.js <baseUrl> [podName]  (requires `jose` resolvable from cwd; prints JSON)
+ *
+ * The public ACL means the load generator can hit the created containers without
+ * authentication, keeping token signing out of the measured request path.
+ */
+const { randomUUID } = require('node:crypto');
+
+const PUBLIC_ACL = `@prefix acl: <http://www.w3.org/ns/auth/acl#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+<#public> a acl:Authorization;
+  acl:agentClass foaf:Agent;
+  acl:accessTo <./>;
+  acl:default <./>;
+  acl:mode acl:Read, acl:Write, acl:Control.
+`;
+
+async function json(res) {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Non-JSON response ${res.status}: ${text.slice(0, 500)}`);
+  }
+}
+
+async function setupPod({ baseUrl, podName = 'bench', jose, containers = [ 'scratch/' ]}) {
+  // 1. Account controls (no auth)
+  let controls = (await json(await fetch(new URL('.account/', baseUrl)))).controls;
+  // 2. Create account
+  const created = await json(await fetch(controls.account.create, { method: 'POST' }));
+  if (!created.authorization) {
+    throw new Error(`No authorization in account create response: ${JSON.stringify(created)}`);
+  }
+  const authHeader = { authorization: `CSS-Account-Token ${created.authorization}` };
+  // 3. Authenticated controls
+  controls = (await json(await fetch(new URL('.account/', baseUrl), { headers: authHeader }))).controls;
+  // 4. Password login (required for the account to be complete)
+  const email = `bench-${randomUUID().slice(0, 8)}@example.com`;
+  await json(await fetch(controls.password.create, {
+    method: 'POST',
+    headers: { ...authHeader, 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password: 'bench-password!1' }),
+  }));
+  // 5. Pod
+  const pod = await json(await fetch(controls.account.pod, {
+    method: 'POST',
+    headers: { ...authHeader, 'content-type': 'application/json' },
+    body: JSON.stringify({ name: podName }),
+  }));
+  // 6. Client credentials
+  const cc = await json(await fetch(controls.account.clientCredentials, {
+    method: 'POST',
+    headers: { ...authHeader, 'content-type': 'application/json' },
+    body: JSON.stringify({ name: 'bench-token', webId: pod.webId }),
+  }));
+  // 7. DPoP-bound access token
+  const { privateKey, publicKey } = await jose.generateKeyPair('ES256');
+  const publicJwk = await jose.exportJWK(publicKey);
+  async function dpop(htm, htu) {
+    return new jose.SignJWT({ htu, htm, jti: randomUUID() })
+      .setProtectedHeader({ alg: 'ES256', typ: 'dpop+jwt', jwk: publicJwk })
+      .setIssuedAt()
+      .sign(privateKey);
+  }
+  const tokenUrl = new URL('.oidc/token', baseUrl).href;
+  const basic = Buffer.from(`${encodeURIComponent(cc.id)}:${encodeURIComponent(cc.secret)}`).toString('base64');
+  const tok = await json(await fetch(tokenUrl, {
+    method: 'POST',
+    headers: {
+      authorization: `Basic ${basic}`,
+      'content-type': 'application/x-www-form-urlencoded',
+      dpop: await dpop('POST', tokenUrl),
+    },
+    body: 'grant_type=client_credentials&scope=webid',
+  }));
+  if (!tok.access_token) {
+    throw new Error(`No access token: ${JSON.stringify(tok)}`);
+  }
+  async function authed(url, init = {}) {
+    return fetch(url, {
+      ...init,
+      headers: {
+        ...init.headers,
+        authorization: `DPoP ${tok.access_token}`,
+        dpop: await dpop(init.method || 'GET', url),
+      },
+    });
+  }
+  // 8. Public containers
+  const containerUrls = {};
+  for (const dir of containers) {
+    const url = new URL(dir, pod.pod).href;
+    let res = await authed(url, { method: 'PUT', headers: { 'content-type': 'text/turtle' }, body: '' });
+    if (res.status >= 400) {
+      throw new Error(`PUT ${url}: ${res.status} ${await res.text()}`);
+    }
+    res = await authed(new URL('.acl', url).href, { method: 'PUT', headers: { 'content-type': 'text/turtle' }, body: PUBLIC_ACL });
+    if (res.status >= 400) {
+      throw new Error(`PUT ${url}.acl: ${res.status} ${await res.text()}`);
+    }
+    containerUrls[dir.replace(/\/$/u, '')] = url;
+  }
+  return { podRoot: pod.pod, webId: pod.webId, email, accessToken: tok.access_token, containers: containerUrls };
+}
+
+module.exports = { setupPod };
+
+if (require.main === module) {
+  const [ baseUrl = 'http://localhost:3456/', podName = 'bench' ] = process.argv.slice(2);
+  // eslint-disable-next-line global-require
+  const jose = require('jose');
+  setupPod({ baseUrl, podName, jose }).then(
+    result => console.log(JSON.stringify(result, null, 2)),
+    (err) => {
+      console.error(err.message);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/perf/bench-setup.js
+++ b/scripts/perf/bench-setup.js
@@ -7,8 +7,10 @@
  * 3. creates the requested containers in the pod with a public read/write ACL
  *
  * As a module: `const { setupPod } = require('./bench-setup');`
- *   setupPod({ baseUrl, podName, jose, containers }) → { podRoot, webId, email, accessToken, containers }
+ *   setupPod({ baseUrl, podName, jose, containers })
+ *     → { podRoot, webId, email, accessToken, containers, authed }
  *   `jose` must be the `jose` library instance resolved from the *server's* dependency tree.
+ *   `authed(url, init?)` performs a fetch authenticated as the pod owner (DPoP-bound token).
  * As a CLI: node bench-setup.js <baseUrl> [podName]  (requires `jose` resolvable from cwd; prints JSON)
  *
  * The public ACL means the load generator can hit the created containers without
@@ -111,7 +113,7 @@ async function setupPod({ baseUrl, podName = 'bench', jose, containers = [ 'scra
     }
     containerUrls[dir.replace(/\/$/u, '')] = url;
   }
-  return { podRoot: pod.pod, webId: pod.webId, email, accessToken: tok.access_token, containers: containerUrls };
+  return { podRoot: pod.pod, webId: pod.webId, email, accessToken: tok.access_token, containers: containerUrls, authed };
 }
 
 module.exports = { setupPod };

--- a/scripts/perf/fs-count.js
+++ b/scripts/perf/fs-count.js
@@ -1,19 +1,9 @@
 'use strict';
 /**
- * File-system operation counter, injected as a preload:
- *   node --require ./scripts/perf/fs-count.js bin/server.js ...
- *
- * Wraps `fs`, `fs.*Sync` and `fs.promises` before any application module loads,
- * so wrappers such as graceful-fs/fs-extra capture the counting functions too.
- * Counts are aggregated per operation, per call site and per (anonymized) path
- * pattern, together with a per-second timeline and the process RSS.
- *
- * Output: a JSON snapshot written every 5 s, on exit, and synchronously on
- * SIGUSR2 (with a forced GC when --expose-gc is set, for honest RSS numbers).
- * Env: FS_COUNT_OUT=<snapshot path> (default ./fs-count.json).
- *
- * This file must stay dependency-free CommonJS: it runs inside the measured
- * server process before anything else is loaded.
+ * Counts every `fs`/`fs.promises` call of the process it is preloaded into (`node --require`),
+ * aggregated per operation, per call site, and per anonymized path pattern.
+ * Writes a JSON snapshot to `FS_COUNT_OUT` every 5 seconds, on exit, and synchronously on SIGUSR2.
+ * Must stay dependency-free CommonJS: it runs inside the measured server process before anything else loads.
  */
 const fs = require('node:fs');
 const path = require('node:path');

--- a/scripts/perf/fs-count.js
+++ b/scripts/perf/fs-count.js
@@ -1,0 +1,180 @@
+'use strict';
+/**
+ * File-system operation counter, injected as a preload:
+ *   node --require ./scripts/perf/fs-count.js bin/server.js ...
+ *
+ * Wraps `fs`, `fs.*Sync` and `fs.promises` before any application module loads,
+ * so wrappers such as graceful-fs/fs-extra capture the counting functions too.
+ * Counts are aggregated per operation, per call site and per (anonymized) path
+ * pattern, together with a per-second timeline and the process RSS.
+ *
+ * Output: a JSON snapshot written every 5 s, on exit, and synchronously on
+ * SIGUSR2 (with a forced GC when --expose-gc is set, for honest RSS numbers).
+ * Env: FS_COUNT_OUT=<snapshot path> (default ./fs-count.json).
+ *
+ * This file must stay dependency-free CommonJS: it runs inside the measured
+ * server process before anything else is loaded.
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+
+const OUT = process.env.FS_COUNT_OUT || path.join(process.cwd(), 'fs-count.json');
+const CWD_PREFIX = `${process.cwd().replaceAll('\\', '/')}/`;
+const origWriteFileSync = fs.writeFileSync.bind(fs);
+
+const startTime = Date.now();
+let total = 0;
+const perOp = new Map();
+const perSite = new Map();
+const perPath = new Map();
+// Per-second buckets (last 900 seconds)
+const timeline = [];
+let curSecond = -1;
+let curCount = 0;
+
+function bump(map, key, n = 1) {
+  map.set(key, (map.get(key) || 0) + n);
+}
+
+// Collapses ids/hashes/counters so identical access patterns aggregate
+function pathPattern(p) {
+  if (typeof p !== 'string') {
+    if (Buffer.isBuffer(p)) {
+      p = p.toString();
+    } else if (p && p.href) {
+      // A URL object
+      p = p.href;
+    } else {
+      return `<${typeof p}>`;
+    }
+  }
+  return p
+    .replaceAll('\\', '/')
+    .replaceAll(/[0-9a-f]{32}/giu, '<hex32>')
+    .replaceAll(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/giu, '<uuid>')
+    .replaceAll(/\d{4,}/gu, '<n>')
+    // Keep only the tail of the path for readability
+    .split('/').slice(-5).join('/');
+}
+
+function callSite() {
+  const o = {};
+  Error.captureStackTrace(o, callSite);
+  const lines = (o.stack || '').split('\n').slice(1);
+  for (const line of lines) {
+    if (line.includes('fs-count.js')) {
+      continue;
+    }
+    if (line.includes('node:internal') || line.includes('node:fs') || line.includes('node:diagnostics')) {
+      continue;
+    }
+    return line.trim()
+      .replace(/^at\s+/u, '')
+      .replace(/.*node_modules\//u, 'nm:')
+      .split(CWD_PREFIX).join('');
+  }
+  return lines[0] ? lines[0].trim() : '<unknown>';
+}
+
+function record(op, p) {
+  total += 1;
+  const sec = Math.floor((Date.now() - startTime) / 1000);
+  if (sec !== curSecond) {
+    if (curSecond >= 0) {
+      timeline.push([ curSecond, curCount ]);
+    }
+    if (timeline.length > 900) {
+      timeline.shift();
+    }
+    curSecond = sec;
+    curCount = 0;
+  }
+  curCount += 1;
+  bump(perOp, op);
+  bump(perSite, `${op} @ ${callSite()}`);
+  if (p !== undefined) {
+    bump(perPath, `${op} ${pathPattern(p)}`);
+  }
+}
+
+function wrap(obj, name, opName) {
+  const orig = obj[name];
+  if (typeof orig !== 'function') {
+    return;
+  }
+  function wrapped(...args) {
+    record(opName || name, args[0]);
+    return orig.apply(this, args);
+  }
+  Object.defineProperty(wrapped, 'name', { value: name });
+  obj[name] = wrapped;
+}
+
+const asyncAndSync = [
+  'open',
+  'readFile',
+  'writeFile',
+  'appendFile',
+  'mkdir',
+  'rmdir',
+  'rm',
+  'unlink',
+  'stat',
+  'lstat',
+  'utimes',
+  'readdir',
+  'access',
+  'copyFile',
+  'rename',
+  'realpath',
+  'symlink',
+  'chmod',
+  'truncate',
+  'opendir',
+  'link',
+  'readlink',
+];
+for (const name of asyncAndSync) {
+  wrap(fs, name);
+  wrap(fs, `${name}Sync`);
+  wrap(fs.promises, name, `p.${name}`);
+}
+wrap(fs, 'createReadStream');
+wrap(fs, 'createWriteStream');
+wrap(fs, 'watch');
+wrap(fs, 'watchFile');
+wrap(fs, 'exists');
+wrap(fs, 'existsSync');
+
+function top(map, n) {
+  return [ ...map.entries() ].sort((a, b) => b[1] - a[1]).slice(0, n);
+}
+
+function snapshot(forceGc) {
+  if (forceGc && typeof globalThis.gc === 'function') {
+    try {
+      globalThis.gc();
+      globalThis.gc();
+    } catch {}
+  }
+  const uptimeSec = (Date.now() - startTime) / 1000;
+  const data = {
+    pid: process.pid,
+    uptimeSec: Math.round(uptimeSec),
+    total,
+    rssMB: Math.round(process.memoryUsage.rss() / 1024 / 1024),
+    perOp: Object.fromEntries(top(perOp, 30)),
+    perSite: Object.fromEntries(top(perSite, 40)),
+    perPath: Object.fromEntries(top(perPath, 30)),
+    timeline: timeline.slice(-240),
+  };
+  try {
+    origWriteFileSync(OUT, JSON.stringify(data, null, 2));
+  } catch {}
+}
+
+const iv = setInterval(snapshot, 5000);
+iv.unref();
+process.on('exit', snapshot);
+// On-demand synchronous dump for benchmark scenario boundaries
+process.on('SIGUSR2', () => snapshot(true));

--- a/scripts/perf/loadgen.js
+++ b/scripts/perf/loadgen.js
@@ -1,0 +1,76 @@
+'use strict';
+/**
+ * Minimal dependency-free HTTP load generator built on global fetch.
+ *
+ * As a module: `const { load } = require('./loadgen');`
+ * As a CLI:    node loadgen.js <url> [concurrency] [seconds] [method] [bodyFile] [contentType]
+ *
+ * A literal `%i` in the URL is replaced by the worker index, so concurrent
+ * workers can target distinct resources (e.g. `.../res-%i.ttl`).
+ */
+const { readFileSync } = require('node:fs');
+
+/**
+ * Drives `conc` concurrent workers against `url` for `seconds` seconds.
+ * Returns { requests, errors, codes, durationSec, rps, p50, p90, p99, max }
+ * with latencies in milliseconds.
+ */
+async function load({ url, method = 'GET', body, contentType, conc = 20, seconds = 10 }) {
+  const deadline = Date.now() + seconds * 1000;
+  let done = 0;
+  let errors = 0;
+  const codes = {};
+  const latencies = [];
+
+  async function worker(i) {
+    const target = url.includes('%i') ? url.replace('%i', String(i)) : url;
+    while (Date.now() < deadline) {
+      const t0 = process.hrtime.bigint();
+      try {
+        const res = await fetch(target, {
+          method,
+          body,
+          headers: contentType ? { 'content-type': contentType } : undefined,
+        });
+        await res.arrayBuffer();
+        codes[res.status] = (codes[res.status] || 0) + 1;
+      } catch {
+        errors += 1;
+      }
+      latencies.push(Number(process.hrtime.bigint() - t0) / 1e6);
+      done += 1;
+    }
+  }
+
+  const t0 = Date.now();
+  await Promise.all(Array.from({ length: conc }, (_, i) => worker(i)));
+  const durationSec = (Date.now() - t0) / 1000;
+  latencies.sort((a, b) => a - b);
+  function pct(p) {
+    return Math.round((latencies[Math.min(latencies.length - 1, Math.floor(latencies.length * p))] || 0) * 100) / 100;
+  }
+  return {
+    requests: done,
+    errors,
+    codes,
+    durationSec: Math.round(durationSec * 10) / 10,
+    rps: Math.round(done / durationSec),
+    p50: pct(0.5),
+    p90: pct(0.9),
+    p99: pct(0.99),
+    max: Math.round((latencies.at(-1) || 0) * 100) / 100,
+  };
+}
+
+module.exports = { load };
+
+if (require.main === module) {
+  const [ url, concurrency = '20', seconds = '10', method = 'GET', bodyFile, contentType ] = process.argv.slice(2);
+  if (!url) {
+    console.error('Usage: node loadgen.js <url> [concurrency] [seconds] [method] [bodyFile] [contentType]');
+    process.exit(1);
+  }
+  const body = bodyFile ? readFileSync(bodyFile) : undefined;
+  load({ url, method, body, contentType, conc: Number(concurrency), seconds: Number(seconds) })
+    .then(stats => console.log(JSON.stringify(stats, null, 2)));
+}

--- a/scripts/perf/loadgen.js
+++ b/scripts/perf/loadgen.js
@@ -1,12 +1,10 @@
 'use strict';
 /**
- * Minimal dependency-free HTTP load generator built on global fetch.
+ * Minimal dependency-free HTTP load generator built on the global fetch.
+ * A literal `%i` in the URL is replaced by the worker index,
+ * so concurrent workers can target distinct resources.
  *
- * As a module: `const { load } = require('./loadgen');`
- * As a CLI:    node loadgen.js <url> [concurrency] [seconds] [method] [bodyFile] [contentType]
- *
- * A literal `%i` in the URL is replaced by the worker index, so concurrent
- * workers can target distinct resources (e.g. `.../res-%i.ttl`).
+ * CLI usage: node loadgen.js <url> [concurrency] [seconds] [method] [bodyFile] [contentType]
  */
 const { readFileSync } = require('node:fs');
 

--- a/scripts/perf/report.js
+++ b/scripts/perf/report.js
@@ -1,13 +1,9 @@
 'use strict';
 /**
- * Renders one or more runner result files as a markdown comparison.
+ * Renders one or more runner result files as a markdown comparison,
+ * with relative differences against the first (baseline) file.
  *
  * Usage: node scripts/perf/report.js baseline.json [candidate.json ...]
- *
- * The first file is the baseline: for every numeric metric the other columns
- * show the relative difference against it. "Better" is metric-dependent
- * (higher rps, lower latency/fs ops/CPU/RSS), so no coloring is applied;
- * the deltas are informational.
  */
 const fs = require('node:fs');
 

--- a/scripts/perf/report.js
+++ b/scripts/perf/report.js
@@ -1,0 +1,79 @@
+'use strict';
+/**
+ * Renders one or more runner result files as a markdown comparison.
+ *
+ * Usage: node scripts/perf/report.js baseline.json [candidate.json ...]
+ *
+ * The first file is the baseline: for every numeric metric the other columns
+ * show the relative difference against it. "Better" is metric-dependent
+ * (higher rps, lower latency/fs ops/CPU/RSS), so no coloring is applied;
+ * the deltas are informational.
+ */
+const fs = require('node:fs');
+
+const METRICS = [ 'rps', 'p50', 'p90', 'p99', 'errors', 'fsOps', 'fsOpsPerReq', 'fsOpsPerSec', 'cpuSec', 'cpuMsPerReq', 'rssMB' ];
+
+const files = process.argv.slice(2);
+if (files.length === 0) {
+  console.error('Usage: node report.js <results.json> [more.json ...]');
+  process.exit(1);
+}
+const runs = files.map(file => JSON.parse(fs.readFileSync(file, 'utf8')));
+const labels = runs.map((run, i) => run.label || `run${i}`);
+
+function delta(base, value) {
+  if (typeof base !== 'number' || typeof value !== 'number' || base === 0) {
+    return '';
+  }
+  const pct = Math.round(((value - base) / base) * 1000) / 10;
+  return ` (${pct > 0 ? '+' : ''}${pct}%)`;
+}
+
+function cell(base, value) {
+  if (value === undefined || value === null) {
+    return '—';
+  }
+  return `${value}${base === value ? '' : delta(base, value)}`;
+}
+
+function table(header, rows) {
+  const lines = [
+    `| ${header.join(' | ')} |`,
+    `|${header.map(() => '---').join('|')}|`,
+    ...rows.map(row => `| ${row.join(' | ')} |`),
+  ];
+  return lines.join('\n');
+}
+
+const out = [];
+out.push(`# Benchmark comparison: ${labels.join(' vs ')}`, '');
+out.push(`Config: ${runs[0].config} — Node ${runs[0].node} — host ${JSON.stringify(runs[0].host || {})}`, '');
+
+// Boot
+const bootRows = [];
+for (const metric of [ 'ms', 'medianMs', 'fsOps', 'rssMB', 'cpuSec' ]) {
+  const values = runs.map(run => run.boot?.[metric]);
+  if (values.every(value => value === undefined)) {
+    continue;
+  }
+  bootRows.push([ metric, ...values.map(value => cell(values[0], value)) ]);
+}
+if (bootRows.length > 0) {
+  out.push('## Boot', '', table([ 'metric', ...labels ], bootRows), '');
+}
+
+// Scenarios
+const names = [ ...new Set(runs.flatMap(run => Object.keys(run.scenarios || {}))) ];
+for (const name of names) {
+  const rows = [];
+  for (const metric of METRICS) {
+    const values = runs.map(run => run.scenarios?.[name]?.[metric]);
+    if (values.every(value => value === undefined)) {
+      continue;
+    }
+    rows.push([ metric, ...values.map(value => cell(values[0], value)) ]);
+  }
+  out.push(`## ${name}`, '', table([ 'metric', ...labels ], rows), '');
+}
+
+console.log(out.join('\n'));

--- a/scripts/perf/runner.js
+++ b/scripts/perf/runner.js
@@ -1,0 +1,305 @@
+'use strict';
+/**
+ * CSS benchmark runner. Boots a server build with the fs-count preload,
+ * drives a fixed set of scenarios against it, and records throughput,
+ * latency percentiles, file-system-operation and CPU-time deltas, and RSS.
+ *
+ * Usage:
+ *   node scripts/perf/runner.js --serverDir <builtCheckout>
+ *     [--config config/file.json] [--port 3460] [--label name] [--out results.json]
+ *     [--seconds 10] [--conc 20] [--wedge] [--bootRuns N]
+ *
+ * --serverDir must point at a *built* CSS checkout (bin/server.js present);
+ *   `jose` is resolved from that checkout's dependency tree for the pod setup.
+ * --wedge additionally reproduces the abandoned-lock-waiter scenario
+ *   (a trickling reader holding a read lock + 40 aborted writers) and
+ *   measures the idle fs-op rate it leaves behind.
+ * --bootRuns N only measures cold-boot time/IO/RSS N times (no scenarios).
+ *
+ * All numbers are indicative: the load generator shares the machine with the
+ * server, and `fetch` (undici) pools connections per origin.
+ */
+const { spawn } = require('node:child_process');
+const { createRequire } = require('node:module');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { load } = require('./loadgen');
+const { setupPod } = require('./bench-setup');
+
+const args = {};
+{
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith('--')) {
+      const key = argv[i].slice(2);
+      if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
+        i += 1;
+        args[key] = argv[i];
+      } else {
+        args[key] = true;
+      }
+    }
+  }
+}
+
+if (!args.serverDir) {
+  console.error('Missing required --serverDir <path to built CSS checkout>');
+  process.exit(1);
+}
+
+const SERVER_DIR = path.resolve(args.serverDir);
+const CONFIG = args.config || 'config/file.json';
+const PORT = Number(args.port || 3460);
+const LABEL = args.label || 'run';
+const SECONDS = Number(args.seconds || 10);
+const CONC = Number(args.conc || 20);
+const OUT = args.out || `${LABEL}.json`;
+const BASE = `http://localhost:${PORT}/`;
+const WORKDIR = fs.mkdtempSync(path.join(os.tmpdir(), `css-bench-${LABEL}-`));
+const COUNTS = path.join(WORKDIR, 'fs-count.json');
+
+const serverRequire = createRequire(path.join(SERVER_DIR, 'noop.js'));
+const jose = serverRequire('jose');
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+let server;
+let serverLog = '';
+
+async function startServer(podDir) {
+  fs.mkdirSync(podDir, { recursive: true });
+  const t0 = Date.now();
+  server = spawn(process.execPath, [
+    '--expose-gc',
+    '--require',
+    path.join(__dirname, 'fs-count.js'),
+    'bin/server.js',
+    '-c',
+    CONFIG,
+    '-f',
+    podDir,
+    '-p',
+    String(PORT),
+    '-l',
+    'warn',
+  ], {
+    cwd: SERVER_DIR,
+    env: { ...process.env, FS_COUNT_OUT: COUNTS },
+    stdio: [ 'ignore', 'pipe', 'pipe' ],
+  });
+  server.stdout.on('data', (data) => {
+    serverLog += data;
+  });
+  server.stderr.on('data', (data) => {
+    serverLog += data;
+  });
+  const deadline = Date.now() + 120000;
+  for (;;) {
+    if (Date.now() > deadline) {
+      throw new Error(`Server did not start.\n${serverLog.slice(-2000)}`);
+    }
+    try {
+      const res = await fetch(BASE, { signal: AbortSignal.timeout(2000) });
+      if (res.status < 500) {
+        break;
+      }
+    } catch {}
+    await sleep(500);
+  }
+  return Date.now() - t0;
+}
+
+function stopServer(signal = 'SIGINT') {
+  return new Promise((resolve) => {
+    if (!server || server.exitCode !== null) {
+      resolve();
+      return;
+    }
+    server.once('exit', resolve);
+    server.kill(signal);
+    // Escalate if a graceful stop hangs
+    setTimeout(() => {
+      try {
+        server.kill('SIGKILL');
+      } catch {}
+    }, 10000).unref();
+  });
+}
+
+// Snapshot of the fs-count preload's counters (forces a dump via SIGUSR2)
+function counters() {
+  try {
+    process.kill(server.pid, 'SIGUSR2');
+  } catch {}
+  return sleep(400).then(() => JSON.parse(fs.readFileSync(COUNTS, 'utf8')));
+}
+
+// Cumulative CPU seconds (user+system) of the server process; Linux only
+function cpuSeconds() {
+  try {
+    const stat = fs.readFileSync(`/proc/${server.pid}/stat`, 'utf8');
+    const rest = stat.slice(stat.lastIndexOf(')') + 2).split(' ');
+    // Fields 14 (utime) and 15 (stime), in USER_HZ ticks (assumed 100 Hz)
+    return (Number(rest[11]) + Number(rest[12])) / 100;
+  } catch {}
+}
+
+async function scenario(name, results, fn) {
+  const before = await counters();
+  const cpuBefore = cpuSeconds();
+  const t0 = Date.now();
+  const stats = await fn();
+  const after = await counters();
+  const cpuAfter = cpuSeconds();
+  const fsOps = after.total - before.total;
+  const durSec = (Date.now() - t0) / 1000;
+  const cpuSec = cpuAfter !== undefined && cpuBefore !== undefined ?
+    Math.round((cpuAfter - cpuBefore) * 100) / 100 :
+    undefined;
+  results.scenarios[name] = {
+    ...stats,
+    fsOps,
+    fsOpsPerReq: stats && stats.requests ? Math.round((fsOps / stats.requests) * 100) / 100 : undefined,
+    fsOpsPerSec: Math.round(fsOps / durSec),
+    cpuSec,
+    cpuMsPerReq: cpuSec !== undefined && stats && stats.requests ?
+      Math.round((cpuSec * 1000 / stats.requests) * 100) / 100 :
+      undefined,
+    rssMB: after.rssMB,
+  };
+  console.log(`[${LABEL}] ${name}: ${JSON.stringify(results.scenarios[name])}`);
+}
+
+const TTL_BODY = '@prefix ex: <http://example.org/> .\nex:s ex:p "hello", "world" ; ex:q 42 .\n';
+
+function idle(seconds) {
+  return async() => {
+    await sleep(seconds * 1000);
+    return { requests: 0, errors: 0, codes: {}, rps: 0 };
+  };
+}
+
+async function runWedge(results, scratch) {
+  // A 100 MB resource, a slow reader holding the read lock, and 40 writers
+  // whose clients abort: on an affected build the abandoned waiters keep
+  // polling the disk although the server is outwardly idle.
+  const big = Buffer.alloc(100 * 1024 * 1024, 7);
+  await fetch(`${scratch}big.bin`, { method: 'PUT', headers: { 'content-type': 'application/octet-stream' }, body: big });
+  const res = await fetch(`${scratch}big.bin`);
+  const reader = res.body.getReader();
+  const state = { trickling: true };
+  const trickler = (async() => {
+    while (state.trickling) {
+      const { done } = await reader.read();
+      if (done) {
+        break;
+      }
+      await sleep(2000);
+    }
+    try {
+      await reader.cancel();
+    } catch {}
+  })();
+  await sleep(1000);
+  const writers = [];
+  for (let i = 0; i < 40; i++) {
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(), 1500);
+    writers.push(fetch(`${scratch}big.bin`, {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain' },
+      body: 'abandoned',
+      signal: ac.signal,
+    }).catch(() => {}));
+  }
+  await Promise.all(writers);
+  await scenario('wedge-40-abandoned-writers-30s', results, idle(30));
+  state.trickling = false;
+  try {
+    await reader.cancel();
+  } catch {}
+  await trickler.catch(() => {});
+  await scenario('wedge-drain-15s', results, idle(15));
+}
+
+async function main() {
+  const results = {
+    label: LABEL,
+    serverDir: SERVER_DIR,
+    config: CONFIG,
+    node: process.version,
+    host: { platform: os.platform(), cpus: os.cpus().length, totalMemMB: Math.round(os.totalmem() / 1024 / 1024) },
+    scenarios: {},
+  };
+
+  // Cold-boot measurement mode: N fresh boots, no load scenarios
+  if (args.bootRuns) {
+    const runs = [];
+    for (let i = 0; i < Number(args.bootRuns); i++) {
+      const ms = await startServer(path.join(WORKDIR, `pod-data-${i}`));
+      const counts = await counters();
+      const cpuSec = cpuSeconds();
+      runs.push({ ms, fsOps: counts.total, rssMB: counts.rssMB, cpuSec });
+      console.log(`[${LABEL}] boot ${i}: ${JSON.stringify(runs[i])}`);
+      await stopServer();
+    }
+    const sorted = [ ...runs ].sort((a, b) => a.ms - b.ms);
+    results.boot = { runs, medianMs: sorted[Math.floor(sorted.length / 2)].ms };
+    fs.writeFileSync(OUT, JSON.stringify(results, null, 2));
+    console.log(`[${LABEL}] written ${OUT}`);
+    return;
+  }
+
+  const bootMs = await startServer(path.join(WORKDIR, 'pod-data'));
+  const bootCounts = await counters();
+  results.boot = { ms: bootMs, fsOps: bootCounts.total, rssMB: bootCounts.rssMB, cpuSec: cpuSeconds() };
+  console.log(`[${LABEL}] boot: ${JSON.stringify(results.boot)}`);
+
+  const pod = await setupPod({ baseUrl: BASE, jose, containers: [ 'scratch/', 'listing/' ]});
+  const { scratch, listing } = pod.containers;
+
+  // Pre-create resources: 20 hot/spread targets + 100 listing children
+  for (let i = 0; i < 20; i++) {
+    await fetch(`${scratch}res-${i}.ttl`, { method: 'PUT', headers: { 'content-type': 'text/turtle' }, body: TTL_BODY });
+  }
+  for (let i = 0; i < 100; i++) {
+    await fetch(`${listing}child-${i}.ttl`, { method: 'PUT', headers: { 'content-type': 'text/turtle' }, body: TTL_BODY });
+  }
+
+  const opts = { conc: CONC, seconds: SECONDS };
+  await scenario('static-get', results, () => load({ url: BASE, ...opts }));
+  await scenario('ldp-get-hot', results, () => load({ url: `${scratch}res-0.ttl`, ...opts }));
+  await scenario('ldp-get-spread', results, () => load({ url: `${scratch}res-%i.ttl`, ...opts }));
+  await scenario('ldp-put', results, () => load({ url: `${scratch}put-%i.ttl`, method: 'PUT', body: TTL_BODY, contentType: 'text/turtle', ...opts }));
+  await scenario('container-listing-100', results, () => load({ url: listing, conc: 10, seconds: SECONDS }));
+  await scenario('idle-20s', results, idle(20));
+
+  if (args.wedge) {
+    await runWedge(results, scratch);
+  }
+
+  const final = await counters();
+  results.final = {
+    totalFsOps: final.total,
+    rssMB: final.rssMB,
+    topSites: Object.fromEntries(Object.entries(final.perSite).slice(0, 15)),
+  };
+
+  fs.writeFileSync(OUT, JSON.stringify(results, null, 2));
+  console.log(`[${LABEL}] written ${OUT}`);
+}
+
+main().then(
+  async() => {
+    await stopServer();
+    process.exit(0);
+  },
+  async(err) => {
+    console.error(err);
+    await stopServer('SIGKILL');
+    process.exit(1);
+  },
+);

--- a/scripts/perf/runner.js
+++ b/scripts/perf/runner.js
@@ -34,14 +34,19 @@ const args = {};
 {
   const argv = process.argv.slice(2);
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i].startsWith('--')) {
+    if (!argv[i].startsWith('--')) {
+      continue;
+    }
+    // --key=value form; required when the value itself starts with '--' (e.g. --serverArgs="--flag x")
+    const eq = argv[i].indexOf('=');
+    if (eq >= 0) {
+      args[argv[i].slice(2, eq)] = argv[i].slice(eq + 1);
+    } else if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
       const key = argv[i].slice(2);
-      if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
-        i += 1;
-        args[key] = argv[i];
-      } else {
-        args[key] = true;
-      }
+      i += 1;
+      args[key] = argv[i];
+    } else {
+      args[argv[i].slice(2)] = true;
     }
   }
 }

--- a/scripts/perf/runner.js
+++ b/scripts/perf/runner.js
@@ -8,6 +8,7 @@
  *   node scripts/perf/runner.js --serverDir <builtCheckout>
  *     [--config config/file.json] [--port 3460] [--label name] [--out results.json]
  *     [--seconds 10] [--conc 20] [--wedge] [--bootRuns N]
+ *     [--serverArgs "--extraFlag value ..."]
  *
  * --serverDir must point at a *built* CSS checkout (bin/server.js present);
  *   `jose` is resolved from that checkout's dependency tree for the pod setup.
@@ -15,6 +16,8 @@
  *   (a trickling reader holding a read lock + 40 aborted writers) and
  *   measures the idle fs-op rate it leaves behind.
  * --bootRuns N only measures cold-boot time/IO/RSS N times (no scenarios).
+ * --serverArgs appends extra whitespace-separated arguments to the server
+ *   command line (e.g. "--moduleStateCachePath /tmp/ms.json").
  *
  * All numbers are indicative: the load generator shares the machine with the
  * server, and `fetch` (undici) pools connections per origin.
@@ -85,6 +88,7 @@ async function startServer(podDir) {
     String(PORT),
     '-l',
     'warn',
+    ...typeof args.serverArgs === 'string' ? args.serverArgs.split(/\s+/u).filter(Boolean) : [],
   ], {
     cwd: SERVER_DIR,
     env: { ...process.env, FS_COUNT_OUT: COUNTS },

--- a/scripts/perf/runner.js
+++ b/scripts/perf/runner.js
@@ -74,6 +74,7 @@ let serverLog = '';
 
 async function startServer(podDir) {
   fs.mkdirSync(podDir, { recursive: true });
+  serverLog = '';
   const t0 = Date.now();
   server = spawn(process.execPath, [
     '--expose-gc',
@@ -107,6 +108,7 @@ async function startServer(podDir) {
     }
     try {
       const res = await fetch(BASE, { signal: AbortSignal.timeout(2000) });
+      await res.arrayBuffer();
       if (res.status < 500) {
         break;
       }
@@ -117,19 +119,26 @@ async function startServer(podDir) {
 }
 
 function stopServer(signal = 'SIGINT') {
+  // Capture the current process: the module-level variable may already
+  // point at the next boot's process by the time the escalation fires.
+  const proc = server;
   return new Promise((resolve) => {
-    if (!server || server.exitCode !== null) {
+    if (!proc || proc.exitCode !== null) {
       resolve();
       return;
     }
-    server.once('exit', resolve);
-    server.kill(signal);
     // Escalate if a graceful stop hangs
-    setTimeout(() => {
+    const escalation = setTimeout(() => {
       try {
-        server.kill('SIGKILL');
+        proc.kill('SIGKILL');
       } catch {}
-    }, 10000).unref();
+    }, 10000);
+    escalation.unref();
+    proc.once('exit', () => {
+      clearTimeout(escalation);
+      resolve();
+    });
+    proc.kill(signal);
   });
 }
 

--- a/scripts/perf/runner.js
+++ b/scripts/perf/runner.js
@@ -1,26 +1,10 @@
 'use strict';
 /**
- * CSS benchmark runner. Boots a server build with the fs-count preload,
- * drives a fixed set of scenarios against it, and records throughput,
- * latency percentiles, file-system-operation and CPU-time deltas, and RSS.
+ * Boots a built CSS checkout with the fs-count preload and drives a fixed scenario suite against it,
+ * recording throughput, latency percentiles, fs-operation and CPU-time deltas, and RSS per scenario.
  *
- * Usage:
- *   node scripts/perf/runner.js --serverDir <builtCheckout>
- *     [--config config/file.json] [--port 3460] [--label name] [--out results.json]
- *     [--seconds 10] [--conc 20] [--wedge] [--bootRuns N]
- *     [--serverArgs "--extraFlag value ..."]
- *
- * --serverDir must point at a *built* CSS checkout (bin/server.js present);
- *   `jose` is resolved from that checkout's dependency tree for the pod setup.
- * --wedge additionally reproduces the abandoned-lock-waiter scenario
- *   (a trickling reader holding a read lock + 40 aborted writers) and
- *   measures the idle fs-op rate it leaves behind.
- * --bootRuns N only measures cold-boot time/IO/RSS N times (no scenarios).
- * --serverArgs appends extra whitespace-separated arguments to the server
- *   command line (e.g. "--moduleStateCachePath /tmp/ms.json").
- *
- * All numbers are indicative: the load generator shares the machine with the
- * server, and `fetch` (undici) pools connections per origin.
+ * Usage: node scripts/perf/runner.js --serverDir <builtCheckout> [options]
+ * Options, scenarios, and caveats are documented in `scripts/perf/README.md`.
  */
 const { spawn } = require('node:child_process');
 const { createRequire } = require('node:module');
@@ -124,8 +108,7 @@ async function startServer(podDir) {
 }
 
 function stopServer(signal = 'SIGINT') {
-  // Capture the current process: the module-level variable may already
-  // point at the next boot's process by the time the escalation fires.
+  // The module-level variable may already point at the next boot's process when the escalation fires
   const proc = server;
   return new Promise((resolve) => {
     if (!proc || proc.exitCode !== null) {
@@ -201,9 +184,7 @@ function idle(seconds) {
 }
 
 async function runWedge(results, scratch) {
-  // A 100 MB resource, a slow reader holding the read lock, and 40 writers
-  // whose clients abort: on an affected build the abandoned waiters keep
-  // polling the disk although the server is outwardly idle.
+  // A slow reader holds the read lock on a large resource while 40 aborted writers leave waiters behind
   const big = Buffer.alloc(100 * 1024 * 1024, 7);
   await fetch(`${scratch}big.bin`, { method: 'PUT', headers: { 'content-type': 'application/octet-stream' }, body: big });
   const res = await fetch(`${scratch}big.bin`);


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — the CSS template requires a linked issue, so an upstream issue describing the need for reproducible benchmarking must be created before this is submitted upstream. Upstream context: [CommunitySolidServer#1169](https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1169) (closed) preferred keeping metrics tooling external to the server, so this may equally stay fork-only as the working equipment behind the fork's performance PR series (#22, #23, #24, #25, #26, #27) — that call is the maintainer's.

#### ✍️ Description

The benchmarking and instrumentation harness behind the A/B numbers in the fork's performance PR series, added under `scripts/perf/` so those numbers are reproducible and reviewable:

- `fs-count.js` — a dependency-free CommonJS preload (`node --require`) that wraps `fs`/`fs.promises` before any application module loads, so wrappers such as `graceful-fs`/`fs-extra` capture the counting functions too. Aggregates every call per operation, per call site, and per anonymized path pattern (hashes/UUIDs/counters collapsed so identical access patterns aggregate), with a per-second timeline and GC-forced RSS; snapshots to JSON every 5 s, on exit, and on `SIGUSR2`. It must stay dependency-free CJS because it runs inside the measured server process before anything else loads.
- `runner.js` — boots a built checkout with the preload and drives fixed scenarios (static GET, hot/spread LDP GET, LDP PUT, container listing with 100 children, idle watch, and the `--wedge` abandoned-lock-waiter reproduction from #22/#23), recording req/s, latency percentiles, fs ops (total / per request / per second), CPU time (from `/proc`, Linux only), and RSS per scenario. `--bootRuns N` measures N cold boots only — for upcoming startup-time work; `--serverArgs` appends extra flags to the measured server's command line.
- `bench-setup.js` — account + pod + client credentials + DPoP token + public benchmark containers. The public ACL keeps token signing out of the measured request path; the returned `authed` fetch covers callers that do need owner-authenticated requests. `jose` (for the DPoP proofs during setup) is resolved from the *measured checkout's* dependency tree at runtime, so the harness itself adds no dependency.
- `loadgen.js` — minimal fetch-based load generator (used by the runner, also standalone).
- `report.js` — renders one or more result files as a markdown comparison with % deltas against the first (baseline) file. The deltas carry no better/worse styling because "better" is metric-dependent (higher req/s, lower latency/fs-ops/CPU/RSS).
- `README.md` — usage, options, scenario list, and an explicit *caveats* section (same-host load generation, connection pooling, warm caches) so numbers aren't over-read.

`eslint.config.mjs` gains a scoped override for `scripts/perf/**/*.js` (`no-console`, `no-sync`, `unicorn/no-process-exit` off): these are standalone CLI tools whose interface is console output, and the preload writes its snapshots synchronously by design. Everything else lints under the repo config.

Example output from a short run on this branch — `node scripts/perf/runner.js --serverDir <built checkout>` with the defaults (`--seconds 10 --conc 20`, `config/file.json`) on a 2-core shared EC2 box, so indicative only (see the README caveats):

| metric | boot | static-get | ldp-get-hot | ldp-put | container-listing-100 |
| --- | --- | --- | --- | --- | --- |
| req/s | — | 396 | 68 | 49 | 13 |
| fs ops/req | 19,192 total | 2 | 21.8 | 49.2 | **115.1** |
| CPU ms/req | 23.6 s total | 3.4 | 20.8 | 28.1 | 108.7 |

Intended target branch is `main` and the intended semver level is **patch**: tooling only — no runtime code, no interface or configuration-behaviour change (labels are maintainer-set). No `src/` change, so unit coverage is unaffected; eslint and markdownlint are clean and the harness was smoke-tested end-to-end (boot + all scenarios + report rendering). Commits are unsigned (the agent has no access to the signing key); re-sign on rebase if wanted.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
