### PR TITLE
chore: Inline the escape-string-regexp helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "cross-fetch": "^4.0.0",
         "ejs": "^3.1.9",
         "end-of-stream": "^1.4.4",
-        "escape-string-regexp": "^4.0.0",
         "eslint": "^9.35.0",
         "fetch-sparql-endpoint": "^6.0.0",
         "fs-extra": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "cross-fetch": "^4.0.0",
     "ejs": "^3.1.9",
     "end-of-stream": "^1.4.4",
-    "escape-string-regexp": "^4.0.0",
     "eslint": "^9.35.0",
     "fetch-sparql-endpoint": "^6.0.0",
     "fs-extra": "^11.1.1",

--- a/scripts/upgradeConfig.ts
+++ b/scripts/upgradeConfig.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env ts-node
 /* eslint-disable no-console */
-import escapeStringRegexp from 'escape-string-regexp';
 import { readdir, readFile, writeFile } from 'fs-extra';
 import simpleGit from 'simple-git';
 import { joinFilePath, readPackageJson } from '../src/util/PathUtil';
+import { escapeStringRegexp } from '../src/util/StringUtil';
 
 /**
  * Script: upgradeConfigs.ts

--- a/src/server/middleware/StaticAssetHandler.ts
+++ b/src/server/middleware/StaticAssetHandler.ts
@@ -1,6 +1,5 @@
 import { createReadStream, readdirSync } from 'node:fs';
 import { posix as pathPosix } from 'node:path';
-import escapeStringRegexp from 'escape-string-regexp';
 import * as mime from 'mime-types';
 import { getLoggerFor } from '../../logging/LogUtil';
 import { APPLICATION_OCTET_STREAM } from '../../util/ContentTypes';
@@ -11,6 +10,7 @@ import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpErr
 import type { SystemError } from '../../util/errors/SystemError';
 import { ensureTrailingSlash, joinFilePath, resolveAssetPath, trimLeadingSlashes } from '../../util/PathUtil';
 import { pipeSafely } from '../../util/StreamUtil';
+import { escapeStringRegexp } from '../../util/StringUtil';
 import type { HttpHandlerInput } from '../HttpHandler';
 import { HttpHandler } from '../HttpHandler';
 import type { HttpRequest } from '../HttpRequest';

--- a/src/util/HeaderUtil.ts
+++ b/src/util/HeaderUtil.ts
@@ -1,5 +1,4 @@
 import type { IncomingHttpHeaders } from 'node:http';
-import escapeStringRegexp from 'escape-string-regexp';
 import { getLoggerFor } from '../logging/LogUtil';
 import type { HttpResponse } from '../server/HttpResponse';
 import { BadRequestHttpError } from './errors/BadRequestHttpError';
@@ -14,6 +13,7 @@ import type {
   LinkEntryParameters,
 } from './Header';
 import { ContentType, QUOTED_STRING, QVALUE, SIMPLE_MEDIA_RANGE, TOKEN } from './Header';
+import { escapeStringRegexp } from './StringUtil';
 
 const logger = getLoggerFor('HeaderUtil');
 

--- a/src/util/StringUtil.ts
+++ b/src/util/StringUtil.ts
@@ -87,16 +87,14 @@ export function msToDuration(ms: number): string {
 /**
  * Escapes all special regular expression characters in a string,
  * so it can be used as a literal match inside a regular expression.
- * This is a local implementation of the `escape-string-regexp` v4 library.
  *
  * @param value - String to escape.
  *
  * @returns The escaped string.
  */
 export function escapeStringRegexp(value: string): string {
-  // Escape characters with special meaning either inside or outside character sets.
-  // Use a simple backslash escape when it's always valid,
-  // and a `\x2d` escape when the simpler form would be disallowed by Unicode patterns' stricter grammar.
+  // Based on https://github.com/sindresorhus/escape-string-regexp
+  // Dashes are escaped as `\x2d` since `\-` is disallowed by the stricter grammar of Unicode patterns.
   return value
     .replaceAll(/[|\\{}()[\]^$+*?.]/gu, '\\$&')
     .replaceAll('-', '\\x2d');

--- a/src/util/StringUtil.ts
+++ b/src/util/StringUtil.ts
@@ -83,3 +83,21 @@ export function msToDuration(ms: number): string {
 
   return stringParts.join('');
 }
+
+/**
+ * Escapes all special regular expression characters in a string,
+ * so it can be used as a literal match inside a regular expression.
+ * This is a local implementation of the `escape-string-regexp` v4 library.
+ *
+ * @param value - String to escape.
+ *
+ * @returns The escaped string.
+ */
+export function escapeStringRegexp(value: string): string {
+  // Escape characters with special meaning either inside or outside character sets.
+  // Use a simple backslash escape when it's always valid,
+  // and a `\x2d` escape when the simpler form would be disallowed by Unicode patterns' stricter grammar.
+  return value
+    .replaceAll(/[|\\{}()[\]^$+*?.]/gu, '\\$&')
+    .replaceAll('-', '\\x2d');
+}

--- a/test/unit/util/StringUtil.test.ts
+++ b/test/unit/util/StringUtil.test.ts
@@ -1,4 +1,5 @@
 import {
+  escapeStringRegexp,
   isUrl,
   isValidFileName,
   msToDuration,
@@ -62,6 +63,25 @@ describe('HeaderUtil', (): void => {
     it('excludes the T if there is no time segment.', async(): Promise<void> => {
       const ms = ((2 * 24 * 60 * 60)) * 1000;
       expect(msToDuration(ms)).toBe('P2D');
+    });
+  });
+
+  describe('#escapeStringRegexp', (): void => {
+    it('escapes all special regular expression characters.', (): void => {
+      expect(escapeStringRegexp('|\\{}()[]^$+*?.')).toBe('\\|\\\\\\{\\}\\(\\)\\[\\]\\^\\$\\+\\*\\?\\.');
+    });
+
+    it('escapes dashes with their hex code so the result can be used in character classes.', (): void => {
+      expect(escapeStringRegexp('foo-bar-baz')).toBe('foo\\x2dbar\\x2dbaz');
+    });
+
+    it('does not change strings without special characters.', (): void => {
+      expect(escapeStringRegexp('nothing special')).toBe('nothing special');
+    });
+
+    it('generates strings that match the original input when used in a regular expression.', (): void => {
+      const input = 'how much $ for a #unicorn-*|[]?';
+      expect(new RegExp(`^${escapeStringRegexp(input)}$`, 'u').test(input)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the upstream template requires a linked issue, so one must be created on CommunitySolidServer/CommunitySolidServer before this is submitted there.

#### ✍️ Description

Removes the `escape-string-regexp` runtime dependency by inlining its two-line algorithm as `escapeStringRegexp()` in `src/util/StringUtil.ts`. The three consumers (`HeaderUtil`'s header-parsing regexes, `StaticAssetHandler`'s path matcher, and `scripts/upgradeConfig.ts`) switch to the local helper.

Why: the library ships ESM-only from v5, so the CJS build had it permanently pinned to v4; for a two-line function, inlining removes both the runtime dependency and the upgrade dead-end. The helper keeps the library's exact algorithm: regex metacharacters are backslash-escaped, and `-` becomes `\x2d` because that is the one dash escape valid both inside and outside character classes under the stricter grammar of Unicode-aware patterns (`\-` is a SyntaxError outside a character class with the `u` flag, and a bare `-` can form a range inside one).

Notes for reviewers:

- Behaviour matches `escape-string-regexp@4.0.0` exactly: the unit tests cover every metacharacter, the dash escape, and a round-trip `RegExp` match, and a 20,000-random-string fuzz comparison against the library (still resolvable from `node_modules` as a transitive dev dependency) shows zero mismatches:

  ```ts
  // fuzz.ts — npx ts-node fuzz.ts
  import { escapeStringRegexp } from './src/util/StringUtil';
  const lib = require('escape-string-regexp');
  const chars = '|\\{}()[]^$+*?.-abc #é€😀/';
  let mismatches = 0;
  for (let i = 0; i < 20_000; i++) {
    const s = Array.from(
      { length: Math.floor(Math.random() * 30) },
      () => chars[Math.floor(Math.random() * chars.length)],
    ).join('');
    if (lib(s) !== escapeStringRegexp(s)) {
      mismatches += 1;
    }
  }
  console.log('mismatches:', mismatches); // 0
  ```

- One cosmetic deviation from the library source (identical behaviour): the dash step uses `replaceAll('-', '\\x2d')` because the repo's `unicorn/prefer-string-replace-all` rule rejects a single-character global regex.
- `StringUtil` is re-exported through the `src/index.ts` barrel, so the helper becomes public API automatically, consistent with the other functions there.
- `escape-string-regexp` remains in the lockfile as a transitive dev-tooling dependency (eslint plugins); only the runtime dependency is removed.

**Semver / branch target:** the new exported helper is a backwards-compatible feature addition, so the intended level is **semver.minor** (contributors cannot set the label). Per the contributing guide that means the upstream submission should target the latest `versions/*` branch (currently `versions/next-major`), not `main`.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
