### PR TITLE
perf: Avoid directory listings when resolving verbatim document paths

### DIFF
--- a/src/storage/mapping/ExtensionBasedMapper.ts
+++ b/src/storage/mapping/ExtensionBasedMapper.ts
@@ -47,22 +47,13 @@ export class ExtensionBasedMapper extends BaseFileIdentifierMapper {
 
     // Existing file
     if (!contentType) {
-      // Metadata resources are always serialized as turtle,
-      // which matches the content-type of their `.meta` extension,
-      // so the server never stores them with a `$.{extension}` suffix.
-      // The folder scan below can thus never find a match, and the direct `stat` can never
-      // change the outcome either (the file path is returned as is regardless of whether the file exists),
-      // so both filesystem calls are skipped for metadata paths.
+      // Metadata is always serialized as turtle, matching the content-type of its `.meta` extension,
+      // so a metadata path never has a `$.{extension}` variant and needs no filesystem check.
       let resolved = this.isMetadataPath(filePath);
 
-      // Fast path: if a file exists at the direct translation of the identifier, use it as is.
-      // This avoids the more expensive folder scan below.
-      // The server never stores both the direct file and a `$.{extension}` variant for the same resource,
-      // as the stale one gets removed when writing (see `FileDataAccessor.verifyExistingExtension`),
-      // making this semantics-preserving for any server-produced state.
-      // Should both exist anyway, due to files being created externally,
-      // the direct match now deterministically takes precedence,
-      // whereas previously the result depended on the file order returned by `readdir`.
+      // A file at the direct translation of the identifier avoids the more expensive folder scan,
+      // as the server never stores both the direct file and a `$.{extension}` variant of a resource
+      // (see `FileDataAccessor.verifyExistingExtension`).
       if (!resolved) {
         try {
           resolved = (await fsPromises.stat(filePath)).isFile();

--- a/src/storage/mapping/ExtensionBasedMapper.ts
+++ b/src/storage/mapping/ExtensionBasedMapper.ts
@@ -47,6 +47,14 @@ export class ExtensionBasedMapper extends BaseFileIdentifierMapper {
 
     // Existing file
     if (!contentType) {
+      // Metadata resources are always serialized as turtle,
+      // which matches the content-type of their `.meta` extension,
+      // so the server never stores them with a `$.{extension}` suffix.
+      // The folder scan below can thus never find a match, and the direct `stat` can never
+      // change the outcome either (the file path is returned as is regardless of whether the file exists),
+      // so both filesystem calls are skipped for metadata paths.
+      let resolved = this.isMetadataPath(filePath);
+
       // Fast path: if a file exists at the direct translation of the identifier, use it as is.
       // This avoids the more expensive folder scan below.
       // The server never stores both the direct file and a `$.{extension}` variant for the same resource,
@@ -55,19 +63,12 @@ export class ExtensionBasedMapper extends BaseFileIdentifierMapper {
       // Should both exist anyway, due to files being created externally,
       // the direct match now deterministically takes precedence,
       // whereas previously the result depended on the file order returned by `readdir`.
-      let resolved = false;
-      try {
-        resolved = (await fsPromises.stat(filePath)).isFile();
-      } catch {
-        // No file at the direct translation (or it is inaccessible)
-      }
-
-      // Metadata resources are always serialized as turtle,
-      // which matches the content-type of their `.meta` extension,
-      // so the server never stores them with a `$.{extension}` suffix.
-      // The folder scan below can thus never find a match and can be skipped.
-      if (!resolved && this.isMetadataPath(filePath)) {
-        resolved = true;
+      if (!resolved) {
+        try {
+          resolved = (await fsPromises.stat(filePath)).isFile();
+        } catch {
+          // No file at the direct translation (or it is inaccessible)
+        }
       }
 
       if (!resolved) {

--- a/src/storage/mapping/ExtensionBasedMapper.ts
+++ b/src/storage/mapping/ExtensionBasedMapper.ts
@@ -47,18 +47,43 @@ export class ExtensionBasedMapper extends BaseFileIdentifierMapper {
 
     // Existing file
     if (!contentType) {
-      // Find a matching file
-      const [ , folder, documentName ] = /^(.*\/)([^/]*)$/u.exec(filePath)!;
-      let fileName: string | undefined;
+      // Fast path: if a file exists at the direct translation of the identifier, use it as is.
+      // This avoids the more expensive folder scan below.
+      // The server never stores both the direct file and a `$.{extension}` variant for the same resource,
+      // as the stale one gets removed when writing (see `FileDataAccessor.verifyExistingExtension`),
+      // making this semantics-preserving for any server-produced state.
+      // Should both exist anyway, due to files being created externally,
+      // the direct match now deterministically takes precedence,
+      // whereas previously the result depended on the file order returned by `readdir`.
+      let resolved = false;
       try {
-        const files = await fsPromises.readdir(folder);
-        fileName = files.find((file): boolean =>
-          file.startsWith(documentName) && /^(?:\$\..+)?$/u.test(file.slice(documentName.length)));
+        resolved = (await fsPromises.stat(filePath)).isFile();
       } catch {
-        // Parent folder does not exist (or is not a folder)
+        // No file at the direct translation (or it is inaccessible)
       }
-      if (fileName) {
-        filePath = joinFilePath(folder, fileName);
+
+      // Metadata resources are always serialized as turtle,
+      // which matches the content-type of their `.meta` extension,
+      // so the server never stores them with a `$.{extension}` suffix.
+      // The folder scan below can thus never find a match and can be skipped.
+      if (!resolved && this.isMetadataPath(filePath)) {
+        resolved = true;
+      }
+
+      if (!resolved) {
+        // Find a matching file
+        const [ , folder, documentName ] = /^(.*\/)([^/]*)$/u.exec(filePath)!;
+        let fileName: string | undefined;
+        try {
+          const files = await fsPromises.readdir(folder);
+          fileName = files.find((file): boolean =>
+            file.startsWith(documentName) && /^(?:\$\..+)?$/u.test(file.slice(documentName.length)));
+        } catch {
+          // Parent folder does not exist (or is not a folder)
+        }
+        if (fileName) {
+          filePath = joinFilePath(folder, fileName);
+        }
       }
       contentType = await this.getContentTypeFromPath(filePath);
     // If the extension of the identifier matches a different content-type than the one that is given,

--- a/test/unit/storage/mapping/ExtensionBasedMapper.test.ts
+++ b/test/unit/storage/mapping/ExtensionBasedMapper.test.ts
@@ -20,7 +20,6 @@ describe('An ExtensionBasedMapper', (): void => {
     jest.clearAllMocks();
     fs.promises = {
       readdir: jest.fn(),
-      // By default there is no file at the direct file path, so the folder scan fallback gets used
       stat: jest.fn().mockRejectedValue(new Error('does not exist')),
     } as any;
     fsPromises = fs.promises as any;
@@ -156,7 +155,6 @@ describe('An ExtensionBasedMapper', (): void => {
         contentType: 'text/turtle',
         isMetadata: true,
       });
-      // The metadata check short-circuits before both the direct stat and the folder scan
       expect(fsPromises.stat).toHaveBeenCalledTimes(0);
       expect(fsPromises.readdir).toHaveBeenCalledTimes(0);
     });

--- a/test/unit/storage/mapping/ExtensionBasedMapper.test.ts
+++ b/test/unit/storage/mapping/ExtensionBasedMapper.test.ts
@@ -149,14 +149,15 @@ describe('An ExtensionBasedMapper', (): void => {
       expect(fsPromises.readdir).toHaveBeenCalledTimes(1);
     });
 
-    it('does not read the folder for metadata paths without a matching file.', async(): Promise<void> => {
+    it('does not stat or read the folder for metadata paths without a matching file.', async(): Promise<void> => {
       await expect(mapper.mapUrlToFilePath({ path: `${base}test` }, true)).resolves.toEqual({
         identifier: { path: `${base}test` },
         filePath: `${rootFilepath}test.meta`,
         contentType: 'text/turtle',
         isMetadata: true,
       });
-      expect(fsPromises.stat).toHaveBeenCalledTimes(1);
+      // The metadata check short-circuits before both the direct stat and the folder scan
+      expect(fsPromises.stat).toHaveBeenCalledTimes(0);
       expect(fsPromises.readdir).toHaveBeenCalledTimes(0);
     });
 

--- a/test/unit/storage/mapping/ExtensionBasedMapper.test.ts
+++ b/test/unit/storage/mapping/ExtensionBasedMapper.test.ts
@@ -20,6 +20,8 @@ describe('An ExtensionBasedMapper', (): void => {
     jest.clearAllMocks();
     fs.promises = {
       readdir: jest.fn(),
+      // By default there is no file at the direct file path, so the folder scan fallback gets used
+      stat: jest.fn().mockRejectedValue(new Error('does not exist')),
     } as any;
     fsPromises = fs.promises as any;
   });
@@ -105,6 +107,69 @@ describe('An ExtensionBasedMapper', (): void => {
         contentType: 'text/turtle',
         isMetadata: false,
       });
+      expect(fsPromises.stat).toHaveBeenCalledTimes(1);
+      expect(fsPromises.readdir).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not read the folder if a file exists at the direct file path.', async(): Promise<void> => {
+      fsPromises.stat.mockResolvedValue({ isFile: (): boolean => true });
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` }, false)).resolves.toEqual({
+        identifier: { path: `${base}test.txt` },
+        filePath: `${rootFilepath}test.txt`,
+        contentType: 'text/plain',
+        isMetadata: false,
+      });
+      expect(fsPromises.stat).toHaveBeenCalledTimes(1);
+      expect(fsPromises.readdir).toHaveBeenCalledTimes(0);
+    });
+
+    it('reads the folder if the direct file path is not a file.', async(): Promise<void> => {
+      fsPromises.stat.mockResolvedValue({ isFile: (): boolean => false });
+      fsPromises.readdir.mockReturnValue([ 'test.txt$.ttl' ]);
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` }, false)).resolves.toEqual({
+        identifier: { path: `${base}test.txt` },
+        filePath: `${rootFilepath}test.txt$.ttl`,
+        contentType: 'text/turtle',
+        isMetadata: false,
+      });
+      expect(fsPromises.stat).toHaveBeenCalledTimes(1);
+      expect(fsPromises.readdir).toHaveBeenCalledTimes(1);
+    });
+
+    it('reads the folder if the direct file path is inaccessible.', async(): Promise<void> => {
+      fsPromises.stat.mockRejectedValue(new Error('permission denied'));
+      fsPromises.readdir.mockReturnValue([ 'test.txt$.ttl' ]);
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.txt` }, false)).resolves.toEqual({
+        identifier: { path: `${base}test.txt` },
+        filePath: `${rootFilepath}test.txt$.ttl`,
+        contentType: 'text/turtle',
+        isMetadata: false,
+      });
+      expect(fsPromises.stat).toHaveBeenCalledTimes(1);
+      expect(fsPromises.readdir).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not read the folder for metadata paths without a matching file.', async(): Promise<void> => {
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test` }, true)).resolves.toEqual({
+        identifier: { path: `${base}test` },
+        filePath: `${rootFilepath}test.meta`,
+        contentType: 'text/turtle',
+        isMetadata: true,
+      });
+      expect(fsPromises.stat).toHaveBeenCalledTimes(1);
+      expect(fsPromises.readdir).toHaveBeenCalledTimes(0);
+    });
+
+    it('reads the folder for non-metadata auxiliary paths without a matching file.', async(): Promise<void> => {
+      fsPromises.readdir.mockReturnValue([ 'test.acl$.txt' ]);
+      await expect(mapper.mapUrlToFilePath({ path: `${base}test.acl` }, false)).resolves.toEqual({
+        identifier: { path: `${base}test.acl` },
+        filePath: `${rootFilepath}test.acl$.txt`,
+        contentType: 'text/plain',
+        isMetadata: false,
+      });
+      expect(fsPromises.stat).toHaveBeenCalledTimes(1);
+      expect(fsPromises.readdir).toHaveBeenCalledTimes(1);
     });
 
     it('generates a file path if the content-type was provided.', async(): Promise<void> => {


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the upstream PR template requires a related issue, so one describing the `readdir`-per-lookup hot spot must be created on [the CommunitySolidServer tracker](https://github.com/CommunitySolidServer/CommunitySolidServer/issues/new/choose) before this is submitted upstream.

#### ✍️ Description

Every document-path resolution without a known content type — i.e. all reads, including the ACL-resolution walks — lists the entire parent directory (`readdir`) to discover whether the resource is stored verbatim (`x.ttl`, `.acl`, `.meta`) or with a content-type marker suffix (`x$.ttl`, `x.ttl$.txt`). That makes `readdir` the dominant filesystem call under load (~12–15 per GET in a short benchmark), with cost growing linearly in directory size.

Two mechanisms, both confined to the `!contentType` branch of `ExtensionBasedMapper.mapUrlToDocumentPath` (and inherited unchanged by `SubdomainExtensionBasedMapper`):

1. **Stat-first fast path** — `stat` the direct (verbatim) file path; when it exists as a regular file, use it and skip the directory listing. Any miss, non-file result, or `stat` error falls through to the unchanged `readdir` scan.
2. **Metadata skip** — `.meta` paths skip both the `stat` and the `readdir`: CSS always serializes metadata as turtle and `meta` is a turtle custom-type extension, so the server can never produce a `.meta$.x` marker file, and the mapper returns the direct path regardless of whether the file exists. `.acl`/`.acr` keep the fallback, since users *can* PUT an ACL with a non-turtle content type.

**Why this is safe**

- For every on-disk state CSS itself can produce, results are byte-identical: `FileDataAccessor.verifyExistingExtension` guarantees at most one of {verbatim, marker} exists per resource.
- Observable differences exist only after out-of-band (non-CSS) writes: (1) if *both* `x` and `x$.ttl` exist, the direct file now wins deterministically, where the `readdir` scan returned whichever entry the OS listed first (nondeterministic); (2) a manually created `foo.meta$.x` marker is no longer discovered — the mapper returns the same unresolved verbatim path it returns when no metadata file exists.
- Slow-path cost is one extra (cheap) `stat` before the retained `readdir` for marker-form or missing non-metadata resources.

The mapping design of https://www.w3.org/DesignIssues/HTTPFilenameMapping.html is followed unchanged — only the lookup strategy for the dominant, unambiguous case changes — unlike the on-disk redesign proposed and declined in https://github.com/CommunitySolidServer/CommunitySolidServer/issues/333.

**Measured effect**

The deterministic per-request filesystem-op counts are the reproducible evidence (an fs-op-counting `--require` preload on a server started with `config/file.json`):

| Request | `readdir`s before | `readdir`s after |
| --- | --- | --- |
| Anonymous GET | 9 | 1 |
| Authenticated GET | 15 | 2 |

The removed `readdir`s are replaced by O(1) `stat`s, so the total op count is similar, but a `stat` does constant work while a `readdir` scales with directory size.

Wall-clock is indicative only (shared 2-core EC2 box; hot GET of a resource with 500 siblings, concurrency 10 for 8 s; no committed reproducible benchmark script exists yet): 66 → 72 req/s (+9%), p50 147 → 131 ms (−11%), 20.8 → 16 fs ops per request, with disk locking still enabled.

Composes with the companion fork PRs jeswr#31 (single ACL walk per authenticated request) and jeswr#22 (in-memory locker), which remove the surrounding call multipliers.

Intended semver level: **semver.patch** — no interface, signature, or configuration-behaviour change, and behaviour is identical for any server-produced state — so this targets `main` per the branch rule for patch updates.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
