### PR TITLE
perf: Support booting from a precompiled configuration

### DIFF
--- a/config/app/variables/cli/cli.json
+++ b/config/app/variables/cli/cli.json
@@ -2,7 +2,7 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
   "@graph": [
     {
-      "comment": "Extracts CLI arguments into a key/value object. Config and mainModulePath are only defined here so their description is returned.",
+      "comment": "Extracts CLI arguments into a key/value object. Config, mainModulePath, and precompiledConfigPath are only defined here so their description is returned.",
       "@id": "urn:solid-server-app-setup:default:CliExtractor",
       "@type": "YargsCliExtractor",
       "parameters": [
@@ -24,6 +24,15 @@
             "requiresArg": true,
             "type": "string",
             "describe": "Path from where Components.js will start its lookup when initializing configurations."
+          }
+        },
+        {
+          "@type": "YargsParameter",
+          "name": "precompiledConfigPath",
+          "options": {
+            "requiresArg": true,
+            "type": "string",
+            "describe": "Path to a file where a precompiled version of the configuration(s) is stored, and generated if missing, to speed up future server starts."
           }
         },
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,6 +300,7 @@ export * from './init/AppRunner';
 export * from './init/BaseUrlVerifier';
 export * from './init/CliResolver';
 export * from './init/ConfigPodInitializer';
+export * from './init/ConfigPrecompiler';
 export * from './init/ContainerInitializer';
 export * from './init/Initializable';
 export * from './init/InitializableHandler';

--- a/src/init/AppRunner.ts
+++ b/src/init/AppRunner.ts
@@ -73,14 +73,10 @@ export interface AppRunnerInput {
   /**
    * Path to a file where a precompiled version of the configuration(s) is stored,
    * allowing the server to start without having to parse any modules or configurations.
-   * If there is no such file yet, or if it is out of date,
-   * the server starts normally and afterwards writes the precompiled configuration to this path,
-   * so it can be used to speed up future server starts.
-   *
-   * Note that changes to configuration files imported by the top-level configuration(s) can not be detected,
+   * If there is no valid file at this path yet, the server starts normally and then generates it.
+   * Changes to transitively imported configuration files can not be detected,
    * so after such changes this file needs to be deleted manually to force a new compilation.
-   * Multithreaded setups are not supported:
-   * for those the file is ignored and the server always starts normally.
+   * Multithreaded setups ignore this value and always start normally.
    */
   precompiledConfigPath?: string;
 }
@@ -159,9 +155,8 @@ export class AppRunner {
 
   /**
    * Creates an App from the precompiled configuration in the given artifact, if possible.
-   * Falls back to {@link AppRunner.createFromConfigs} if there is no valid artifact,
-   * in which case the artifact also gets (re)generated to speed up future server starts,
-   * or if the resolved variables imply a multithreaded setup.
+   * Falls back to {@link AppRunner.createFromConfigs} in multithreaded setups,
+   * or if there is no valid artifact, in which case the artifact also gets (re)generated.
    *
    * @param precompilerInput - Determines the artifact location and the values used to verify its key.
    * @param loaderProperties - Properties used when building the Components.js manager, in case of a fallback.
@@ -180,8 +175,7 @@ export class AppRunner {
       if (app) {
         return app;
       }
-      // Multithreaded setups require a Components.js manager for the thread safety check,
-      // so those fall back to a full build without regenerating the artifact.
+      // The artifact is still valid, so it does not need to be regenerated
       return this.createFromConfigs(loaderProperties, configs, input);
     }
 
@@ -231,7 +225,6 @@ export class AppRunner {
   /**
    * Determines the variable values by extracting shorthand values from the CLI arguments, if any,
    * and resolving those together with the shorthand input.
-   * Values from the `variableBindings` input override the resolved values.
    *
    * @param cliResolver - {@link CliResolver} used to extract and resolve shorthand values.
    * @param input - All values necessary to configure the server.

--- a/src/init/AppRunner.ts
+++ b/src/init/AppRunner.ts
@@ -13,6 +13,8 @@ import type { App } from './App';
 import type { CliExtractor } from './cli/CliExtractor';
 import type { CliResolver } from './CliResolver';
 import { listSingleThreadedComponents } from './cluster/SingleThreaded';
+import type { ConfigPrecompilerInput, PrecompiledConfig } from './ConfigPrecompiler';
+import { ConfigPrecompiler } from './ConfigPrecompiler';
 import type { ShorthandResolver } from './variables/ShorthandResolver';
 import type { CliArgv, Shorthand, VariableBindings } from './variables/Types';
 
@@ -25,6 +27,7 @@ const CORE_CLI_PARAMETERS = {
   config: { type: 'array', alias: 'c', default: [ DEFAULT_CONFIG ], requiresArg: true },
   loggingLevel: { type: 'string', alias: 'l', default: 'info', requiresArg: true, choices: LOG_LEVELS },
   mainModulePath: { type: 'string', alias: 'm', requiresArg: true },
+  precompiledConfigPath: { type: 'string', requiresArg: true },
 } as const;
 
 const ENV_VAR_PREFIX = 'CSS';
@@ -67,6 +70,19 @@ export interface AppRunnerInput {
    * Entries here have the lowest priority for assigning values to variables.
    */
   argv?: string[];
+  /**
+   * Path to a file where a precompiled version of the configuration(s) is stored,
+   * allowing the server to start without having to parse any modules or configurations.
+   * If there is no such file yet, or if it is out of date,
+   * the server starts normally and afterwards writes the precompiled configuration to this path,
+   * so it can be used to speed up future server starts.
+   *
+   * Note that changes to configuration files imported by the top-level configuration(s) can not be detected,
+   * so after such changes this file needs to be deleted manually to force a new compilation.
+   * Multithreaded setups are not supported:
+   * for those the file is ignored and the server always starts normally.
+   */
+  precompiledConfigPath?: string;
 }
 
 /**
@@ -74,6 +90,7 @@ export interface AppRunnerInput {
  */
 export class AppRunner {
   private readonly logger = getLoggerFor(this);
+  private readonly precompiler = new ConfigPrecompiler();
 
   /**
    * Starts the server with a given config.
@@ -104,6 +121,29 @@ export class AppRunner {
     let configs = input.config ?? [ '@css:config/default.json' ];
     configs = (Array.isArray(configs) ? configs : [ configs ]).map(resolveAssetPath);
 
+    if (input.precompiledConfigPath) {
+      return this.createPrecompiled({
+        path: resolveAssetPath(input.precompiledConfigPath),
+        mainModulePath: loaderProperties.mainModulePath,
+        configPaths: configs,
+      }, loaderProperties, configs, input);
+    }
+
+    return this.createFromConfigs(loaderProperties, configs, input);
+  }
+
+  /**
+   * Creates an App by having Components.js build and instantiate the given configurations.
+   *
+   * @param loaderProperties - Properties used when building the Components.js manager.
+   * @param configs - The resolved configuration paths.
+   * @param input - All values necessary to configure the server.
+   */
+  private async createFromConfigs(
+    loaderProperties: IComponentsManagerBuilderOptions<App>,
+    configs: string[],
+    input: AppRunnerInput,
+  ): Promise<App> {
     let componentsManager: ComponentsManager<App | CliResolver>;
     try {
       componentsManager = await this.createComponentsManager<App>(loaderProperties, configs);
@@ -112,6 +152,91 @@ export class AppRunner {
     }
 
     const cliResolver = await this.createCliResolver(componentsManager as ComponentsManager<CliResolver>);
+    const variables = await this.resolveVariables(cliResolver, input);
+
+    return this.createApp(componentsManager as ComponentsManager<App>, variables);
+  }
+
+  /**
+   * Creates an App from the precompiled configuration in the given artifact, if possible.
+   * Falls back to {@link AppRunner.createFromConfigs} if there is no valid artifact,
+   * in which case the artifact also gets (re)generated to speed up future server starts,
+   * or if the resolved variables imply a multithreaded setup.
+   *
+   * @param precompilerInput - Determines the artifact location and the values used to verify its key.
+   * @param loaderProperties - Properties used when building the Components.js manager, in case of a fallback.
+   * @param configs - The resolved configuration paths.
+   * @param input - All values necessary to configure the server.
+   */
+  private async createPrecompiled(
+    precompilerInput: ConfigPrecompilerInput,
+    loaderProperties: IComponentsManagerBuilderOptions<App>,
+    configs: string[],
+    input: AppRunnerInput,
+  ): Promise<App> {
+    const precompiled = await this.precompiler.load(precompilerInput);
+    if (precompiled) {
+      const app = await this.createPrecompiledApp(precompiled, input, precompilerInput.path);
+      if (app) {
+        return app;
+      }
+      // Multithreaded setups require a Components.js manager for the thread safety check,
+      // so those fall back to a full build without regenerating the artifact.
+      return this.createFromConfigs(loaderProperties, configs, input);
+    }
+
+    const app = await this.createFromConfigs(loaderProperties, configs, input);
+    this.logger.info(`Precompiling the configuration to ${precompilerInput.path} to speed up future server starts`);
+    await this.precompiler.precompile(precompilerInput);
+    return app;
+  }
+
+  /**
+   * Creates an App using the instantiation functions of a precompiled configuration,
+   * without any Components.js involvement.
+   * Returns `undefined` if the result would run multithreaded,
+   * as verifying thread safety requires a Components.js manager.
+   *
+   * @param precompiled - The precompiled configuration.
+   * @param input - All values necessary to configure the server.
+   * @param path - Path of the artifact the precompiled configuration was loaded from.
+   */
+  private async createPrecompiledApp(precompiled: PrecompiledConfig, input: AppRunnerInput, path: string):
+  Promise<App | undefined> {
+    let cliResolver: CliResolver;
+    try {
+      cliResolver = precompiled.cliResolver({});
+    } catch (error: unknown) {
+      this.resolveError(`Could not create the CLI resolver from the precompiled configuration ${path}`, error);
+    }
+
+    const variables = await this.resolveVariables(cliResolver, input);
+
+    let app: App;
+    try {
+      app = precompiled.app(variables);
+    } catch (error: unknown) {
+      this.resolveError(`Could not create the server from the precompiled configuration ${path}`, error);
+    }
+
+    if (!app.clusterManager.isSingleThreaded()) {
+      this.logger.warn(`Precompiled configurations can not be used in multithreaded setups. Ignoring ${path}.`);
+      return;
+    }
+
+    this.logger.info(`Created the server from the precompiled configuration ${path}`);
+    return app;
+  }
+
+  /**
+   * Determines the variable values by extracting shorthand values from the CLI arguments, if any,
+   * and resolving those together with the shorthand input.
+   * Values from the `variableBindings` input override the resolved values.
+   *
+   * @param cliResolver - {@link CliResolver} used to extract and resolve shorthand values.
+   * @param input - All values necessary to configure the server.
+   */
+  private async resolveVariables(cliResolver: CliResolver, input: AppRunnerInput): Promise<VariableBindings> {
     let extracted: Shorthand = {};
     if (input.argv) {
       extracted = await this.extractShorthand(cliResolver.cliExtractor, input.argv);
@@ -121,12 +246,8 @@ export class AppRunner {
       ...input.shorthand,
     });
 
-    // Create the application using the translated variable values.
     // `variableBindings` override those resolved from the `shorthand` input.
-    return this.createApp(
-      componentsManager as ComponentsManager<App>,
-      { ...parsedVariables, ...input.variableBindings },
-    );
+    return { ...parsedVariables, ...input.variableBindings };
   }
 
   /**
@@ -197,6 +318,7 @@ export class AppRunner {
       config: params.config as string[],
       argv,
       shorthand: settings,
+      precompiledConfigPath: params.precompiledConfigPath,
     });
   }
 

--- a/src/init/ConfigPrecompiler.ts
+++ b/src/init/ConfigPrecompiler.ts
@@ -59,13 +59,6 @@ export interface PrecompiledConfig {
  * without having to parse any modules or configurations,
  * significantly reducing server startup time.
  * The artifact is a CommonJS module with the exports described in {@link PrecompiledConfig}.
- *
- * To detect artifacts that are out of date,
- * the artifact also exports a key generated from the server version, the Node.js version,
- * the main module path, and the paths and contents of the top-level configuration files.
- * Configurations imported by those files are not part of the key,
- * so changes to such transitively imported configuration files can not be detected:
- * in that case the artifact file needs to be deleted manually to force a new compilation.
  */
 export class ConfigPrecompiler {
   protected readonly logger = getLoggerFor(this);
@@ -81,9 +74,7 @@ export class ConfigPrecompiler {
   public async precompile(input: ConfigPrecompilerInput): Promise<void> {
     try {
       const key = await this.generateKey(input);
-      // Compiled instantiations of components in the main module get emitted
-      // as `require` calls relative to the main module path,
-      // so the artifact resolves them with a `require` scoped to that directory.
+      // Compiled `require` calls are relative to the main module path, so the artifact resolves them from there
       const req = createRequire(joinFilePath(input.mainModulePath, 'package.json'));
       const strategy = new ConstructionStrategyCommonJsString({ asFunction: true, req });
       const manager = await ComponentsManager.build<string>({
@@ -96,8 +87,7 @@ export class ConfigPrecompiler {
           }
         },
       });
-      // With the above construction strategy,
-      // `instantiate` returns the name of the variable containing the instance in the compiled source
+      // With this construction strategy, `instantiate` returns the instance's variable name in the compiled source
       const cliVariable = await manager.instantiate(DEFAULT_CLI_RESOLVER);
       const cliSource = strategy.serializeDocument(cliVariable);
       const appVariable = await manager.instantiate(DEFAULT_APP);
@@ -142,6 +132,8 @@ export class ConfigPrecompiler {
    * Generates the key used to detect precompiled configurations that are out of date.
    * This is a hash of the server version, the Node.js version, the main module path,
    * and the paths and contents of the top-level configuration files.
+   * Transitively imported configurations are not part of the key,
+   * so changes to those files can not be detected.
    *
    * @param input - The values that determine the compilation result.
    */

--- a/src/init/ConfigPrecompiler.ts
+++ b/src/init/ConfigPrecompiler.ts
@@ -1,0 +1,195 @@
+import { createHash } from 'node:crypto';
+import { existsSync, promises as fsPromises } from 'node:fs';
+import { createRequire } from 'node:module';
+import type { ConfigRegistry } from 'componentsjs';
+import { ComponentsManager, ConstructionStrategyCommonJsString } from 'componentsjs';
+import { getLoggerFor } from '../logging/LogUtil';
+import { createErrorMessage } from '../util/errors/ErrorUtil';
+import { joinFilePath, readPackageJson } from '../util/PathUtil';
+import type { App } from './App';
+import type { CliResolver } from './CliResolver';
+
+const DEFAULT_CLI_RESOLVER = 'urn:solid-server-app-setup:default:CliResolver';
+const DEFAULT_APP = 'urn:solid-server:default:App';
+
+/**
+ * The values needed to precompile a configuration or load the resulting artifact.
+ */
+export interface ConfigPrecompilerInput {
+  /**
+   * Path of the JavaScript artifact containing the precompiled configuration.
+   */
+  path: string;
+  /**
+   * The resolved path Components.js uses as entry point when resolving modules.
+   */
+  mainModulePath: string;
+  /**
+   * The resolved paths of the top-level configuration files.
+   */
+  configPaths: string[];
+}
+
+/**
+ * The exports of a precompiled configuration artifact.
+ */
+export interface PrecompiledConfig {
+  /**
+   * The key that was generated when the artifact was written,
+   * used to detect artifacts that are out of date.
+   */
+  key: string;
+  /**
+   * Instantiates the {@link CliResolver} of the configuration.
+   *
+   * @param variables - Values for the Components.js variables the configuration references.
+   */
+  cliResolver: (variables?: Record<string, unknown>) => CliResolver;
+  /**
+   * Instantiates the {@link App} of the configuration.
+   *
+   * @param variables - Values for the Components.js variables the configuration references.
+   */
+  app: (variables: Record<string, unknown>) => App;
+}
+
+/**
+ * Compiles Components.js configurations into a single JavaScript artifact
+ * that can instantiate the {@link CliResolver} and the {@link App}
+ * without having to parse any modules or configurations,
+ * significantly reducing server startup time.
+ * The artifact is a CommonJS module with the exports described in {@link PrecompiledConfig}.
+ *
+ * To detect artifacts that are out of date,
+ * the artifact also exports a key generated from the server version, the Node.js version,
+ * the main module path, and the paths and contents of the top-level configuration files.
+ * Configurations imported by those files are not part of the key,
+ * so changes to such transitively imported configuration files can not be detected:
+ * in that case the artifact file needs to be deleted manually to force a new compilation.
+ */
+export class ConfigPrecompiler {
+  protected readonly logger = getLoggerFor(this);
+
+  /**
+   * Compiles the given configurations into a single JavaScript artifact,
+   * written to the path in the input.
+   * Errors are logged instead of thrown,
+   * as a server that failed to write this optimization can keep functioning without it.
+   *
+   * @param input - Determines the configurations to compile and where the result is written.
+   */
+  public async precompile(input: ConfigPrecompilerInput): Promise<void> {
+    try {
+      const key = await this.generateKey(input);
+      // Compiled instantiations of components in the main module get emitted
+      // as `require` calls relative to the main module path,
+      // so the artifact resolves them with a `require` scoped to that directory.
+      const req = createRequire(joinFilePath(input.mainModulePath, 'package.json'));
+      const strategy = new ConstructionStrategyCommonJsString({ asFunction: true, req });
+      const manager = await ComponentsManager.build<string>({
+        mainModulePath: input.mainModulePath,
+        typeChecking: false,
+        constructionStrategy: strategy,
+        configLoader: async(registry: ConfigRegistry): Promise<void> => {
+          for (const configPath of input.configPaths) {
+            await registry.register(configPath);
+          }
+        },
+      });
+      // With the above construction strategy,
+      // `instantiate` returns the name of the variable containing the instance in the compiled source
+      const cliVariable = await manager.instantiate(DEFAULT_CLI_RESOLVER);
+      const cliSource = strategy.serializeDocument(cliVariable);
+      const appVariable = await manager.instantiate(DEFAULT_APP);
+      const appSource = strategy.serializeDocument(appVariable);
+      await fsPromises.writeFile(input.path, this.serializeArtifact(key, input, cliSource, appSource), 'utf8');
+      this.logger.info(`Wrote a precompiled configuration to ${input.path}`);
+    } catch (error: unknown) {
+      this.logger.warn(`Unable to write a precompiled configuration to ${input.path}: ${createErrorMessage(error)}`);
+    }
+  }
+
+  /**
+   * Loads a precompiled configuration artifact.
+   * Returns `undefined` if there is no artifact at the path in the input,
+   * or if the artifact is invalid or out of date,
+   * in which case the caller is expected to fall back to a full Components.js instantiation.
+   *
+   * @param input - Determines the artifact location and the values used to verify its key.
+   */
+  public async load(input: ConfigPrecompilerInput): Promise<PrecompiledConfig | undefined> {
+    if (!existsSync(input.path)) {
+      return;
+    }
+    try {
+      const imported = await import(input.path) as PrecompiledConfig & { default?: PrecompiledConfig };
+      const artifact = imported.default ?? imported;
+      if (artifact.key !== await this.generateKey(input)) {
+        this.logger.warn(`The precompiled configuration ${input.path} is out of date and will be regenerated.`);
+        return;
+      }
+      if (typeof artifact.cliResolver !== 'function' || typeof artifact.app !== 'function') {
+        this.logger.warn(`The precompiled configuration ${input.path} is invalid and will be regenerated.`);
+        return;
+      }
+      return artifact;
+    } catch (error: unknown) {
+      this.logger.warn(`Unable to load the precompiled configuration ${input.path}: ${createErrorMessage(error)}`);
+    }
+  }
+
+  /**
+   * Generates the key used to detect precompiled configurations that are out of date.
+   * This is a hash of the server version, the Node.js version, the main module path,
+   * and the paths and contents of the top-level configuration files.
+   *
+   * @param input - The values that determine the compilation result.
+   */
+  public async generateKey(input: ConfigPrecompilerInput): Promise<string> {
+    const pkg = await readPackageJson();
+    const hash = createHash('sha256');
+    hash.update(`${pkg.version as string}\n${process.version}\n${input.mainModulePath}\n`);
+    for (const configPath of input.configPaths) {
+      hash.update(`${configPath}\n`);
+      hash.update(await fsPromises.readFile(configPath, 'utf8'));
+      hash.update('\n');
+    }
+    return hash.digest('hex');
+  }
+
+  /**
+   * Combines the compiled sources into the source of a module with the {@link PrecompiledConfig} exports.
+   * Each compiled source is a standalone CommonJS module,
+   * so they get wrapped in functions providing scoped `require` and `module` values.
+   *
+   * @param key - Key used to detect artifacts that are out of date.
+   * @param input - The input that was used to compile the sources.
+   * @param cliSource - Compiled source of the {@link CliResolver} instantiation.
+   * @param appSource - Compiled source of the {@link App} instantiation.
+   */
+  protected serializeArtifact(key: string, input: ConfigPrecompilerInput, cliSource: string, appSource: string):
+  string {
+    return [
+      '// Precompiled Community Solid Server configuration.',
+      `// This file was generated from [ ${input.configPaths.join(', ')} ] and should not be edited.`,
+      `'use strict';`,
+      `const { createRequire } = require('node:module');`,
+      `const contextRequire = createRequire(${JSON.stringify(joinFilePath(input.mainModulePath, 'package.json'))});`,
+      'function load(factory) {',
+      '  const module = { exports: {} };',
+      '  factory(contextRequire, module);',
+      '  return module.exports;',
+      '}',
+      'module.exports = {',
+      `  key: ${JSON.stringify(key)},`,
+      '  cliResolver: load(function(require, module) {',
+      cliSource,
+      '  }),',
+      '  app: load(function(require, module) {',
+      appSource,
+      '  }),',
+      '};',
+      '',
+    ].join('\n');
+  }
+}

--- a/test/unit/init/AppRunner.test.ts
+++ b/test/unit/init/AppRunner.test.ts
@@ -4,6 +4,7 @@ import type { App } from '../../../src/init/App';
 import { AppRunner } from '../../../src/init/AppRunner';
 import type { CliExtractor } from '../../../src/init/cli/CliExtractor';
 import type { ShorthandResolver } from '../../../src/init/variables/ShorthandResolver';
+import { getLoggerFor } from '../../../src/logging/LogUtil';
 import { joinFilePath } from '../../../src/util/PathUtil';
 import { flushPromises } from '../../util/Util';
 
@@ -95,6 +96,21 @@ jest.mock('componentsjs', (): any => ({
   },
 }));
 
+const precompiledCliResolver = jest.fn((): any => ({ cliExtractor, shorthandResolver }));
+const precompiledApp = jest.fn((): any => app);
+const precompiled = { key: 'key', cliResolver: precompiledCliResolver, app: precompiledApp };
+
+const precompiler = {
+  load: jest.fn(async(): Promise<any> => undefined),
+  precompile: jest.fn(async(): Promise<void> => undefined),
+};
+
+jest.mock('../../../src/init/ConfigPrecompiler', (): any => ({
+  ConfigPrecompiler: jest.fn((): any => precompiler),
+}));
+
+jest.mock('../../../src/logging/LogUtil');
+
 let files: Record<string, any> = {};
 
 const alternateParameters = {
@@ -137,6 +153,8 @@ const exit = jest.spyOn(process, 'exit').mockImplementation(jest.fn() as any);
 
 describe('AppRunner', (): void => {
   beforeEach((): void => {
+    jest.mocked(getLoggerFor).mockReturnValue(mockLogger as any);
+
     files = {};
 
     defaultParameters = {
@@ -303,6 +321,136 @@ describe('AppRunner', (): void => {
     });
   });
 
+  describe('create with a precompiled configuration', (): void => {
+    it('creates an App from a valid artifact without building a ComponentsManager.', async(): Promise<void> => {
+      precompiler.load.mockResolvedValueOnce(precompiled);
+      clusterManager.isSingleThreaded.mockReturnValueOnce(true);
+
+      const createdApp = await new AppRunner().create({
+        config: joinFilePath(__dirname, '../../../config/default.json'),
+        variableBindings: { 'urn:solid-server:default:variable:port': 4000 },
+        shorthand: { logLevel: 'info' },
+        precompiledConfigPath: '/precompiled.js',
+      });
+      expect(createdApp).toBe(app);
+
+      expect(precompiler.load).toHaveBeenCalledTimes(1);
+      expect(precompiler.load).toHaveBeenLastCalledWith({
+        path: '/precompiled.js',
+        mainModulePath: joinFilePath(__dirname, '../../../'),
+        configPaths: [ joinFilePath(__dirname, '../../../config/default.json') ],
+      });
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(0);
+      expect(manager.instantiate).toHaveBeenCalledTimes(0);
+      expect(precompiledCliResolver).toHaveBeenCalledTimes(1);
+      expect(precompiledCliResolver).toHaveBeenLastCalledWith({});
+      expect(cliExtractor.handleSafe).toHaveBeenCalledTimes(0);
+      expect(shorthandResolver.handleSafe).toHaveBeenCalledTimes(1);
+      expect(shorthandResolver.handleSafe).toHaveBeenLastCalledWith({ logLevel: 'info' });
+      expect(precompiledApp).toHaveBeenCalledTimes(1);
+      expect(precompiledApp).toHaveBeenLastCalledWith({
+        'urn:solid-server:default:variable:loggingLevel': 'info',
+        'urn:solid-server:default:variable:port': 4000,
+      });
+      expect(precompiler.precompile).toHaveBeenCalledTimes(0);
+      expect(mockLogger.info).toHaveBeenCalledTimes(1);
+      expect(mockLogger.info)
+        .toHaveBeenLastCalledWith('Created the server from the precompiled configuration /precompiled.js');
+      expect(app.start).toHaveBeenCalledTimes(0);
+    });
+
+    it('builds normally and writes the artifact if there is no valid artifact yet.', async(): Promise<void> => {
+      // The load mock resolving to `undefined` covers both a missing and a stale artifact
+      const createdApp = await new AppRunner().create({ precompiledConfigPath: '/precompiled.js' });
+      expect(createdApp).toBe(app);
+
+      expect(precompiler.load).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
+      expect(manager.instantiate).toHaveBeenCalledTimes(2);
+      expect(manager.instantiate).toHaveBeenNthCalledWith(1, 'urn:solid-server-app-setup:default:CliResolver', {});
+      expect(manager.instantiate).toHaveBeenNthCalledWith(2, 'urn:solid-server:default:App', { variables: {}});
+      expect(precompiledCliResolver).toHaveBeenCalledTimes(0);
+      expect(precompiledApp).toHaveBeenCalledTimes(0);
+      expect(precompiler.precompile).toHaveBeenCalledTimes(1);
+      expect(precompiler.precompile).toHaveBeenLastCalledWith({
+        path: '/precompiled.js',
+        mainModulePath: joinFilePath(__dirname, '../../../'),
+        configPaths: [ joinFilePath(__dirname, '/../../../config/default.json') ],
+      });
+      expect(mockLogger.info).toHaveBeenCalledTimes(1);
+      expect(mockLogger.info)
+        .toHaveBeenLastCalledWith('Precompiling the configuration to /precompiled.js to speed up future server starts');
+    });
+
+    it('falls back to building normally in multithreaded setups.', async(): Promise<void> => {
+      precompiler.load.mockResolvedValueOnce(precompiled);
+
+      const createdApp = await new AppRunner().create({ precompiledConfigPath: '/precompiled.js' });
+      expect(createdApp).toBe(app);
+
+      expect(precompiledCliResolver).toHaveBeenCalledTimes(1);
+      expect(precompiledApp).toHaveBeenCalledTimes(1);
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      expect(mockLogger.warn).toHaveBeenLastCalledWith(
+        'Precompiled configurations can not be used in multithreaded setups. Ignoring /precompiled.js.',
+      );
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
+      expect(manager.instantiate).toHaveBeenCalledTimes(2);
+      expect(shorthandResolver.handleSafe).toHaveBeenCalledTimes(2);
+      expect(precompiler.precompile).toHaveBeenCalledTimes(0);
+    });
+
+    it('does not use the precompiler if no precompiledConfigPath is set.', async(): Promise<void> => {
+      const createdApp = await new AppRunner().create();
+      expect(createdApp).toBe(app);
+
+      expect(precompiler.load).toHaveBeenCalledTimes(0);
+      expect(precompiler.precompile).toHaveBeenCalledTimes(0);
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
+      expect(manager.instantiate).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws an error if the precompiled CLI resolver can not be instantiated.', async(): Promise<void> => {
+      precompiler.load.mockResolvedValueOnce(precompiled);
+      precompiledCliResolver.mockImplementationOnce((): never => {
+        throw new Error('Fatal');
+      });
+
+      let caughtError: Error = new Error('should disappear');
+      try {
+        await new AppRunner().create({ precompiledConfigPath: '/precompiled.js' });
+      } catch (error: unknown) {
+        caughtError = error as Error;
+      }
+      expect(caughtError.message)
+        .toMatch(/^Could not create the CLI resolver from the precompiled configuration \/precompiled\.js/mu);
+      expect(caughtError.message).toMatch(/^Error: Fatal/mu);
+
+      expect(precompiledApp).toHaveBeenCalledTimes(0);
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(0);
+    });
+
+    it('throws an error if the precompiled server can not be instantiated.', async(): Promise<void> => {
+      precompiler.load.mockResolvedValueOnce(precompiled);
+      precompiledApp.mockImplementationOnce((): never => {
+        throw new Error('Fatal');
+      });
+
+      let caughtError: Error = new Error('should disappear');
+      try {
+        await new AppRunner().create({ precompiledConfigPath: '/precompiled.js' });
+      } catch (error: unknown) {
+        caughtError = error as Error;
+      }
+      expect(caughtError.message)
+        .toMatch(/^Could not create the server from the precompiled configuration \/precompiled\.js/mu);
+      expect(caughtError.message).toMatch(/^Error: Fatal/mu);
+
+      expect(precompiledApp).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(0);
+    });
+  });
+
   describe('run', (): void => {
     it('starts the server with provided settings.', async(): Promise<void> => {
       const variables = {
@@ -415,6 +563,32 @@ describe('AppRunner', (): void => {
       expect(manager.instantiate)
         .toHaveBeenNthCalledWith(2, 'urn:solid-server:default:App', { variables: defaultVariables });
       expect(app.clusterManager.isSingleThreaded()).toBeFalsy();
+      expect(app.start).toHaveBeenCalledTimes(0);
+    });
+
+    it('supports the precompiledConfigPath parameter.', async(): Promise<void> => {
+      precompiler.load.mockResolvedValueOnce(precompiled);
+      clusterManager.isSingleThreaded.mockReturnValueOnce(true);
+
+      const params = [ 'node', 'script', '--precompiledConfigPath', '/precompiled.js' ];
+      await expect(new AppRunner().createCli(params)).resolves.toBe(app);
+
+      expect(precompiler.load).toHaveBeenCalledTimes(1);
+      expect(precompiler.load).toHaveBeenLastCalledWith({
+        path: '/precompiled.js',
+        mainModulePath: joinFilePath(__dirname, '../../../'),
+        configPaths: [ joinFilePath(__dirname, '/../../../config/default.json') ],
+      });
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(0);
+      expect(precompiledCliResolver).toHaveBeenCalledTimes(1);
+      expect(precompiledCliResolver).toHaveBeenLastCalledWith({});
+      expect(cliExtractor.handleSafe).toHaveBeenCalledTimes(1);
+      expect(cliExtractor.handleSafe).toHaveBeenLastCalledWith(params);
+      expect(shorthandResolver.handleSafe).toHaveBeenCalledTimes(1);
+      expect(shorthandResolver.handleSafe).toHaveBeenLastCalledWith(defaultParameters);
+      expect(precompiledApp).toHaveBeenCalledTimes(1);
+      expect(precompiledApp).toHaveBeenLastCalledWith(defaultVariables);
+      expect(precompiler.precompile).toHaveBeenCalledTimes(0);
       expect(app.start).toHaveBeenCalledTimes(0);
     });
 

--- a/test/unit/init/ConfigPrecompiler.test.ts
+++ b/test/unit/init/ConfigPrecompiler.test.ts
@@ -1,0 +1,227 @@
+import { promises as fsPromises } from 'node:fs';
+import { ComponentsManager, ConstructionStrategyCommonJsString } from 'componentsjs';
+import type { ConfigPrecompilerInput } from '../../../src/init/ConfigPrecompiler';
+import { ConfigPrecompiler } from '../../../src/init/ConfigPrecompiler';
+import type { Logger } from '../../../src/logging/Logger';
+import { getLoggerFor } from '../../../src/logging/LogUtil';
+
+const cliResolverFn = jest.fn();
+const appFn = jest.fn();
+const artifact = { key: '', cliResolver: cliResolverFn, app: appFn };
+const esArtifactWithoutCliResolver = { __esModule: true, key: '', app: appFn };
+const esArtifactWithoutApp = { __esModule: true, key: '', cliResolver: cliResolverFn };
+
+let files: Record<string, string> = {};
+
+jest.mock('node:fs', (): any => ({
+  existsSync: jest.fn((pth: string): boolean => pth in files),
+  promises: {
+    readFile: jest.fn(async(pth: string): Promise<string> => {
+      if (!(pth in files)) {
+        throw new Error(`No file at ${pth}`);
+      }
+      return files[pth];
+    }),
+    writeFile: jest.fn(async(pth: string, data: string): Promise<void> => {
+      files[pth] = data;
+    }),
+  },
+}));
+
+jest.mock('fs-extra', (): any => ({
+  readJson: jest.fn(async(): Promise<any> => ({ version: '9.9.9' })),
+}));
+
+jest.mock('../../../src/logging/LogUtil');
+
+const registry = { register: jest.fn() };
+
+const manager = {
+  instantiate: jest.fn(async(iri: string): Promise<string> =>
+    iri === 'urn:solid-server:default:App' ? 'appVariable' : 'cliVariable'),
+};
+
+const strategy = {
+  serializeDocument: jest.fn((variable: string): string => `module.exports = '${variable}';`),
+};
+
+jest.mock('componentsjs', (): any => ({
+  ComponentsManager: {
+    build: jest.fn(async(options: any): Promise<any> => {
+      await options.configLoader(registry);
+      return manager;
+    }),
+  },
+  ConstructionStrategyCommonJsString: jest.fn((): any => strategy),
+}));
+
+jest.mock('/artifact.js', (): any => artifact, { virtual: true });
+jest.mock('/no-cli-artifact.js', (): any => esArtifactWithoutCliResolver, { virtual: true });
+jest.mock('/no-app-artifact.js', (): any => esArtifactWithoutApp, { virtual: true });
+
+describe('A ConfigPrecompiler', (): void => {
+  let logger: jest.Mocked<Logger>;
+  let input: ConfigPrecompilerInput;
+  let precompiler: ConfigPrecompiler;
+
+  beforeEach(async(): Promise<void> => {
+    files = {
+      '/config/main.json': '{ "import": [ "css:config/extra.json" ] }',
+      '/config/other.json': '{}',
+    };
+
+    logger = { info: jest.fn(), warn: jest.fn() } as any;
+    jest.mocked(getLoggerFor).mockReturnValue(logger);
+
+    input = {
+      path: '/artifact.js',
+      mainModulePath: '/main/',
+      configPaths: [ '/config/main.json', '/config/other.json' ],
+    };
+
+    precompiler = new ConfigPrecompiler();
+  });
+
+  afterEach((): void => {
+    jest.clearAllMocks();
+  });
+
+  describe('generating keys', (): void => {
+    it('generates a deterministic hexadecimal hash.', async(): Promise<void> => {
+      const key = await precompiler.generateKey(input);
+      expect(key).toMatch(/^[0-9a-f]{64}$/u);
+      await expect(precompiler.generateKey(input)).resolves.toBe(key);
+    });
+
+    it('generates a different key if a configuration file changes.', async(): Promise<void> => {
+      const key = await precompiler.generateKey(input);
+      files['/config/other.json'] = '{ "changed": true }';
+      await expect(precompiler.generateKey(input)).resolves.not.toBe(key);
+    });
+
+    it('generates a different key for a different main module path.', async(): Promise<void> => {
+      const key = await precompiler.generateKey(input);
+      input.mainModulePath = '/other/';
+      await expect(precompiler.generateKey(input)).resolves.not.toBe(key);
+    });
+  });
+
+  describe('precompiling', (): void => {
+    it('compiles the configurations and writes the artifact.', async(): Promise<void> => {
+      await expect(precompiler.precompile(input)).resolves.toBeUndefined();
+
+      expect(ConstructionStrategyCommonJsString).toHaveBeenCalledTimes(1);
+      expect(ConstructionStrategyCommonJsString)
+        .toHaveBeenLastCalledWith({ asFunction: true, req: expect.any(Function) });
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenLastCalledWith({
+        mainModulePath: '/main/',
+        typeChecking: false,
+        constructionStrategy: strategy,
+        configLoader: expect.any(Function),
+      });
+      expect(registry.register).toHaveBeenCalledTimes(2);
+      expect(registry.register).toHaveBeenNthCalledWith(1, '/config/main.json');
+      expect(registry.register).toHaveBeenNthCalledWith(2, '/config/other.json');
+      expect(manager.instantiate).toHaveBeenCalledTimes(2);
+      expect(manager.instantiate).toHaveBeenNthCalledWith(1, 'urn:solid-server-app-setup:default:CliResolver');
+      expect(manager.instantiate).toHaveBeenNthCalledWith(2, 'urn:solid-server:default:App');
+      expect(strategy.serializeDocument).toHaveBeenCalledTimes(2);
+      expect(strategy.serializeDocument).toHaveBeenNthCalledWith(1, 'cliVariable');
+      expect(strategy.serializeDocument).toHaveBeenNthCalledWith(2, 'appVariable');
+
+      expect(fsPromises.writeFile).toHaveBeenCalledTimes(1);
+      expect(fsPromises.writeFile).toHaveBeenLastCalledWith('/artifact.js', expect.any(String), 'utf8');
+      const source = files['/artifact.js'];
+      expect(source).toContain(`createRequire("/main/package.json")`);
+      expect(source).toContain(`key: "${await precompiler.generateKey(input)}",`);
+      expect(source).toContain(`cliResolver: load(function(require, module) {\nmodule.exports = 'cliVariable';`);
+      expect(source).toContain(`app: load(function(require, module) {\nmodule.exports = 'appVariable';`);
+
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenLastCalledWith('Wrote a precompiled configuration to /artifact.js');
+      expect(logger.warn).toHaveBeenCalledTimes(0);
+    });
+
+    it('logs a warning if the configurations can not be compiled.', async(): Promise<void> => {
+      jest.mocked(ComponentsManager.build).mockRejectedValueOnce(new Error('bad config'));
+      await expect(precompiler.precompile(input)).resolves.toBeUndefined();
+
+      expect(fsPromises.writeFile).toHaveBeenCalledTimes(0);
+      expect(logger.info).toHaveBeenCalledTimes(0);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenLastCalledWith(
+        'Unable to write a precompiled configuration to /artifact.js: bad config',
+      );
+    });
+
+    it('logs a warning if the artifact can not be written.', async(): Promise<void> => {
+      jest.mocked(fsPromises.writeFile).mockRejectedValueOnce(new Error('read-only'));
+      await expect(precompiler.precompile(input)).resolves.toBeUndefined();
+
+      expect(fsPromises.writeFile).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenCalledTimes(0);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenLastCalledWith(
+        'Unable to write a precompiled configuration to /artifact.js: read-only',
+      );
+    });
+  });
+
+  describe('loading', (): void => {
+    it('returns undefined if there is no artifact.', async(): Promise<void> => {
+      input.path = '/missing-artifact.js';
+      await expect(precompiler.load(input)).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledTimes(0);
+    });
+
+    it('returns the exports of a valid artifact.', async(): Promise<void> => {
+      files['/artifact.js'] = 'compiled';
+      artifact.key = await precompiler.generateKey(input);
+      await expect(precompiler.load(input)).resolves.toBe(artifact);
+      expect(logger.warn).toHaveBeenCalledTimes(0);
+    });
+
+    it('returns undefined if the artifact key is out of date.', async(): Promise<void> => {
+      files['/artifact.js'] = 'compiled';
+      artifact.key = 'outdated';
+      await expect(precompiler.load(input)).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenLastCalledWith(
+        'The precompiled configuration /artifact.js is out of date and will be regenerated.',
+      );
+    });
+
+    it('returns undefined if the artifact has no cliResolver function.', async(): Promise<void> => {
+      input.path = '/no-cli-artifact.js';
+      files['/no-cli-artifact.js'] = 'compiled';
+      esArtifactWithoutCliResolver.key = await precompiler.generateKey(input);
+      await expect(precompiler.load(input)).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenLastCalledWith(
+        'The precompiled configuration /no-cli-artifact.js is invalid and will be regenerated.',
+      );
+    });
+
+    it('returns undefined if the artifact has no app function.', async(): Promise<void> => {
+      input.path = '/no-app-artifact.js';
+      files['/no-app-artifact.js'] = 'compiled';
+      esArtifactWithoutApp.key = await precompiler.generateKey(input);
+      await expect(precompiler.load(input)).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenLastCalledWith(
+        'The precompiled configuration /no-app-artifact.js is invalid and will be regenerated.',
+      );
+    });
+
+    it('returns undefined if the artifact can not be imported.', async(): Promise<void> => {
+      input.path = '/broken-artifact.js';
+      files['/broken-artifact.js'] = 'compiled';
+      await expect(precompiler.load(input)).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenLastCalledWith(expect.stringMatching(
+        /^Unable to load the precompiled configuration \/broken-artifact\.js: /u,
+      ));
+    });
+  });
+});


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — an upstream issue proposing precompiled-configuration boot must be created before this is submitted to CommunitySolidServer (the upstream PR template requires one).

#### ✍️ Description

Server boot spends 10–25 s in Components.js — scanning ~168 component modules, JSON-LD-parsing the ~100-file config graph, and RDF-driven instantiation — repeated identically on **every** start even though the result is deterministic for a fixed configuration and version.

This adds an opt-in `--precompiledConfigPath <file>` CLI parameter (env: `CSS_PRECOMPILED_CONFIG_PATH`, or the `precompiledConfigPath` `AppRunnerInput` field):

- **First boot** with the flag set: the server starts normally, then the new `ConfigPrecompiler` compiles its configuration into a single JavaScript artifact — using componentsjs's own `ConstructionStrategyCommonJsString` (the machinery behind `componentsjs-compile-config -f`, driven directly here so CSS's multiple top-level configs compile through one manager build) — exporting `cliResolver(variables)` and `app(variables)` factories plus a staleness key.
- **Subsequent boots** `require()` the artifact and call the factories directly: no `ComponentsManager`, no module scan, no JSON-LD parsing, no RDF instantiation.
- With the flag unset, behaviour is byte-identical to before.

Design notes (the safety story):

- **The optimization can never break the server.** Precompilation errors are logged instead of thrown, and a missing, stale, or corrupt artifact, a failed write, or a moved install all log a warning and fall back to a normal Components.js build (regenerating the artifact where that makes sense).
- **Staleness detection** is a sha256 key over the CSS version, Node.js version, `mainModulePath`, and the paths and contents of the *top-level* configuration files. Transitively imported configs are deliberately not part of the key: enumerating the import closure would require parsing the config graph, which is the exact cost this feature removes. After editing transitively imported config files the artifact must therefore be deleted manually — documented on the input field and on `ConfigPrecompiler.generateKey`.
- **The artifact is machine/install-specific**: compiled `require` calls are resolved relative to `mainModulePath` via an embedded `createRequire`, so a moved install changes the key and falls back gracefully.
- **Multithreaded setups** (`--workers` ≠ 1) fall back to a live build with a warning, because the single-threaded-components check needs a live Components.js manager. The artifact is still valid in that case and is not regenerated.

#### 📈 Measured

Measured with a fork-local harness (`scripts/perf/runner.js --bootRuns 3`, **not part of this PR** — there is no upstream-reproducible benchmark command yet) booting `config/file.json` on a shared 2-core EC2 box; treat the numbers as indicative. The simplest manual check is timing `node bin/server.js -c config/file.json --precompiledConfigPath /tmp/css-precompiled.js` twice — the second run is the warm boot.

| | main (median) | first boot w/ flag (compile) | **warm boots (×2)** |
|---|---|---|---|
| boot wall time | 24.2 s | 38.5 s | **3.0 s (−87%)** |
| boot CPU time | 25.1 s | 42.1 s | **3.3 s (−87%)** |
| boot fs ops | 19,230 | 30,387 | **8,535 (−56%)** |
| RSS after boot | ~460 MB | 685 MB | **153 MB (−67%)** |

The RSS drop is structural: the manager's RDF object graphs never exist in the warm-boot process.

#### 📋 Notes for review

- Intended level: **semver.minor** (backwards-compatible feature: new CLI parameter, new `AppRunnerInput` field, new exported `ConfigPrecompiler` class). As a feature with interface additions, the upstream submission should target the **latest `versions/*` branch** (currently `versions/next-major`), not `main` — this draft targets the fork's `main` for review only.
- Composes with fork PR #29 (`--moduleStateCachePath`), which still helps first/fallback boots; on warm precompiled boots the module scan doesn't happen at all.
- `BaseComponentsJsFactory` (dynamic pod templates) keeps its own live manager — out of scope.
- Before upstream submission: create the related issue, and add a `--precompiledConfigPath` row to the CLI parameter table in `documentation/markdown/usage/starting-server.md`.
- Validation: full unit suite green under the 100% `./src` coverage thresholds, `npm run build` and lint clean, and live-verified on this box (miss → compile → two warm boots above).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
