### PR TITLE
perf: Allow skipping child metadata stats in container listings

### DIFF
--- a/src/storage/accessors/AtomicFileDataAccessor.ts
+++ b/src/storage/accessors/AtomicFileDataAccessor.ts
@@ -17,8 +17,20 @@ import { FileDataAccessor } from './FileDataAccessor';
 export class AtomicFileDataAccessor extends FileDataAccessor implements AtomicDataAccessor {
   private readonly tempFilePath: string;
 
-  public constructor(resourceMapper: FileIdentifierMapper, rootFilePath: string, tempFilePath: string) {
-    super(resourceMapper);
+  /**
+   * @param resourceMapper - Maps identifiers to file paths and vice versa.
+   * @param rootFilePath - Root folder of the file system.
+   * @param tempFilePath - Folder in which temporary files will be stored, relative to the root folder.
+   * @param detailedChildMetadata - If true, a `stat` call is performed for every child when generating
+   *   the metadata of all children in a container. See {@link FileDataAccessor}.
+   */
+  public constructor(
+    resourceMapper: FileIdentifierMapper,
+    rootFilePath: string,
+    tempFilePath: string,
+    detailedChildMetadata = true,
+  ) {
+    super(resourceMapper, detailedChildMetadata);
     this.tempFilePath = joinFilePath(rootFilePath, tempFilePath);
     ensureDirSync(this.tempFilePath);
   }

--- a/src/storage/accessors/AtomicFileDataAccessor.ts
+++ b/src/storage/accessors/AtomicFileDataAccessor.ts
@@ -21,8 +21,8 @@ export class AtomicFileDataAccessor extends FileDataAccessor implements AtomicDa
    * @param resourceMapper - Maps identifiers to file paths and vice versa.
    * @param rootFilePath - Root folder of the file system.
    * @param tempFilePath - Folder in which temporary files will be stored, relative to the root folder.
-   * @param detailedChildMetadata - If true, a `stat` call is performed for every child when generating
-   *   the metadata of all children in a container. See {@link FileDataAccessor}.
+   * @param detailedChildMetadata - If true, a `stat` call is performed for every child when listing a container.
+   *   See {@link FileDataAccessor}.
    */
   public constructor(
     resourceMapper: FileIdentifierMapper,

--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -26,9 +26,20 @@ export class FileDataAccessor implements DataAccessor {
   protected readonly logger = getLoggerFor(this);
 
   protected readonly resourceMapper: FileIdentifierMapper;
+  protected readonly detailedChildMetadata: boolean;
 
-  public constructor(resourceMapper: FileIdentifierMapper) {
+  /**
+   * @param resourceMapper - Maps identifiers to file paths and vice versa.
+   * @param detailedChildMetadata - If true, a `stat` call is performed for every child when generating
+   *   the metadata of all children in a container, adding `posix:mtime`, `posix:size` and `dc:modified`
+   *   metadata for every child. Setting this to false skips those `stat` calls,
+   *   dropping the triples mentioned above from container listings.
+   *   Symbolic links and entries whose type is not reported by the file system
+   *   are still resolved through a `stat` call and keep their detailed metadata.
+   */
+  public constructor(resourceMapper: FileIdentifierMapper, detailedChildMetadata = true) {
     this.resourceMapper = resourceMapper;
+    this.detailedChildMetadata = detailedChildMetadata;
   }
 
   /**
@@ -284,23 +295,33 @@ export class FileDataAccessor implements DataAccessor {
 
     // For every child in the container we want to generate specific metadata
     for await (const entry of dir) {
-      // Obtain details of the entry, resolving any symbolic links
       const childPath = joinFilePath(link.filePath, entry.name);
-      let childStats;
-      try {
-        childStats = await this.getStats(childPath);
-      } catch {
-        // Skip this entry if details could not be retrieved (e.g., bad symbolic link)
-        continue;
+
+      // A `stat` call is needed when detailed metadata is requested,
+      // and to resolve symbolic links or entries whose type is not reported by the file system
+      const requiresStats = this.detailedChildMetadata || entry.isSymbolicLink() ||
+        (!entry.isFile() && !entry.isDirectory());
+
+      // Obtain details of the entry, resolving any symbolic links
+      let childStats: Stats | undefined;
+      if (requiresStats) {
+        try {
+          childStats = await this.getStats(childPath);
+        } catch {
+          // Skip this entry if details could not be retrieved (e.g., bad symbolic link)
+          continue;
+        }
+
+        // Ignore non-file/directory entries in the folder
+        if (!childStats.isFile() && !childStats.isDirectory()) {
+          continue;
+        }
       }
 
-      // Ignore non-file/directory entries in the folder
-      if (!childStats.isFile() && !childStats.isDirectory()) {
-        continue;
-      }
+      const isDirectory = childStats ? childStats.isDirectory() : entry.isDirectory();
 
       // Generate the URI corresponding to the child resource
-      const childLink = await this.resourceMapper.mapFilePathToUrl(childPath, childStats.isDirectory());
+      const childLink = await this.resourceMapper.mapFilePathToUrl(childPath, isDirectory);
 
       // Hide metadata files
       if (childLink.isMetadata) {
@@ -310,8 +331,10 @@ export class FileDataAccessor implements DataAccessor {
       // Generate metadata of this specific child as described in
       // https://solidproject.org/TR/2021/protocol-20211217#contained-resource-metadata
       const metadata = new RepresentationMetadata(childLink.identifier);
-      addResourceMetadata(metadata, childStats.isDirectory());
-      this.addPosixMetadata(metadata, childStats);
+      addResourceMetadata(metadata, isDirectory);
+      if (childStats) {
+        this.addPosixMetadata(metadata, childStats);
+      }
       // Containers will not have a content-type
       const { contentType, identifier } = childLink;
       if (contentType) {

--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -30,12 +30,10 @@ export class FileDataAccessor implements DataAccessor {
 
   /**
    * @param resourceMapper - Maps identifiers to file paths and vice versa.
-   * @param detailedChildMetadata - If true, a `stat` call is performed for every child when generating
-   *   the metadata of all children in a container, adding `posix:mtime`, `posix:size` and `dc:modified`
-   *   metadata for every child. Setting this to false skips those `stat` calls,
-   *   dropping the triples mentioned above from container listings.
-   *   Symbolic links and entries whose type is not reported by the file system
-   *   are still resolved through a `stat` call and keep their detailed metadata.
+   * @param detailedChildMetadata - If true, a `stat` call is performed for every child when listing a container,
+   *   adding its `posix:mtime`, `posix:size` and `dc:modified` metadata.
+   *   If false, those calls only happen for symbolic links and entries whose type the directory listing
+   *   does not report, so all other children lack that metadata.
    */
   public constructor(resourceMapper: FileIdentifierMapper, detailedChildMetadata = true) {
     this.resourceMapper = resourceMapper;
@@ -297,8 +295,7 @@ export class FileDataAccessor implements DataAccessor {
     for await (const entry of dir) {
       const childPath = joinFilePath(link.filePath, entry.name);
 
-      // A `stat` call is needed when detailed metadata is requested,
-      // and to resolve symbolic links or entries whose type is not reported by the file system
+      // Symbolic links and entries whose type the directory listing does not report require a `stat` call
       const requiresStats = this.detailedChildMetadata || entry.isSymbolicLink() ||
         (!entry.isFile() && !entry.isDirectory());
 

--- a/test/unit/storage/accessors/AtomicFileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/AtomicFileDataAccessor.test.ts
@@ -6,7 +6,7 @@ import { ExtensionBasedMapper } from '../../../../src/storage/mapping/ExtensionB
 import { APPLICATION_OCTET_STREAM } from '../../../../src/util/ContentTypes';
 import type { Guarded } from '../../../../src/util/GuardedStream';
 import { guardedStreamFrom } from '../../../../src/util/StreamUtil';
-import { CONTENT_TYPE } from '../../../../src/util/Vocabularies';
+import { CONTENT_TYPE, POSIX } from '../../../../src/util/Vocabularies';
 import { mockFileSystem } from '../../../util/Util';
 
 jest.mock('node:fs');
@@ -33,6 +33,29 @@ describe('AtomicFileDataAccessor', (): void => {
     cache.data['.internal'] = { tempFiles: {}};
     metadata = new RepresentationMetadata(APPLICATION_OCTET_STREAM);
     data = guardedStreamFrom([ 'data' ]);
+  });
+
+  describe('getting children', (): void => {
+    it('forwards the detailedChildMetadata flag to the parent FileDataAccessor.', async(): Promise<void> => {
+      accessor = new AtomicFileDataAccessor(
+        new ExtensionBasedMapper(base, rootFilePath),
+        rootFilePath,
+        './.internal/tempFiles/',
+        false,
+      );
+      cache.data.container = { resource: 'data' };
+      const statSpy = jest.spyOn(jest.requireMock('fs-extra'), 'stat');
+
+      const children = [];
+      for await (const child of accessor.getChildren({ path: `${base}container/` })) {
+        children.push(child);
+      }
+
+      expect(children).toHaveLength(1);
+      expect(children[0].identifier.value).toBe(`${base}container/resource`);
+      expect(children[0].get(POSIX.terms.mtime)).toBeUndefined();
+      expect(statSpy).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('writing a document', (): void => {

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -340,7 +340,7 @@ describe('A FileDataAccessor', (): void => {
       expect(children[2].identifier.value).toBe(`${base}container/symlink`);
       expect(children[3].identifier.value).toBe(`${base}container/symlinkContainer/`);
 
-      // Symlinked children were resolved through a `stat` call so keep their detailed metadata
+      // Symlinked children keep their detailed metadata
       const symlinkTypes = children[2].getAll(RDF.terms.type).map((term): string => term.value);
       expect(symlinkTypes).toContain(LDP.Resource);
       expect(symlinkTypes).toContain('http://www.w3.org/ns/iana/media-types/application/octet-stream#Resource');
@@ -355,7 +355,7 @@ describe('A FileDataAccessor', (): void => {
         .toEqualRdfTerm(toLiteral(Math.floor(now.getTime() / 1000), XSD.terms.integer));
       expect(children[3].get(POSIX.terms.size)).toBeUndefined();
 
-      // Plainly typed children were not statted
+      // Plainly typed children have no detailed metadata
       expect(children[0].get(POSIX.terms.mtime)).toBeUndefined();
       expect(children[1].get(POSIX.terms.mtime)).toBeUndefined();
 

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -1,4 +1,5 @@
 import 'jest-rdf';
+import type { Dirent } from 'node:fs';
 import type { Readable } from 'node:stream';
 import { DataFactory } from 'n3';
 import type { Representation } from '../../../../src/http/representation/Representation';
@@ -269,6 +270,154 @@ describe('A FileDataAccessor', (): void => {
       cache.data = { resource: 'data', 'resource.meta': 'invalid metadata!.' };
       await expect(accessor.getMetadata({ path: `${base}resource` }))
         .rejects.toThrow('Unexpected "invalid" on line 1.');
+    });
+  });
+
+  describe('getting children without detailed metadata', (): void => {
+    let statSpy: jest.SpyInstance;
+
+    beforeEach(async(): Promise<void> => {
+      accessor = new FileDataAccessor(mapper, false);
+      statSpy = jest.spyOn(jest.requireMock('fs-extra'), 'stat');
+    });
+
+    it('does not stat children whose type is reported by the directory listing.', async(): Promise<void> => {
+      cache.data = {
+        container: {
+          resource: 'data',
+          'resource.meta': 'metadata',
+          container2: {},
+        },
+      };
+
+      const children = [];
+      for await (const child of accessor.getChildren({ path: `${base}container/` })) {
+        children.push(child);
+      }
+      children.sort((left, right): number => left.identifier.value.localeCompare(right.identifier.value));
+
+      expect(children).toHaveLength(2);
+      expect(children[0].identifier.value).toBe(`${base}container/container2/`);
+      expect(children[1].identifier.value).toBe(`${base}container/resource`);
+
+      const containerTypes = children[0].getAll(RDF.terms.type).map((term): string => term.value);
+      expect(containerTypes).toContain(LDP.Resource);
+      expect(containerTypes).toContain(LDP.Container);
+      expect(containerTypes).toContain(LDP.BasicContainer);
+
+      const documentTypes = children[1].getAll(RDF.terms.type).map((term): string => term.value);
+      expect(documentTypes).toContain(LDP.Resource);
+      expect(documentTypes).toContain('http://www.w3.org/ns/iana/media-types/application/octet-stream#Resource');
+      expect(documentTypes).not.toContain(LDP.Container);
+
+      for (const child of children) {
+        expect(child.get(DC.terms.modified)).toBeUndefined();
+        expect(child.get(POSIX.terms.mtime)).toBeUndefined();
+        expect(child.get(POSIX.terms.size)).toBeUndefined();
+        expect(child.quads(null, null, null, SOLID_META.terms.ResponseMetadata)).toHaveLength(0);
+      }
+
+      expect(statSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('still stats symlinked children to resolve their type.', async(): Promise<void> => {
+      cache.data = {
+        container: {
+          resource: 'data',
+          container2: {},
+          symlink: Symbol(`${rootFilePath}/container/resource`),
+          symlinkContainer: Symbol(`${rootFilePath}/container/container2`),
+        },
+      };
+
+      const children = [];
+      for await (const child of accessor.getChildren({ path: `${base}container/` })) {
+        children.push(child);
+      }
+      children.sort((left, right): number => left.identifier.value.localeCompare(right.identifier.value));
+
+      expect(children).toHaveLength(4);
+      expect(children[2].identifier.value).toBe(`${base}container/symlink`);
+      expect(children[3].identifier.value).toBe(`${base}container/symlinkContainer/`);
+
+      // Symlinked children were resolved through a `stat` call so keep their detailed metadata
+      const symlinkTypes = children[2].getAll(RDF.terms.type).map((term): string => term.value);
+      expect(symlinkTypes).toContain(LDP.Resource);
+      expect(symlinkTypes).toContain('http://www.w3.org/ns/iana/media-types/application/octet-stream#Resource');
+      expect(children[2].get(DC.terms.modified)).toEqualRdfTerm(toLiteral(now.toISOString(), XSD.terms.dateTime));
+      expect(children[2].get(POSIX.terms.mtime))
+        .toEqualRdfTerm(toLiteral(Math.floor(now.getTime() / 1000), XSD.terms.integer));
+      expect(children[2].get(POSIX.terms.size)).toEqualRdfTerm(toLiteral('data'.length, XSD.terms.integer));
+
+      const symlinkContainerTypes = children[3].getAll(RDF.terms.type).map((term): string => term.value);
+      expect(symlinkContainerTypes).toContain(LDP.Container);
+      expect(children[3].get(POSIX.terms.mtime))
+        .toEqualRdfTerm(toLiteral(Math.floor(now.getTime() / 1000), XSD.terms.integer));
+      expect(children[3].get(POSIX.terms.size)).toBeUndefined();
+
+      // Plainly typed children were not statted
+      expect(children[0].get(POSIX.terms.mtime)).toBeUndefined();
+      expect(children[1].get(POSIX.terms.mtime)).toBeUndefined();
+
+      expect(statSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('still stats children whose type is not reported by the directory listing.', async(): Promise<void> => {
+      cache.data = { container: { unknown: 'data' }};
+
+      // Simulate a file system that does not report entry types in directory listings (`DT_UNKNOWN`)
+      const fsExtra = jest.requireMock('fs-extra');
+      const sourceOpendir = fsExtra.opendir;
+      fsExtra.opendir = async function* (path: string): AsyncIterableIterator<Dirent> {
+        for await (const entry of sourceOpendir(path)) {
+          yield {
+            ...entry,
+            isFile: (): boolean => false,
+            isDirectory: (): boolean => false,
+            isSymbolicLink: (): boolean => false,
+          } as Dirent;
+        }
+      };
+
+      const children = [];
+      for await (const child of accessor.getChildren({ path: `${base}container/` })) {
+        children.push(child);
+      }
+
+      expect(children).toHaveLength(1);
+      expect(children[0].identifier.value).toBe(`${base}container/unknown`);
+      const types = children[0].getAll(RDF.terms.type).map((term): string => term.value);
+      expect(types).toContain(LDP.Resource);
+      expect(types).toContain('http://www.w3.org/ns/iana/media-types/application/octet-stream#Resource');
+      expect(children[0].get(POSIX.terms.mtime))
+        .toEqualRdfTerm(toLiteral(Math.floor(now.getTime() / 1000), XSD.terms.integer));
+      expect(statSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips children that are neither a file nor a directory.', async(): Promise<void> => {
+      cache.data = { container: { resource: 'data', notAFile: 5 }};
+
+      const children = [];
+      for await (const child of accessor.getChildren({ path: `${base}container/` })) {
+        children.push(child);
+      }
+
+      expect(children).toHaveLength(1);
+      expect(children[0].identifier.value).toBe(`${base}container/resource`);
+      expect(statSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips symlinked children if their details could not be retrieved.', async(): Promise<void> => {
+      cache.data = { container: { resource: 'data', symlinkInvalid: Symbol(`${rootFilePath}/invalid`) }};
+
+      const children = [];
+      for await (const child of accessor.getChildren({ path: `${base}container/` })) {
+        children.push(child);
+      }
+
+      expect(children).toHaveLength(1);
+      expect(children[0].identifier.value).toBe(`${base}container/resource`);
+      expect(statSpy).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — an upstream issue describing the container-listing scaling problem must be created before this is submitted upstream (the CSS template requires one).

#### ✍️ Description

A `GET` on a container performs one `fs.stat` call per child (`FileDataAccessor.getChildMetadata`), so listing cost grows linearly with container size — those stats are 87–98% of the filesystem operations of a container `GET` at 100–1,000 children. Each stat feeds two things: the file-vs-directory decision, which the `opendir` `Dirent` already answers for plain entries, and the per-child `posix:mtime`/`posix:size`/`dc:modified` triples, which nothing server-side consumes (container ETags, `Last-Modified`, and conditional requests read only the container-subject `dc:modified`; notifications and templates do not touch per-child posix data; the Solid protocol does not require it).

This adds an optional `detailedChildMetadata` constructor parameter to `FileDataAccessor`/`AtomicFileDataAccessor`, defaulting to `true` (today's behaviour — no shipped config changes; an operator opts in via an `Override` on `urn:solid-server:default:FileDataAccessor`). When `false`, plain entries are typed from the `Dirent` and not statted. Symbolic links and entries whose type the directory listing does not report (`DT_UNKNOWN` filesystems) are still resolved through `stat`, preserving the "symlinks appear in container listings" behaviour and correct typing everywhere; a failing stat still skips the entry as before. The Components.js parameter description is generated from the constructor TSDoc (verified present in the built component files).

What a client loses with the flag off: per-child `posix:mtime`/`posix:size`/`dc:modified` on plain children in listings (they keep `rdf:type` including the IANA media-type Resource, and `ldp:contains`). Symlinked children keep full metadata (still statted), so listings on symlink-containing pods can be heterogeneous. Alternatives considered: caching per-child metadata keeps the triples but adds invalidation machinery; deriving everything from the `Dirent` alone breaks symlink typing and `DT_UNKNOWN` filesystems. The opt-in flag with a stat fallback is the smallest mechanism that removes the per-child cost.

The deterministic effect is that filesystem operations per container `GET` become O(1) in child count (the fixed ACL walk + container metadata + locks, ~14 ops) instead of O(children) — that op count is the reproducible evidence. The wall-clock numbers below are indicative only, from an ad-hoc harness (fs-call-counting preload + HTTP load generator against `config/file.json` with an `Override` flipping the flag, concurrency 5 × 8 s, shared 2-core EC2 box); the harness is not committed, so there is no exact command to reproduce them.

| Container GET | default (= `main`) | `detailedChildMetadata: false` |
| --- | --- | --- |
| 100 children — req/s / p50 / fs ops/req | 16 / 283 ms / 115 | 34 / 131 ms / 14.2 |
| 500 children — req/s / p50 / fs ops/req | 3 / 1,755 ms / 515 | 12 / 400 ms / 14.6 |

Intended semver level: **minor** (backwards-compatible optional parameter; contributors cannot set the label). Because this changes constructor signatures and adds a component parameter, the upstream submission should target the latest `versions/*` branch (currently `versions/next-major`) rather than `main`; this fork PR targets `main` only for pre-upstream review.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
