### PR TITLE
perf: Cache the Components.js module state between server starts

### DIFF
--- a/config/app/variables/cli/cli.json
+++ b/config/app/variables/cli/cli.json
@@ -2,7 +2,7 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
   "@graph": [
     {
-      "comment": "Extracts CLI arguments into a key/value object. Config and mainModulePath are only defined here so their description is returned.",
+      "comment": "Extracts CLI arguments into a key/value object. Config, mainModulePath, and moduleStateCachePath are only defined here so their description is returned.",
       "@id": "urn:solid-server-app-setup:default:CliExtractor",
       "@type": "YargsCliExtractor",
       "parameters": [
@@ -24,6 +24,15 @@
             "requiresArg": true,
             "type": "string",
             "describe": "Path from where Components.js will start its lookup when initializing configurations."
+          }
+        },
+        {
+          "@type": "YargsParameter",
+          "name": "moduleStateCachePath",
+          "options": {
+            "requiresArg": true,
+            "type": "string",
+            "describe": "Path to a file used to cache the Components.js module state between server starts, speeding up startup."
           }
         },
         {

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -63,6 +63,7 @@ to some commonly used settings:
 | `--podConfigJson`       | `./pod-config.json`        | Path to the file that keeps track of dynamic Pod configurations. Only relevant when using `@css:config/dynamic.json`.                         |
 | `--seedConfig`          |                            | Path to the file that keeps track of seeded account configurations.                                                                           |
 | `--mainModulePath, -m`  |                            | Path from where Components.js will start its lookup when initializing configurations.                                                         |
+| `--moduleStateCachePath` |                           | Path to a file used to cache the Components.js module state between server starts, speeding up startup.                                       |
 | `--workers, -w`         | `1`                        | Run in multithreaded mode using workers. Special values are `-1` (scale to `num_cores-1`), `0` (scale to `num_cores`) and 1 (singlethreaded). |
 
 Parameters can also be passed through environment variables.

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,6 +305,7 @@ export * from './init/Initializable';
 export * from './init/InitializableHandler';
 export * from './init/Initializer';
 export * from './init/LoggerInitializer';
+export * from './init/ModuleStateCache';
 export * from './init/ModuleVersionVerifier';
 export * from './init/SeededAccountInitializer';
 export * from './init/ServerInitializer';

--- a/src/init/AppRunner.ts
+++ b/src/init/AppRunner.ts
@@ -13,6 +13,7 @@ import type { App } from './App';
 import type { CliExtractor } from './cli/CliExtractor';
 import type { CliResolver } from './CliResolver';
 import { listSingleThreadedComponents } from './cluster/SingleThreaded';
+import { ModuleStateCache } from './ModuleStateCache';
 import type { ShorthandResolver } from './variables/ShorthandResolver';
 import type { CliArgv, Shorthand, VariableBindings } from './variables/Types';
 
@@ -25,6 +26,7 @@ const CORE_CLI_PARAMETERS = {
   config: { type: 'array', alias: 'c', default: [ DEFAULT_CONFIG ], requiresArg: true },
   loggingLevel: { type: 'string', alias: 'l', default: 'info', requiresArg: true, choices: LOG_LEVELS },
   mainModulePath: { type: 'string', alias: 'm', requiresArg: true },
+  moduleStateCachePath: { type: 'string', requiresArg: true },
 } as const;
 
 const ENV_VAR_PREFIX = 'CSS';
@@ -46,6 +48,16 @@ export interface AppRunnerInput {
    * Path to the server config file(s). Defaults to `@css:config/default.json`.
    */
   config?: string | string[];
+  /**
+   * Path to a file in which the Components.js module state gets cached between server starts.
+   * When defined, a valid cached module state will be reused,
+   * skipping the expensive scan of all `node_modules` directories.
+   * If there is no valid cache entry yet,
+   * the module state generated during the build will be written to this file.
+   * Corresponds to the `--moduleStateCachePath` CLI parameter
+   * and the `CSS_MODULE_STATE_CACHE_PATH` environment variable.
+   */
+  moduleStateCachePath?: string;
   /**
    * Values to apply to the Components.js variables.
    * These are the variables CLI values will be converted to.
@@ -104,11 +116,33 @@ export class AppRunner {
     let configs = input.config ?? [ '@css:config/default.json' ];
     configs = (Array.isArray(configs) ? configs : [ configs ]).map(resolveAssetPath);
 
+    // When a cache path was provided, try to reuse a previously cached Components.js module state,
+    // so the expensive scan of all `node_modules` directories can be skipped.
+    let moduleStateCache: ModuleStateCache | undefined;
+    if (input.moduleStateCachePath && !loaderProperties.moduleState) {
+      const cache = new ModuleStateCache(
+        resolveAssetPath(input.moduleStateCachePath),
+        loaderProperties.mainModulePath,
+      );
+      const cachedState = await cache.load();
+      if (cachedState) {
+        loaderProperties.moduleState = cachedState;
+      } else {
+        // Remember the cache so the module state can be stored after it has been generated
+        moduleStateCache = cache;
+      }
+    }
+
     let componentsManager: ComponentsManager<App | CliResolver>;
     try {
       componentsManager = await this.createComponentsManager<App>(loaderProperties, configs);
     } catch (error: unknown) {
       this.resolveError(`Could not build the config files from ${configs.join(',')}`, error);
+    }
+
+    // Store the generated module state so the next server start can reuse it
+    if (moduleStateCache) {
+      await moduleStateCache.save(componentsManager.moduleState);
     }
 
     const cliResolver = await this.createCliResolver(componentsManager as ComponentsManager<CliResolver>);
@@ -195,6 +229,7 @@ export class AppRunner {
     return this.create({
       loaderProperties,
       config: params.config as string[],
+      moduleStateCachePath: params.moduleStateCachePath,
       argv,
       shorthand: settings,
     });

--- a/src/init/AppRunner.ts
+++ b/src/init/AppRunner.ts
@@ -49,13 +49,9 @@ export interface AppRunnerInput {
    */
   config?: string | string[];
   /**
-   * Path to a file in which the Components.js module state gets cached between server starts.
-   * When defined, a valid cached module state will be reused,
-   * skipping the expensive scan of all `node_modules` directories.
-   * If there is no valid cache entry yet,
-   * the module state generated during the build will be written to this file.
-   * Corresponds to the `--moduleStateCachePath` CLI parameter
-   * and the `CSS_MODULE_STATE_CACHE_PATH` environment variable.
+   * Path to a file in which the Components.js module state gets cached between server starts,
+   * so the expensive scan of all `node_modules` directories can be skipped.
+   * On a cache miss, the newly generated module state gets written to this file.
    */
   moduleStateCachePath?: string;
   /**
@@ -116,8 +112,7 @@ export class AppRunner {
     let configs = input.config ?? [ '@css:config/default.json' ];
     configs = (Array.isArray(configs) ? configs : [ configs ]).map(resolveAssetPath);
 
-    // When a cache path was provided, try to reuse a previously cached Components.js module state,
-    // so the expensive scan of all `node_modules` directories can be skipped.
+    // An explicitly provided module state takes precedence over the cache
     let moduleStateCache: ModuleStateCache | undefined;
     if (input.moduleStateCachePath && !loaderProperties.moduleState) {
       const cache = new ModuleStateCache(

--- a/src/init/ModuleStateCache.ts
+++ b/src/init/ModuleStateCache.ts
@@ -6,6 +6,12 @@ import { createErrorMessage } from '../util/errors/ErrorUtil';
 import { joinFilePath, readPackageJson } from '../util/PathUtil';
 
 /**
+ * Counter combined with the process id to generate unique temporary file names,
+ * ensuring concurrent writes never target the same temporary path.
+ */
+let tempCounter = 0;
+
+/**
  * The contents of a module state cache file.
  */
 interface ModuleStateCacheEntry {
@@ -63,13 +69,25 @@ export class ModuleStateCache {
     }
 
     let entry: ModuleStateCacheEntry | null;
-    let key: string;
     try {
       entry = JSON.parse(raw) as ModuleStateCacheEntry | null;
+    } catch (error: unknown) {
+      // The cache file is corrupt and can never become valid again, so it gets removed.
+      this.logger.warn(`Removing corrupt module state cache at ${this.path}: ${createErrorMessage(error)}`);
+      await this.remove();
+      return;
+    }
+
+    let key: string;
+    try {
       key = await this.getKey();
     } catch (error: unknown) {
-      this.logger.warn(`Ignoring invalid module state cache at ${this.path}: ${createErrorMessage(error)}`);
-      await this.remove();
+      // Computing the key can fail because of transient environment issues,
+      // such as a temporarily missing or unreadable package-lock.json or package.json.
+      // The cached entry might still be valid, so it is treated as a miss without being removed.
+      this.logger.warn(
+        `Unable to compute the module state cache key, ignoring cache at ${this.path}: ${createErrorMessage(error)}`,
+      );
       return;
     }
 
@@ -91,16 +109,25 @@ export class ModuleStateCache {
    * @param moduleState - The module state to cache.
    */
   public async save(moduleState: IModuleState): Promise<void> {
+    // Use a temporary file name that is unique per process and per call so concurrent writes
+    // from multiple server instances never target the same temporary file and corrupt each other.
+    const nonce = tempCounter;
+    tempCounter += 1;
+    const tempPath = `${this.path}.${process.pid}.${Date.now()}.${nonce}.tmp`;
     try {
       const entry: ModuleStateCacheEntry = { key: await this.getKey(), moduleState };
       // Write to a temporary file first so an existing cache file does not get corrupted
       // in case an error occurs halfway through the write.
-      const tempPath = `${this.path}.tmp`;
       await fsPromises.writeFile(tempPath, JSON.stringify(entry), 'utf8');
+      // Best-effort removal of the destination before renaming: on some platforms (notably Windows)
+      // `rename` does not reliably overwrite an existing file.
+      await this.remove();
       await fsPromises.rename(tempPath, this.path);
       this.logger.debug(`Stored module state in ${this.path}`);
     } catch (error: unknown) {
       this.logger.warn(`Unable to write module state cache to ${this.path}: ${createErrorMessage(error)}`);
+      // Best-effort cleanup so a failed write does not leave the unique temporary file behind.
+      await this.remove(tempPath);
     }
   }
 
@@ -132,13 +159,15 @@ export class ModuleStateCache {
   }
 
   /**
-   * Removes the cache file, ignoring any errors.
+   * Removes the given file, ignoring any errors.
+   *
+   * @param path - Path of the file to remove. Defaults to the cache file path.
    */
-  private async remove(): Promise<void> {
+  private async remove(path: string = this.path): Promise<void> {
     try {
-      await fsPromises.unlink(this.path);
+      await fsPromises.unlink(path);
     } catch {
-      this.logger.debug(`Unable to remove module state cache at ${this.path}`);
+      this.logger.debug(`Unable to remove file at ${path}`);
     }
   }
 }

--- a/src/init/ModuleStateCache.ts
+++ b/src/init/ModuleStateCache.ts
@@ -1,0 +1,144 @@
+import { createHash } from 'node:crypto';
+import { promises as fsPromises } from 'node:fs';
+import type { IModuleState } from 'componentsjs';
+import { getLoggerFor } from '../logging/LogUtil';
+import { createErrorMessage } from '../util/errors/ErrorUtil';
+import { joinFilePath, readPackageJson } from '../util/PathUtil';
+
+/**
+ * The contents of a module state cache file.
+ */
+interface ModuleStateCacheEntry {
+  /**
+   * Key identifying the environment in which the module state was generated.
+   */
+  key: string;
+  /**
+   * The cached module state.
+   */
+  moduleState: IModuleState;
+}
+
+/**
+ * Caches a Components.js {@link IModuleState} as JSON on disk,
+ * allowing subsequent server starts to skip the expensive scan of all `node_modules` directories.
+ *
+ * Cache entries contain a key identifying the environment in which they were generated.
+ * This key is a SHA-256 hash of the server version, the Node.js version, the main module path,
+ * and the contents of the `package-lock.json` file in the main module path.
+ * If there is no such file, the contents of the `package.json` file in the main module path are used instead.
+ * A cached module state only gets reused if its key matches that of the current environment,
+ * otherwise the stale cache file gets removed.
+ */
+export class ModuleStateCache {
+  private readonly logger = getLoggerFor(this);
+
+  private readonly path: string;
+  private readonly mainModulePath: string;
+  private key: string | undefined;
+
+  /**
+   * @param path - Path of the file in which the module state gets cached.
+   * @param mainModulePath - The main module path used when building the Components.js manager.
+   */
+  public constructor(path: string, mainModulePath: string) {
+    this.path = path;
+    this.mainModulePath = mainModulePath;
+  }
+
+  /**
+   * Loads the module state from the cache.
+   * Invalid or stale cache files get removed.
+   * Never throws: all errors result in a cache miss.
+   *
+   * @returns The cached module state, or `undefined` if there is no valid cache entry.
+   */
+  public async load(): Promise<IModuleState | undefined> {
+    let raw: string;
+    try {
+      raw = await fsPromises.readFile(this.path, 'utf8');
+    } catch {
+      this.logger.debug(`Unable to read module state cache from ${this.path}`);
+      return;
+    }
+
+    let entry: ModuleStateCacheEntry | null;
+    let key: string;
+    try {
+      entry = JSON.parse(raw) as ModuleStateCacheEntry | null;
+      key = await this.getKey();
+    } catch (error: unknown) {
+      this.logger.warn(`Ignoring invalid module state cache at ${this.path}: ${createErrorMessage(error)}`);
+      await this.remove();
+      return;
+    }
+
+    if (entry?.key !== key) {
+      this.logger.debug(`Removing stale module state cache at ${this.path}`);
+      await this.remove();
+      return;
+    }
+
+    this.logger.debug(`Reusing cached module state from ${this.path}`);
+    return entry.moduleState;
+  }
+
+  /**
+   * Writes the given module state to the cache,
+   * together with the key of the current environment.
+   * Never throws: a warning gets logged if writing fails.
+   *
+   * @param moduleState - The module state to cache.
+   */
+  public async save(moduleState: IModuleState): Promise<void> {
+    try {
+      const entry: ModuleStateCacheEntry = { key: await this.getKey(), moduleState };
+      // Write to a temporary file first so an existing cache file does not get corrupted
+      // in case an error occurs halfway through the write.
+      const tempPath = `${this.path}.tmp`;
+      await fsPromises.writeFile(tempPath, JSON.stringify(entry), 'utf8');
+      await fsPromises.rename(tempPath, this.path);
+      this.logger.debug(`Stored module state in ${this.path}`);
+    } catch (error: unknown) {
+      this.logger.warn(`Unable to write module state cache to ${this.path}: ${createErrorMessage(error)}`);
+    }
+  }
+
+  /**
+   * Generates the key identifying the current environment.
+   * The result is cached so it only gets computed once.
+   */
+  private async getKey(): Promise<string> {
+    if (!this.key) {
+      const pkg = await readPackageJson();
+      this.key = createHash('sha256')
+        .update(`${pkg.version as string}\n${process.version}\n${this.mainModulePath}\n`)
+        .update(await this.readDependencies())
+        .digest('hex');
+    }
+    return this.key;
+  }
+
+  /**
+   * Reads the contents of the `package-lock.json` file in the main module path,
+   * falling back to the `package.json` file if there is no lock file.
+   */
+  private async readDependencies(): Promise<string> {
+    try {
+      return await fsPromises.readFile(joinFilePath(this.mainModulePath, 'package-lock.json'), 'utf8');
+    } catch {
+      return fsPromises.readFile(joinFilePath(this.mainModulePath, 'package.json'), 'utf8');
+    }
+  }
+
+  /**
+   * Removes the cache file, ignoring any errors.
+   */
+  private async remove(): Promise<void> {
+    try {
+      await fsPromises.unlink(this.path);
+    } catch {
+      this.logger.debug(`Unable to remove module state cache at ${this.path}`);
+    }
+  }
+}

--- a/src/init/ModuleStateCache.ts
+++ b/src/init/ModuleStateCache.ts
@@ -6,8 +6,7 @@ import { createErrorMessage } from '../util/errors/ErrorUtil';
 import { joinFilePath, readPackageJson } from '../util/PathUtil';
 
 /**
- * Counter combined with the process id to generate unique temporary file names,
- * ensuring concurrent writes never target the same temporary path.
+ * Counter combined with the process id to keep concurrent saves from sharing a temporary file.
  */
 let tempCounter = 0;
 
@@ -28,13 +27,8 @@ interface ModuleStateCacheEntry {
 /**
  * Caches a Components.js {@link IModuleState} as JSON on disk,
  * allowing subsequent server starts to skip the expensive scan of all `node_modules` directories.
- *
- * Cache entries contain a key identifying the environment in which they were generated.
- * This key is a SHA-256 hash of the server version, the Node.js version, the main module path,
- * and the contents of the `package-lock.json` file in the main module path.
- * If there is no such file, the contents of the `package.json` file in the main module path are used instead.
- * A cached module state only gets reused if its key matches that of the current environment,
- * otherwise the stale cache file gets removed.
+ * Entries are keyed on a hash of the server version, the Node.js version, the main module path,
+ * and the dependency file contents, so a cached state only gets reused in the environment that generated it.
  */
 export class ModuleStateCache {
   private readonly logger = getLoggerFor(this);
@@ -82,9 +76,7 @@ export class ModuleStateCache {
     try {
       key = await this.getKey();
     } catch (error: unknown) {
-      // Computing the key can fail because of transient environment issues,
-      // such as a temporarily missing or unreadable package-lock.json or package.json.
-      // The cached entry might still be valid, so it is treated as a miss without being removed.
+      // Key errors can be transient, so the potentially valid cache file is kept.
       this.logger.warn(
         `Unable to compute the module state cache key, ignoring cache at ${this.path}: ${createErrorMessage(error)}`,
       );
@@ -109,24 +101,20 @@ export class ModuleStateCache {
    * @param moduleState - The module state to cache.
    */
   public async save(moduleState: IModuleState): Promise<void> {
-    // Use a temporary file name that is unique per process and per call so concurrent writes
-    // from multiple server instances never target the same temporary file and corrupt each other.
     const nonce = tempCounter;
     tempCounter += 1;
     const tempPath = `${this.path}.${process.pid}.${Date.now()}.${nonce}.tmp`;
     try {
       const entry: ModuleStateCacheEntry = { key: await this.getKey(), moduleState };
-      // Write to a temporary file first so an existing cache file does not get corrupted
-      // in case an error occurs halfway through the write.
+      // Write to a temporary file first so a failed write cannot corrupt an existing cache file.
       await fsPromises.writeFile(tempPath, JSON.stringify(entry), 'utf8');
-      // Best-effort removal of the destination before renaming: on some platforms (notably Windows)
-      // `rename` does not reliably overwrite an existing file.
+      // Remove the destination first: on some platforms (notably Windows) `rename` does not reliably overwrite.
       await this.remove();
       await fsPromises.rename(tempPath, this.path);
       this.logger.debug(`Stored module state in ${this.path}`);
     } catch (error: unknown) {
       this.logger.warn(`Unable to write module state cache to ${this.path}: ${createErrorMessage(error)}`);
-      // Best-effort cleanup so a failed write does not leave the unique temporary file behind.
+      // Best-effort cleanup so a failed write does not leave the temporary file behind.
       await this.remove(tempPath);
     }
   }

--- a/test/unit/init/AppRunner.test.ts
+++ b/test/unit/init/AppRunner.test.ts
@@ -3,6 +3,7 @@ import type { ClusterManager } from '../../../src';
 import type { App } from '../../../src/init/App';
 import { AppRunner } from '../../../src/init/AppRunner';
 import type { CliExtractor } from '../../../src/init/cli/CliExtractor';
+import { ModuleStateCache } from '../../../src/init/ModuleStateCache';
 import type { ShorthandResolver } from '../../../src/init/variables/ShorthandResolver';
 import { joinFilePath } from '../../../src/util/PathUtil';
 import { flushPromises } from '../../util/Util';
@@ -70,6 +71,8 @@ const app: jest.Mocked<App> = {
   clusterManager,
 } as any;
 
+const builtModuleState = { mainModulePath: 'built' };
+
 const manager: jest.Mocked<ComponentsManager<App>> = {
   instantiate: jest.fn(async(iri: string): Promise<any> => {
     switch (iri) {
@@ -81,6 +84,7 @@ const manager: jest.Mocked<ComponentsManager<App>> = {
   configRegistry: {
     register: jest.fn(),
   },
+  moduleState: builtModuleState,
 } as any;
 
 const listSingleThreadedComponentsMock = jest.fn().mockResolvedValue([]);
@@ -93,6 +97,17 @@ jest.mock('componentsjs', (): any => ({
   ComponentsManager: {
     build: jest.fn(async(): Promise<ComponentsManager<App>> => manager),
   },
+}));
+
+const cachedModuleState = { mainModulePath: 'cached' };
+
+const moduleStateCache = {
+  load: jest.fn(),
+  save: jest.fn(),
+};
+
+jest.mock('../../../src/init/ModuleStateCache', (): any => ({
+  ModuleStateCache: jest.fn((): any => moduleStateCache),
 }));
 
 let files: Record<string, any> = {};
@@ -228,6 +243,63 @@ describe('AppRunner', (): void => {
       expect(cliExtractor.handleSafe).toHaveBeenCalledTimes(0);
       expect(app.start).toHaveBeenCalledTimes(0);
       expect(app.clusterManager.isSingleThreaded()).toBeFalsy();
+      expect(ModuleStateCache).toHaveBeenCalledTimes(0);
+      expect(moduleStateCache.load).toHaveBeenCalledTimes(0);
+      expect(moduleStateCache.save).toHaveBeenCalledTimes(0);
+    });
+
+    it('uses the cached module state on a cache hit.', async(): Promise<void> => {
+      moduleStateCache.load.mockResolvedValueOnce(cachedModuleState);
+      const createdApp = await new AppRunner().create({ moduleStateCachePath: 'module-state.json' });
+      expect(createdApp).toBe(app);
+
+      expect(ModuleStateCache).toHaveBeenCalledTimes(1);
+      expect(ModuleStateCache).toHaveBeenCalledWith('/var/cwd/module-state.json', joinFilePath(__dirname, '../../../'));
+      expect(moduleStateCache.load).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledWith({
+        mainModulePath: joinFilePath(__dirname, '../../../'),
+        typeChecking: false,
+        dumpErrorState: false,
+        moduleState: cachedModuleState,
+      });
+      expect(moduleStateCache.save).toHaveBeenCalledTimes(0);
+    });
+
+    it('saves the module state on a cache miss.', async(): Promise<void> => {
+      const createdApp = await new AppRunner().create({ moduleStateCachePath: 'module-state.json' });
+      expect(createdApp).toBe(app);
+
+      expect(ModuleStateCache).toHaveBeenCalledTimes(1);
+      expect(ModuleStateCache).toHaveBeenCalledWith('/var/cwd/module-state.json', joinFilePath(__dirname, '../../../'));
+      expect(moduleStateCache.load).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledWith({
+        mainModulePath: joinFilePath(__dirname, '../../../'),
+        typeChecking: false,
+        dumpErrorState: false,
+      });
+      expect(moduleStateCache.save).toHaveBeenCalledTimes(1);
+      expect(moduleStateCache.save).toHaveBeenCalledWith(builtModuleState);
+    });
+
+    it('does not use the cache if a module state is provided.', async(): Promise<void> => {
+      const createdApp = await new AppRunner().create({
+        moduleStateCachePath: 'module-state.json',
+        loaderProperties: { moduleState: cachedModuleState as any },
+      });
+      expect(createdApp).toBe(app);
+
+      expect(ModuleStateCache).toHaveBeenCalledTimes(0);
+      expect(moduleStateCache.load).toHaveBeenCalledTimes(0);
+      expect(moduleStateCache.save).toHaveBeenCalledTimes(0);
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledWith({
+        mainModulePath: joinFilePath(__dirname, '../../../'),
+        typeChecking: false,
+        dumpErrorState: false,
+        moduleState: cachedModuleState,
+      });
     });
 
     it('throws an error if threading issues are detected with 1 class.', async(): Promise<void> => {
@@ -462,6 +534,52 @@ describe('AppRunner', (): void => {
       expect(app.clusterManager.isSingleThreaded()).toBeFalsy();
 
       process.argv = argv;
+    });
+
+    it('uses the module state cache when the moduleStateCachePath parameter is set.', async(): Promise<void> => {
+      moduleStateCache.load.mockResolvedValueOnce(cachedModuleState);
+      const params = [ 'node', 'script', '--moduleStateCachePath', 'module-state.json' ];
+      await expect(new AppRunner().createCli(params)).resolves.toBe(app);
+
+      expect(ModuleStateCache).toHaveBeenCalledTimes(1);
+      expect(ModuleStateCache).toHaveBeenCalledWith('/var/cwd/module-state.json', joinFilePath(__dirname, '../../../'));
+      expect(moduleStateCache.load).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledWith({
+        logLevel: 'info',
+        mainModulePath: joinFilePath(__dirname, '../../../'),
+        typeChecking: false,
+        dumpErrorState: false,
+        moduleState: cachedModuleState,
+      });
+      expect(moduleStateCache.save).toHaveBeenCalledTimes(0);
+    });
+
+    it('honours the CSS_MODULE_STATE_CACHE_PATH environment variable.', async(): Promise<void> => {
+      const { env } = process;
+      const OLD_STATE = env.CSS_MODULE_STATE_CACHE_PATH;
+      env.CSS_MODULE_STATE_CACHE_PATH = 'module-state.json';
+      moduleStateCache.load.mockResolvedValueOnce(cachedModuleState);
+
+      await expect(new AppRunner().createCli([ 'node', 'script' ])).resolves.toBe(app);
+
+      expect(ModuleStateCache).toHaveBeenCalledTimes(1);
+      expect(ModuleStateCache).toHaveBeenCalledWith('/var/cwd/module-state.json', joinFilePath(__dirname, '../../../'));
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledWith({
+        logLevel: 'info',
+        mainModulePath: joinFilePath(__dirname, '../../../'),
+        typeChecking: false,
+        dumpErrorState: false,
+        moduleState: cachedModuleState,
+      });
+
+      // Reset env
+      if (OLD_STATE) {
+        env.CSS_MODULE_STATE_CACHE_PATH = OLD_STATE;
+      } else {
+        delete env.CSS_MODULE_STATE_CACHE_PATH;
+      }
     });
 
     it('checks for threading issues when starting in multithreaded mode.', async(): Promise<void> => {

--- a/test/unit/init/ModuleStateCache.test.ts
+++ b/test/unit/init/ModuleStateCache.test.ts
@@ -60,12 +60,15 @@ describe('A ModuleStateCache', (): void => {
   it('stores the module state together with the key.', async(): Promise<void> => {
     await expect(cache.save(moduleState)).resolves.toBeUndefined();
     expect(logger.warn).toHaveBeenCalledTimes(0);
-    expect(files[`${cachePath}.tmp`]).toBeUndefined();
+    // No temporary file (neither the legacy nor a unique name) remains after saving.
+    expect(Object.keys(files).some((path): boolean => path.endsWith('.tmp'))).toBe(false);
     expect(JSON.parse(files[cachePath])).toEqual({ key: expect.any(String), moduleState });
   });
 
   it('returns the module state if the stored key matches.', async(): Promise<void> => {
     await cache.save(moduleState);
+    // Reset the mocks so only the behaviour of load() is asserted below.
+    jest.clearAllMocks();
     // Use a new instance to make sure the key is not being reused from memory
     cache = new ModuleStateCache(cachePath, mainModulePath);
     await expect(cache.load()).resolves.toEqual(moduleState);
@@ -110,11 +113,15 @@ describe('A ModuleStateCache', (): void => {
     expect(files[cachePath]).toBeUndefined();
   });
 
-  it('ignores the cache if the key could not be computed.', async(): Promise<void> => {
-    files[cachePath] = JSON.stringify({ key: 'irrelevant', moduleState });
+  it('ignores the cache without removing it if the key could not be computed.', async(): Promise<void> => {
+    const entry = JSON.stringify({ key: 'irrelevant', moduleState });
+    files[cachePath] = entry;
     jest.mocked(readJson).mockRejectedValueOnce(new Error('bad package.json'));
     await expect(cache.load()).resolves.toBeUndefined();
     expect(logger.warn).toHaveBeenCalledTimes(1);
+    // A transient key-computation error must not invalidate a potentially valid cache entry.
+    expect(fsPromises.unlink).toHaveBeenCalledTimes(0);
+    expect(files[cachePath]).toBe(entry);
   });
 
   it('generates a different key if there is no package-lock.json.', async(): Promise<void> => {
@@ -130,6 +137,48 @@ describe('A ModuleStateCache', (): void => {
     // The cache remains valid as long as the package.json does not change
     cache = new ModuleStateCache(cachePath, mainModulePath);
     await expect(cache.load()).resolves.toEqual(moduleState);
+  });
+
+  it('writes to a unique temporary file that includes the process id.', async(): Promise<void> => {
+    await cache.save(moduleState);
+    const firstTemp = jest.mocked(fsPromises.writeFile).mock.calls[0][0] as string;
+    await cache.save(moduleState);
+    const secondTemp = jest.mocked(fsPromises.writeFile).mock.calls[1][0] as string;
+
+    // The temporary name is unique per process and per call, unlike the fixed `${path}.tmp`.
+    expect(firstTemp).toContain(`.${process.pid}.`);
+    expect(firstTemp).not.toBe(`${cachePath}.tmp`);
+    expect(firstTemp).not.toBe(secondTemp);
+    // No temporary files are left behind after saving.
+    expect(Object.keys(files).some((path): boolean => path.endsWith('.tmp'))).toBe(false);
+  });
+
+  it('removes the existing cache file before renaming for cross-platform overwrite.', async(): Promise<void> => {
+    files[cachePath] = 'stale';
+    const order: string[] = [];
+    jest.mocked(fsPromises.unlink).mockImplementationOnce(async(path: string): Promise<void> => {
+      order.push(`unlink:${path}`);
+      delete files[path];
+    });
+    jest.mocked(fsPromises.rename).mockImplementationOnce(async(source: string, destination: string): Promise<void> => {
+      order.push(`rename:${destination}`);
+      files[destination] = files[source];
+      delete files[source];
+    });
+
+    await expect(cache.save(moduleState)).resolves.toBeUndefined();
+    // The destination gets removed first so the rename works even where it does not overwrite.
+    expect(order).toEqual([ `unlink:${cachePath}`, `rename:${cachePath}` ]);
+    expect(JSON.parse(files[cachePath])).toEqual({ key: expect.any(String), moduleState });
+  });
+
+  it('cleans up the temporary file if renaming fails.', async(): Promise<void> => {
+    jest.mocked(fsPromises.rename).mockRejectedValueOnce(new Error('rename failed'));
+    await expect(cache.save(moduleState)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    // The unique temporary file must not be left behind when the write does not complete.
+    const tempPath = jest.mocked(fsPromises.writeFile).mock.calls[0][0] as string;
+    expect(files[tempPath]).toBeUndefined();
   });
 
   it('logs a warning if the module state could not be written.', async(): Promise<void> => {

--- a/test/unit/init/ModuleStateCache.test.ts
+++ b/test/unit/init/ModuleStateCache.test.ts
@@ -1,0 +1,156 @@
+import { promises as fsPromises } from 'node:fs';
+import type { IModuleState } from 'componentsjs';
+import { readJson } from 'fs-extra';
+import { ModuleStateCache } from '../../../src/init/ModuleStateCache';
+import type { Logger } from '../../../src/logging/Logger';
+import { getLoggerFor } from '../../../src/logging/LogUtil';
+
+let files: Record<string, string>;
+
+jest.mock('node:fs', (): any => ({
+  promises: {
+    readFile: jest.fn(async(path: string): Promise<string> => {
+      if (typeof files[path] === 'string') {
+        return files[path];
+      }
+      throw new Error(`File not found: ${path}`);
+    }),
+    writeFile: jest.fn(async(path: string, data: string): Promise<void> => {
+      files[path] = data;
+    }),
+    rename: jest.fn(async(source: string, destination: string): Promise<void> => {
+      files[destination] = files[source];
+      delete files[source];
+    }),
+    unlink: jest.fn(async(path: string): Promise<void> => {
+      delete files[path];
+    }),
+  },
+}));
+
+jest.mock('fs-extra', (): any => ({
+  readJson: jest.fn(async(): Promise<unknown> => ({ version: '7.1.0' })),
+}));
+
+jest.mock('../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { debug: jest.fn(), warn: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+
+describe('A ModuleStateCache', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor(ModuleStateCache) as any;
+  const cachePath = '/data/module-state.json';
+  const mainModulePath = '/data';
+  const moduleState = { mainModulePath } as unknown as IModuleState;
+  let cache: ModuleStateCache;
+
+  beforeEach((): void => {
+    files = {
+      '/data/package-lock.json': '{ "lockfileVersion": 3 }',
+      '/data/package.json': '{ "name": "test" }',
+    };
+
+    cache = new ModuleStateCache(cachePath, mainModulePath);
+  });
+
+  afterEach((): void => {
+    jest.clearAllMocks();
+  });
+
+  it('stores the module state together with the key.', async(): Promise<void> => {
+    await expect(cache.save(moduleState)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(0);
+    expect(files[`${cachePath}.tmp`]).toBeUndefined();
+    expect(JSON.parse(files[cachePath])).toEqual({ key: expect.any(String), moduleState });
+  });
+
+  it('returns the module state if the stored key matches.', async(): Promise<void> => {
+    await cache.save(moduleState);
+    // Use a new instance to make sure the key is not being reused from memory
+    cache = new ModuleStateCache(cachePath, mainModulePath);
+    await expect(cache.load()).resolves.toEqual(moduleState);
+    expect(fsPromises.unlink).toHaveBeenCalledTimes(0);
+    expect(logger.warn).toHaveBeenCalledTimes(0);
+  });
+
+  it('only computes the key once.', async(): Promise<void> => {
+    await cache.save(moduleState);
+    await cache.save(moduleState);
+    expect(readJson).toHaveBeenCalledTimes(1);
+    await expect(cache.load()).resolves.toEqual(moduleState);
+    expect(readJson).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined if there is no cache file.', async(): Promise<void> => {
+    await expect(cache.load()).resolves.toBeUndefined();
+    expect(fsPromises.unlink).toHaveBeenCalledTimes(0);
+    expect(logger.warn).toHaveBeenCalledTimes(0);
+  });
+
+  it('removes the cache file if it does not contain valid JSON.', async(): Promise<void> => {
+    files[cachePath] = 'invalid json';
+    await expect(cache.load()).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(fsPromises.unlink).toHaveBeenCalledTimes(1);
+    expect(files[cachePath]).toBeUndefined();
+  });
+
+  it('removes the cache file if it does not contain an object.', async(): Promise<void> => {
+    files[cachePath] = 'null';
+    await expect(cache.load()).resolves.toBeUndefined();
+    expect(fsPromises.unlink).toHaveBeenCalledTimes(1);
+    expect(files[cachePath]).toBeUndefined();
+  });
+
+  it('removes the cache file if the stored key does not match.', async(): Promise<void> => {
+    files[cachePath] = JSON.stringify({ key: 'wrong', moduleState });
+    await expect(cache.load()).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(0);
+    expect(fsPromises.unlink).toHaveBeenCalledTimes(1);
+    expect(files[cachePath]).toBeUndefined();
+  });
+
+  it('ignores the cache if the key could not be computed.', async(): Promise<void> => {
+    files[cachePath] = JSON.stringify({ key: 'irrelevant', moduleState });
+    jest.mocked(readJson).mockRejectedValueOnce(new Error('bad package.json'));
+    await expect(cache.load()).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates a different key if there is no package-lock.json.', async(): Promise<void> => {
+    await cache.save(moduleState);
+    const lockKey = (JSON.parse(files[cachePath]) as { key: string }).key;
+
+    delete files['/data/package-lock.json'];
+    cache = new ModuleStateCache(cachePath, mainModulePath);
+    await cache.save(moduleState);
+    const packageKey = (JSON.parse(files[cachePath]) as { key: string }).key;
+    expect(packageKey).not.toBe(lockKey);
+
+    // The cache remains valid as long as the package.json does not change
+    cache = new ModuleStateCache(cachePath, mainModulePath);
+    await expect(cache.load()).resolves.toEqual(moduleState);
+  });
+
+  it('logs a warning if the module state could not be written.', async(): Promise<void> => {
+    jest.mocked(fsPromises.writeFile).mockRejectedValueOnce(new Error('disk full'));
+    await expect(cache.save(moduleState)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(files[cachePath]).toBeUndefined();
+  });
+
+  it('logs a warning if no dependencies file could be read while saving.', async(): Promise<void> => {
+    delete files['/data/package-lock.json'];
+    delete files['/data/package.json'];
+    await expect(cache.save(moduleState)).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(fsPromises.writeFile).toHaveBeenCalledTimes(0);
+  });
+
+  it('ignores errors when removing the cache file.', async(): Promise<void> => {
+    files[cachePath] = 'invalid json';
+    jest.mocked(fsPromises.unlink).mockRejectedValueOnce(new Error('file is locked'));
+    await expect(cache.load()).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/init/ModuleStateCache.test.ts
+++ b/test/unit/init/ModuleStateCache.test.ts
@@ -60,7 +60,7 @@ describe('A ModuleStateCache', (): void => {
   it('stores the module state together with the key.', async(): Promise<void> => {
     await expect(cache.save(moduleState)).resolves.toBeUndefined();
     expect(logger.warn).toHaveBeenCalledTimes(0);
-    // No temporary file (neither the legacy nor a unique name) remains after saving.
+    // No temporary file remains after saving.
     expect(Object.keys(files).some((path): boolean => path.endsWith('.tmp'))).toBe(false);
     expect(JSON.parse(files[cachePath])).toEqual({ key: expect.any(String), moduleState });
   });
@@ -145,7 +145,7 @@ describe('A ModuleStateCache', (): void => {
     await cache.save(moduleState);
     const secondTemp = jest.mocked(fsPromises.writeFile).mock.calls[1][0] as string;
 
-    // The temporary name is unique per process and per call, unlike the fixed `${path}.tmp`.
+    // The temporary name is unique per process and per call.
     expect(firstTemp).toContain(`.${process.pid}.`);
     expect(firstTemp).not.toBe(`${cachePath}.tmp`);
     expect(firstTemp).not.toBe(secondTemp);


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue describing the boot-time cost of the module state scan still needs to be created before this is submitted to CommunitySolidServer (the PR template requires one).

#### ✍️ Description

`ComponentsManager.build` runs `ModuleStateBuilder` on every server start, scanning all of `node_modules` (~1,780 directories, ~1,470 `package.json` reads, ~8,000 fs operations on a default install), even though Components.js skips the scan entirely when `options.moduleState` is supplied, and the resulting `IModuleState` is plain JSON-serializable data.

This PR adds an opt-in disk cache for that module state:

- A new `ModuleStateCache` class stores `{ key, moduleState }` as JSON. The key is a SHA-256 hash of the server version, the Node.js version, the main module path, and the `package-lock.json` contents (`package.json` when no lock file exists), so any dependency change invalidates the cache.
- `AppRunner` gains a `moduleStateCachePath` input / `--moduleStateCachePath` CLI parameter / `CSS_MODULE_STATE_CACHE_PATH` environment variable (through the existing generic yargs env mechanism). On a hit the cached state is injected as `loaderProperties.moduleState`; on a miss the freshly built `manager.moduleState` is saved for the next start. An explicitly provided `loaderProperties.moduleState` always takes precedence.
- Without the parameter, behaviour is unchanged.

Robustness decisions, for review:

- A corrupt (unparseable) cache file is removed, and so is a stale entry whose key does not match. A *failure to compute the key* (e.g. a temporarily unreadable lock file) is instead treated as a plain miss without removing the file, since the entry may still be valid.
- Writes go through a temporary file — unique per process and per call, so concurrent server instances cannot corrupt each other's writes — followed by a rename; the destination is removed first because `rename` does not reliably overwrite on Windows. A failed write only logs a warning.
- Known limitation: invalidation trusts the lock file, so `node_modules` mutations that do not touch it (`npm link`, manual edits) are not detected — delete the cache file or omit the parameter in that case.

#### 📈 Measurements (indicative)

Measured on a shared 2-core EC2 box, booting `config/file.json` 3 times per configuration with a local instrumentation script that counts fs operations and wall/CPU time. That script is not part of this PR, so there is no reproducible in-repo command yet; the fs-op counts are the deterministic part of the evidence.

|                | main (median of 3) | this PR, cache miss | this PR, cache hit |
| -------------- | ------------------ | ------------------- | ------------------ |
| boot fs ops    | 19,230             | 19,461              | **11,469 (−40%)**  |
| boot wall time | 24.2 s             | 24.4 s              | **21.7 s (−10%)**  |
| boot CPU time  | 25.1 s             | 25.1 s              | 23.7 s             |

The removed fs operations correspond to the `ModuleStateBuilder` scan. The remaining boot cost is dominated by JSON-LD parsing of the discovered component modules and the config graph, which this PR deliberately does not touch (a possible follow-up is precompiling the shipped configs — separate PR if pursued).

#### 📋 Notes for review

- Intended semver level: **minor** (backwards-compatible feature addition: a new CLI parameter and a new exported class). Stated in prose since contributors cannot set the labels.
- Branch target: as a feature addition this should target the latest `versions/*` branch (currently `versions/next-major`) when submitted upstream, per the contribution guidelines — it sits on the fork's `main` only for this review.
- The parameter is registered in `config/app/variables/cli/cli.json` following the `config`/`mainModulePath` precedent, since the second, strict yargs parse needs to know it.
- Unit tests cover the new class and the `AppRunner` wiring (the suite's 100% `./src` coverage thresholds apply); the CLI parameter is documented in `documentation/markdown/usage/starting-server.md`.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
