### PR TITLE
feat: Add an Azure Blob Storage backend

### DIFF
--- a/config/app/variables/cli/cli.json
+++ b/config/app/variables/cli/cli.json
@@ -96,6 +96,24 @@
         },
         {
           "@type": "YargsParameter",
+          "name": "azureBlobConnectionString",
+          "options": {
+            "requiresArg": true,
+            "type": "string",
+            "describe": "Connection string of the Azure Storage account, when using an Azure Blob Storage-based configuration."
+          }
+        },
+        {
+          "@type": "YargsParameter",
+          "name": "azureBlobContainer",
+          "options": {
+            "requiresArg": true,
+            "type": "string",
+            "describe": "Name of the Azure Blob Storage container, when using an Azure Blob Storage-based configuration."
+          }
+        },
+        {
+          "@type": "YargsParameter",
           "name": "podConfigJson",
           "options": {
             "requiresArg": true,

--- a/config/app/variables/resolver/resolver.json
+++ b/config/app/variables/resolver/resolver.json
@@ -52,6 +52,20 @@
           }
         },
         {
+          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:azureBlobConnectionString",
+          "CombinedShorthandResolver:_resolvers_value": {
+            "@type": "KeyExtractor",
+            "key": "azureBlobConnectionString"
+          }
+        },
+        {
+          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:azureBlobContainer",
+          "CombinedShorthandResolver:_resolvers_value": {
+            "@type": "KeyExtractor",
+            "key": "azureBlobContainer"
+          }
+        },
+        {
           "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:showStackTrace",
           "CombinedShorthandResolver:_resolvers_value": {
             "@type": "KeyExtractor",

--- a/config/azure-blob-storage.json
+++ b/config/azure-blob-storage.json
@@ -1,0 +1,44 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "import": [
+    "css:config/app/init/static-root.json",
+    "css:config/app/main/default.json",
+    "css:config/app/variables/default.json",
+    "css:config/http/handler/default.json",
+    "css:config/http/middleware/default.json",
+    "css:config/http/notifications/all.json",
+    "css:config/http/server-factory/http.json",
+    "css:config/http/static/default.json",
+    "css:config/identity/access/public.json",
+    "css:config/identity/email/default.json",
+    "css:config/identity/handler/default.json",
+    "css:config/identity/oidc/default.json",
+    "css:config/identity/ownership/token.json",
+    "css:config/identity/pod/static.json",
+    "css:config/ldp/authentication/dpop-bearer.json",
+    "css:config/ldp/authorization/webacl.json",
+    "css:config/ldp/handler/default.json",
+    "css:config/ldp/metadata-parser/default.json",
+    "css:config/ldp/metadata-writer/default.json",
+    "css:config/ldp/modes/default.json",
+    "css:config/storage/backend/azure-blob.json",
+    "css:config/storage/key-value/memory.json",
+    "css:config/storage/location/pod.json",
+    "css:config/storage/middleware/default.json",
+    "css:config/util/auxiliary/acl.json",
+    "css:config/util/identifiers/suffix.json",
+    "css:config/util/index/default.json",
+    "css:config/util/logging/winston.json",
+    "css:config/util/representation-conversion/default.json",
+    "css:config/util/resource-locker/memory.json",
+    "css:config/util/variables/default.json"
+  ],
+  "@graph": [
+    {
+      "comment": [
+        "A Solid server that stores its resources in an Azure Blob Storage container and uses WAC for authorization.",
+        "Internal data is stored in memory, so it will be lost when the server restarts."
+      ]
+    }
+  ]
+}

--- a/config/storage/backend/azure-blob.json
+++ b/config/storage/backend/azure-blob.json
@@ -1,0 +1,17 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "import": [
+    "css:config/storage/backend/data-accessors/azure-blob.json"
+  ],
+  "@graph": [
+    {
+      "comment": "A default store setup with an Azure Blob Storage backend.",
+      "@id": "urn:solid-server:default:ResourceStore_Backend",
+      "@type": "DataAccessorBasedStore",
+      "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },
+      "auxiliaryStrategy": { "@id": "urn:solid-server:default:AuxiliaryStrategy" },
+      "accessor": { "@id": "urn:solid-server:default:AzureBlobDataAccessor" },
+      "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" }
+    }
+  ]
+}

--- a/config/storage/backend/data-accessors/azure-blob.json
+++ b/config/storage/backend/data-accessors/azure-blob.json
@@ -1,0 +1,13 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Stores data in an Azure Blob Storage container. Only supports binary data.",
+      "@id": "urn:solid-server:default:AzureBlobDataAccessor",
+      "@type": "AzureBlobDataAccessor",
+      "connectionString": { "@id": "urn:solid-server:default:variable:azureBlobConnectionString" },
+      "containerName": { "@id": "urn:solid-server:default:variable:azureBlobContainer" },
+      "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" }
+    }
+  ]
+}

--- a/config/util/variables/default.json
+++ b/config/util/variables/default.json
@@ -28,6 +28,16 @@
       "@type": "Variable"
     },
     {
+      "comment": "Connection string of the Azure Storage account to use when using an Azure Blob Storage-based config.",
+      "@id": "urn:solid-server:default:variable:azureBlobConnectionString",
+      "@type": "Variable"
+    },
+    {
+      "comment": "Name of the Azure Blob Storage container to use when using an Azure Blob Storage-based config.",
+      "@id": "urn:solid-server:default:variable:azureBlobContainer",
+      "@type": "Variable"
+    },
+    {
       "comment": "The max level of log messages that should be output.",
       "@id": "urn:solid-server:default:variable:loggingLevel",
       "@type": "Variable"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "7.1.9",
       "license": "MIT",
       "dependencies": {
+        "@azure/storage-blob": "^12.33.0",
         "@comunica/context-entries": "^2.8.2",
         "@comunica/query-sparql": "^2.9.0",
         "@isaacs/ttlcache": "^1.4.1",
@@ -132,6 +133,280 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
+      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure/core-client": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-lro/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+      "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.9",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@azure/storage-blob": {
+      "version": "12.33.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.33.0.tgz",
+      "integrity": "sha512-2SX8oP8PyblUcAFZSg39c8Ls+tFjavM6sBeV+qpw33mRzRhI/5hrFJmJ/x0H9xx5l6ECPvgSP8uPxqTeVbHNIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.4.1",
+        "events": "^3.0.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@azure/storage-common": {
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.4.1.tgz",
+      "integrity": "sha512-t14unw/WofGDUi7TKJrsyXyPsN+NLgRm7hMaq0llxNmTIzt7f257+6LE6FKIJPh88zLj6M7LPvzve0fEYg/L3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.24.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-common/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
@@ -5411,6 +5686,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6941,6 +7228,26 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
@@ -7274,6 +7581,15 @@
       "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
       "dev": true
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -7366,6 +7682,18 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/are-docs-informative": {
       "version": "0.0.2",
@@ -10491,6 +10819,45 @@
         }
       ]
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -11451,6 +11818,19 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http2-wrapper": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
@@ -11472,6 +11852,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -11901,6 +12294,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -14341,6 +14746,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -16001,6 +16421,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -16888,6 +17323,21 @@
         }
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -17066,6 +17516,236 @@
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "requires": {
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@azure/core-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
+      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@azure/core-http-compat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+      "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2"
+      }
+    },
+    "@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "requires": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "requires": {
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@azure/core-rest-pipeline": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "requires": {
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@azure/core-xml": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+      "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+      "requires": {
+        "fast-xml-parser": "^5.5.9",
+        "tslib": "^2.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "requires": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@azure/storage-blob": {
+      "version": "12.33.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.33.0.tgz",
+      "integrity": "sha512-2SX8oP8PyblUcAFZSg39c8Ls+tFjavM6sBeV+qpw33mRzRhI/5hrFJmJ/x0H9xx5l6ECPvgSP8uPxqTeVbHNIA==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.3",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.1",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.1.4",
+        "@azure/storage-common": "^12.4.1",
+        "events": "^3.0.0",
+        "tslib": "^2.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@azure/storage-common": {
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.4.1.tgz",
+      "integrity": "sha512-t14unw/WofGDUi7TKJrsyXyPsN+NLgRm7hMaq0llxNmTIzt7f257+6LE6FKIJPh88zLj6M7LPvzve0fEYg/L3A==",
+      "requires": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-rest-pipeline": "^1.24.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "events": "^3.3.0",
+        "tslib": "^2.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
       }
     },
     "@babel/code-frame": {
@@ -21553,6 +22233,11 @@
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "dev": true
     },
+    "@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -22732,6 +23417,23 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@typespec/ts-http-runtime": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "requires": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
     "@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
@@ -22914,6 +23616,11 @@
       "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
       "dev": true
     },
+    "agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+    },
     "ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -22979,6 +23686,11 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="
     },
     "are-docs-informative": {
       "version": "0.0.2",
@@ -25153,6 +25865,28 @@
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true
     },
+    "fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "requires": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "fast-xml-parser": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "requires": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.1.0"
+      }
+    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -25867,6 +26601,15 @@
       "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.3.tgz",
       "integrity": "sha512-nARK1wSKoBBrtcoESlHBx36c1Ln/gnbNQi1eB6MeTUefJIT3NvUOsV15bClga0k38f0q/kN5xxrGSDS3EFnm9w=="
     },
+    "http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "requires": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      }
+    },
     "http2-wrapper": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
@@ -25881,6 +26624,15 @@
           "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
           "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
         }
+      }
+    },
+    "https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
       }
     },
     "human-signals": {
@@ -26167,6 +26919,11 @@
       "requires": {
         "text-extensions": "^1.0.0"
       }
+    },
+    "is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -28046,6 +28803,11 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
+    "path-expression-matcher": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ=="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -29348,6 +30110,14 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
+    "strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "requires": {
+        "anynum": "^1.0.1"
+      }
+    },
     "superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -29940,6 +30710,11 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "requires": {}
+    },
+    "xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "watch": "nodemon --watch \"dist/**/*.js\" --exec npm start"
   },
   "dependencies": {
+    "@azure/storage-blob": "^12.33.0",
     "@comunica/context-entries": "^2.8.2",
     "@comunica/query-sparql": "^2.9.0",
     "@isaacs/ttlcache": "^1.4.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -442,6 +442,7 @@ export * from './server/util/RouterHandler';
 // Storage/Accessors
 export * from './storage/accessors/AtomicDataAccessor';
 export * from './storage/accessors/AtomicFileDataAccessor';
+export * from './storage/accessors/AzureBlobDataAccessor';
 export * from './storage/accessors/DataAccessor';
 export * from './storage/accessors/FileDataAccessor';
 export * from './storage/accessors/FilterMetadataDataAccessor';

--- a/src/storage/accessors/AzureBlobDataAccessor.ts
+++ b/src/storage/accessors/AzureBlobDataAccessor.ts
@@ -21,8 +21,7 @@ import type { DataAccessor } from './DataAccessor';
 
 /**
  * The suffix used for metadata companion blobs.
- * This matches the auxiliary suffix used by the metadata strategy,
- * which prevents users from creating resources with this suffix directly at the store level,
+ * The metadata strategy blocks writes to identifiers with this suffix,
  * so companion blobs can never collide with user resources.
  */
 const METADATA_SUFFIX = '.meta';
@@ -39,22 +38,13 @@ interface AzureBlobProperties {
 /**
  * DataAccessor that stores documents and containers as blobs in an Azure Blob Storage container.
  *
- * Blob keys are the full resource URLs,
- * similarly to how the {@link SparqlDataAccessor} uses resource URLs as graph names.
- * This is the simplest robust mapping as it requires no base URL variable,
- * while `listBlobsByHierarchy` with a `/` delimiter still works since URLs are `/`-hierarchical.
- *
- * Containers are stored as empty marker blobs whose key is the container URL itself (ending in a slash),
+ * Blob keys are the full resource URLs, so `listBlobsByHierarchy` with a `/` delimiter can be used for listings.
+ * Containers are stored as empty marker blobs whose key is the container URL itself,
  * so empty containers remain visible.
- * Additional metadata of a resource is persisted in a companion blob with the `.meta` suffix appended to its key.
- * Since that suffix matches the auxiliary suffix of the metadata strategy,
- * which blocks direct writes to such identifiers at the store level,
- * no collisions between companion blobs and user resources are possible.
+ * Additional metadata of a resource is stored in a companion blob with the `.meta` suffix appended to its key.
  *
- * Note that this class implements {@link DataAccessor} but not {@link AtomicDataAccessor}:
- * blobs are overwritten in place so a failed call can leave a partially updated state behind.
- * Consequently, this accessor cannot be wrapped by the quota-related {@link ValidatingDataAccessor}
- * and {@link PassthroughDataAccessor} wrappers, as those require an atomic accessor.
+ * Note that this is not an {@link AtomicDataAccessor}, as blobs are overwritten in place,
+ * so it cannot be wrapped by accessors requiring atomicity, such as the {@link ValidatingDataAccessor}.
  */
 export class AzureBlobDataAccessor implements DataAccessor {
   protected readonly logger = getLoggerFor(this);
@@ -97,8 +87,6 @@ export class AzureBlobDataAccessor implements DataAccessor {
   /**
    * Will return the corresponding metadata by reading the metadata companion blob (if it exists)
    * and adding blob-specific metadata elements generated from the blob properties.
-   * Containers are only found if their marker blob exists,
-   * so a document identifier of a stored container will result in a 404 and vice versa.
    */
   public async getMetadata(identifier: ResourceIdentifier): Promise<RepresentationMetadata> {
     const properties = await this.getBlobProperties(this.getBlobKey(identifier));
@@ -107,19 +95,13 @@ export class AzureBlobDataAccessor implements DataAccessor {
     const metadata = await this.getRawMetadata(identifier);
     addResourceMetadata(metadata, isContainer);
     this.addBlobMetadata(metadata, properties, isContainer);
-    // Containers have no content type. For documents the value stored in the blob properties is used.
+    // Containers will not have a content-type
     if (!isContainer) {
       metadata.set(CONTENT_TYPE_TERM, properties.contentType);
     }
     return metadata;
   }
 
-  /**
-   * Generates metadata for all children of the container
-   * by listing the blobs directly below the container key.
-   * The listing transparently pages through all results.
-   * Marker blobs and metadata companion blobs are not children and will be skipped.
-   */
   public async* getChildren(identifier: ResourceIdentifier): AsyncIterableIterator<RepresentationMetadata> {
     // Documents have no children
     if (!isContainerIdentifier(identifier)) {
@@ -169,19 +151,14 @@ export class AzureBlobDataAccessor implements DataAccessor {
 
   /**
    * Creates or overwrites the marker blob of the container and writes metadata to its companion blob if necessary.
-   * Since there is no parent logic needed, this also works for root containers.
    */
   public async writeContainer(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
     const key = this.getBlobKey(identifier);
-    // An empty marker blob keeps (empty) containers visible
     await this.containerClient.getBlockBlobClient(key).upload('', 0);
 
     await this.writeMetadataBlob(identifier, metadata);
   }
 
-  /**
-   * Replaces the contents of the metadata companion blob.
-   */
   public async writeMetadata(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
     await this.writeMetadataBlob(identifier, metadata);
   }
@@ -351,7 +328,6 @@ export class AzureBlobDataAccessor implements DataAccessor {
 
   /**
    * Determines the blob key corresponding to the given identifier.
-   * Keys are the full resource URLs, with container keys ending in a slash due to their trailing slash.
    *
    * @param identifier - Identifier to get the key for.
    *

--- a/src/storage/accessors/AzureBlobDataAccessor.ts
+++ b/src/storage/accessors/AzureBlobDataAccessor.ts
@@ -1,0 +1,385 @@
+import type { Readable } from 'node:stream';
+import { BlobServiceClient, RestError } from '@azure/storage-blob';
+import type { BlobDownloadResponseParsed, ContainerClient } from '@azure/storage-blob';
+import type { Representation } from '../../http/representation/Representation';
+import { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
+import { getLoggerFor } from '../../logging/LogUtil';
+import { TEXT_TURTLE } from '../../util/ContentTypes';
+import { createErrorMessage } from '../../util/errors/ErrorUtil';
+import { NotFoundHttpError } from '../../util/errors/NotFoundHttpError';
+import { UnsupportedMediaTypeHttpError } from '../../util/errors/UnsupportedMediaTypeHttpError';
+import { guardStream } from '../../util/GuardedStream';
+import type { Guarded } from '../../util/GuardedStream';
+import type { IdentifierStrategy } from '../../util/identifiers/IdentifierStrategy';
+import { isContainerIdentifier } from '../../util/PathUtil';
+import { parseQuads, serializeQuads } from '../../util/QuadUtil';
+import { addResourceMetadata, updateModifiedDate } from '../../util/ResourceUtil';
+import { toLiteral } from '../../util/TermUtil';
+import { CONTENT_TYPE_TERM, DC, LDP, POSIX, RDF, SOLID_META, XSD } from '../../util/Vocabularies';
+import type { DataAccessor } from './DataAccessor';
+
+/**
+ * The suffix used for metadata companion blobs.
+ * This matches the auxiliary suffix used by the metadata strategy,
+ * which prevents users from creating resources with this suffix directly at the store level,
+ * so companion blobs can never collide with user resources.
+ */
+const METADATA_SUFFIX = '.meta';
+
+/**
+ * The subset of the properties returned by Azure Blob Storage that is used to generate metadata.
+ */
+interface AzureBlobProperties {
+  contentType?: string;
+  contentLength?: number;
+  lastModified?: Date;
+}
+
+/**
+ * DataAccessor that stores documents and containers as blobs in an Azure Blob Storage container.
+ *
+ * Blob keys are the full resource URLs,
+ * similarly to how the {@link SparqlDataAccessor} uses resource URLs as graph names.
+ * This is the simplest robust mapping as it requires no base URL variable,
+ * while `listBlobsByHierarchy` with a `/` delimiter still works since URLs are `/`-hierarchical.
+ *
+ * Containers are stored as empty marker blobs whose key is the container URL itself (ending in a slash),
+ * so empty containers remain visible.
+ * Additional metadata of a resource is persisted in a companion blob with the `.meta` suffix appended to its key.
+ * Since that suffix matches the auxiliary suffix of the metadata strategy,
+ * which blocks direct writes to such identifiers at the store level,
+ * no collisions between companion blobs and user resources are possible.
+ *
+ * Note that this class implements {@link DataAccessor} but not {@link AtomicDataAccessor}:
+ * blobs are overwritten in place so a failed call can leave a partially updated state behind.
+ * Consequently, this accessor cannot be wrapped by the quota-related {@link ValidatingDataAccessor}
+ * and {@link PassthroughDataAccessor} wrappers, as those require an atomic accessor.
+ */
+export class AzureBlobDataAccessor implements DataAccessor {
+  protected readonly logger = getLoggerFor(this);
+
+  private readonly containerClient: ContainerClient;
+  private readonly identifierStrategy: IdentifierStrategy;
+
+  /**
+   * @param connectionString - Connection string of the Azure Storage account.
+   * @param containerName - Name of the Azure Blob Storage container in which all blobs will be stored.
+   * @param identifierStrategy - Strategy for interpreting the identifiers.
+   */
+  public constructor(connectionString: string, containerName: string, identifierStrategy: IdentifierStrategy) {
+    this.containerClient = BlobServiceClient.fromConnectionString(connectionString)
+      .getContainerClient(containerName);
+    this.identifierStrategy = identifierStrategy;
+  }
+
+  /**
+   * Only binary data can be stored as blobs so will error on non-binary data.
+   */
+  public async canHandle(representation: Representation): Promise<void> {
+    if (!representation.binary) {
+      throw new UnsupportedMediaTypeHttpError('Only binary data is supported.');
+    }
+  }
+
+  /**
+   * Returns the data stream of the blob corresponding to the resource.
+   * Will throw a NotFoundHttpError if the input is a container.
+   */
+  public async getData(identifier: ResourceIdentifier): Promise<Guarded<Readable>> {
+    if (isContainerIdentifier(identifier)) {
+      throw new NotFoundHttpError();
+    }
+    const response = await this.downloadBlob(this.getBlobKey(identifier));
+    return guardStream(response.readableStreamBody as Readable);
+  }
+
+  /**
+   * Will return the corresponding metadata by reading the metadata companion blob (if it exists)
+   * and adding blob-specific metadata elements generated from the blob properties.
+   * Containers are only found if their marker blob exists,
+   * so a document identifier of a stored container will result in a 404 and vice versa.
+   */
+  public async getMetadata(identifier: ResourceIdentifier): Promise<RepresentationMetadata> {
+    const properties = await this.getBlobProperties(this.getBlobKey(identifier));
+    const isContainer = isContainerIdentifier(identifier);
+
+    const metadata = await this.getRawMetadata(identifier);
+    addResourceMetadata(metadata, isContainer);
+    this.addBlobMetadata(metadata, properties, isContainer);
+    // Containers have no content type. For documents the value stored in the blob properties is used.
+    if (!isContainer) {
+      metadata.set(CONTENT_TYPE_TERM, properties.contentType);
+    }
+    return metadata;
+  }
+
+  /**
+   * Generates metadata for all children of the container
+   * by listing the blobs directly below the container key.
+   * The listing transparently pages through all results.
+   * Marker blobs and metadata companion blobs are not children and will be skipped.
+   */
+  public async* getChildren(identifier: ResourceIdentifier): AsyncIterableIterator<RepresentationMetadata> {
+    // Documents have no children
+    if (!isContainerIdentifier(identifier)) {
+      return;
+    }
+    const prefix = this.getBlobKey(identifier);
+    for await (const child of this.containerClient.listBlobsByHierarchy('/', { prefix })) {
+      if (child.kind === 'prefix') {
+        // Blob prefixes correspond to child containers and already have a trailing slash
+        const metadata = new RepresentationMetadata({ path: child.name });
+        addResourceMetadata(metadata, true);
+        yield metadata;
+      } else if (!child.name.endsWith('/') && !AzureBlobDataAccessor.isMetadataKey(child.name)) {
+        // Blob items correspond to child documents,
+        // excluding container marker blobs and metadata companion blobs
+        const metadata = new RepresentationMetadata({ path: child.name });
+        addResourceMetadata(metadata, false);
+        this.addBlobMetadata(metadata, child.properties, false);
+        yield metadata;
+      }
+    }
+  }
+
+  /**
+   * Writes the given data as a blob (and potential metadata as a companion blob).
+   * The companion blob will be written first and will be deleted if something goes wrong writing the data.
+   */
+  public async writeDocument(identifier: ResourceIdentifier, data: Guarded<Readable>, metadata: RepresentationMetadata):
+  Promise<void> {
+    const key = this.getBlobKey(identifier);
+    // The content type needs to be extracted before writing the metadata as it gets removed there
+    const { contentType } = metadata;
+
+    const wroteMetadata = await this.writeMetadataBlob(identifier, metadata);
+
+    try {
+      await this.containerClient.getBlockBlobClient(key)
+        .uploadStream(data, undefined, undefined, { blobHTTPHeaders: { blobContentType: contentType }});
+    } catch (error: unknown) {
+      // Delete the metadata if there was an error writing the data
+      if (wroteMetadata) {
+        await this.containerClient.getBlobClient(this.getMetadataKey(identifier)).deleteIfExists();
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Creates or overwrites the marker blob of the container and writes metadata to its companion blob if necessary.
+   * Since there is no parent logic needed, this also works for root containers.
+   */
+  public async writeContainer(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
+    const key = this.getBlobKey(identifier);
+    // An empty marker blob keeps (empty) containers visible
+    await this.containerClient.getBlockBlobClient(key).upload('', 0);
+
+    await this.writeMetadataBlob(identifier, metadata);
+  }
+
+  /**
+   * Replaces the contents of the metadata companion blob.
+   */
+  public async writeMetadata(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
+    await this.writeMetadataBlob(identifier, metadata);
+  }
+
+  /**
+   * Removes the corresponding blob (or marker blob for containers) and its companion blob.
+   */
+  public async deleteResource(identifier: ResourceIdentifier): Promise<void> {
+    await this.deleteBlob(this.getMetadataKey(identifier));
+
+    if (!await this.deleteBlob(this.getBlobKey(identifier))) {
+      throw new NotFoundHttpError();
+    }
+  }
+
+  /**
+   * Writes the metadata of the resource to a companion blob.
+   * If no metadata needs to be stored, a (potentially) existing companion blob is deleted instead.
+   *
+   * @param identifier - Identifier of the resource (not the metadata!).
+   * @param metadata - Metadata to write.
+   *
+   * @returns True if data was written to a companion blob.
+   */
+  protected async writeMetadataBlob(identifier: ResourceIdentifier, metadata: RepresentationMetadata):
+  Promise<boolean> {
+    // These are stored by the blob properties or generated when reading
+    metadata.remove(RDF.terms.type, LDP.terms.Resource);
+    metadata.remove(RDF.terms.type, LDP.terms.Container);
+    metadata.remove(RDF.terms.type, LDP.terms.BasicContainer);
+    metadata.removeAll(DC.terms.modified);
+    metadata.removeAll(CONTENT_TYPE_TERM);
+    const quads = metadata.quads();
+    const key = this.getMetadataKey(identifier);
+
+    // Write metadata to a companion blob if there are quads remaining
+    if (quads.length > 0) {
+      const serializedMetadata = serializeQuads(quads, TEXT_TURTLE);
+      await this.containerClient.getBlockBlobClient(key)
+        .uploadStream(serializedMetadata, undefined, undefined, { blobHTTPHeaders: { blobContentType: TEXT_TURTLE }});
+      return true;
+    }
+
+    // Delete a (potentially) existing companion blob if no metadata needs to be stored
+    await this.containerClient.getBlobClient(key).deleteIfExists();
+    return false;
+  }
+
+  /**
+   * Reads the metadata from the corresponding companion blob.
+   * Returns empty metadata if there is no companion blob.
+   *
+   * @param identifier - Identifier of the resource (not the metadata!).
+   */
+  private async getRawMetadata(identifier: ResourceIdentifier): Promise<RepresentationMetadata> {
+    try {
+      const response = await this.downloadBlob(this.getMetadataKey(identifier));
+      const readMetadataStream = guardStream(response.readableStreamBody as Readable);
+      const quads = await parseQuads(readMetadataStream, { format: TEXT_TURTLE, baseIRI: identifier.path });
+      const metadata = new RepresentationMetadata(identifier).addQuads(quads);
+
+      // Already add modified date of the companion blob.
+      // Final modified date should be max of data and metadata.
+      if (response.lastModified) {
+        updateModifiedDate(metadata, response.lastModified);
+      }
+
+      return metadata;
+    } catch (error: unknown) {
+      // Companion blob doesn't exist so return empty metadata
+      if (!NotFoundHttpError.isInstance(error)) {
+        throw error;
+      }
+      return new RepresentationMetadata(identifier);
+    }
+  }
+
+  /**
+   * Helper function to add metadata generated from the blob properties.
+   *
+   * @param metadata - Metadata object to add to.
+   * @param properties - Blob properties of the blob corresponding to the resource.
+   * @param isContainer - Whether the metadata corresponds to a container.
+   */
+  private addBlobMetadata(metadata: RepresentationMetadata, properties: AzureBlobProperties, isContainer: boolean):
+  void {
+    const { contentLength, lastModified } = properties;
+    if (lastModified) {
+      // Make sure the last modified date is the max of the data and metadata modified date
+      const modified = new Date(metadata.get(DC.terms.modified)?.value ?? 0);
+      if (modified < lastModified) {
+        updateModifiedDate(metadata, lastModified);
+      }
+      metadata.add(
+        POSIX.terms.mtime,
+        toLiteral(Math.floor(lastModified.getTime() / 1000), XSD.terms.integer),
+        SOLID_META.terms.ResponseMetadata,
+      );
+    }
+    if (!isContainer && typeof contentLength === 'number') {
+      metadata.add(POSIX.terms.size, toLiteral(contentLength, XSD.terms.integer), SOLID_META.terms.ResponseMetadata);
+    }
+  }
+
+  /**
+   * Downloads the blob with the given key.
+   *
+   * @param key - Key of the blob.
+   *
+   * @throws NotFoundHttpError
+   * If the blob does not exist.
+   */
+  private async downloadBlob(key: string): Promise<BlobDownloadResponseParsed> {
+    try {
+      return await this.containerClient.getBlobClient(key).download();
+    } catch (error: unknown) {
+      this.handleAzureError(error);
+    }
+  }
+
+  /**
+   * Gets the properties of the blob with the given key.
+   *
+   * @param key - Key of the blob.
+   *
+   * @throws NotFoundHttpError
+   * If the blob does not exist.
+   */
+  private async getBlobProperties(key: string): Promise<AzureBlobProperties> {
+    try {
+      return await this.containerClient.getBlobClient(key).getProperties();
+    } catch (error: unknown) {
+      this.handleAzureError(error);
+    }
+  }
+
+  /**
+   * Deletes the blob with the given key if it exists.
+   *
+   * @param key - Key of the blob.
+   *
+   * @returns Whether the blob existed.
+   */
+  private async deleteBlob(key: string): Promise<boolean> {
+    try {
+      const { succeeded } = await this.containerClient.getBlobClient(key).deleteIfExists();
+      return succeeded;
+    } catch (error: unknown) {
+      this.handleAzureError(error);
+    }
+  }
+
+  /**
+   * Interprets an error thrown by the Azure SDK.
+   * {@link RestError}s indicating a missing blob are converted to a {@link NotFoundHttpError},
+   * all other errors are thrown again as-is.
+   *
+   * @param error - Error thrown by the Azure SDK.
+   */
+  private handleAzureError(error: unknown): never {
+    if (error instanceof RestError && (error.statusCode === 404 || error.code === 'BlobNotFound')) {
+      throw new NotFoundHttpError('', { cause: error });
+    }
+    this.logger.error(`Unexpected Azure Blob Storage error: ${createErrorMessage(error)}`);
+    throw error;
+  }
+
+  /**
+   * Determines the blob key corresponding to the given identifier.
+   * Keys are the full resource URLs, with container keys ending in a slash due to their trailing slash.
+   *
+   * @param identifier - Identifier to get the key for.
+   *
+   * @throws NotFoundHttpError
+   * If the identifier is not supported by the identifier strategy.
+   */
+  private getBlobKey(identifier: ResourceIdentifier): string {
+    if (!this.identifierStrategy.supportsIdentifier(identifier)) {
+      throw new NotFoundHttpError();
+    }
+    return identifier.path;
+  }
+
+  /**
+   * Determines the key of the metadata companion blob corresponding to the given identifier.
+   *
+   * @param identifier - Identifier to get the metadata key for.
+   */
+  private getMetadataKey(identifier: ResourceIdentifier): string {
+    return `${this.getBlobKey(identifier)}${METADATA_SUFFIX}`;
+  }
+
+  /**
+   * Checks if the given key corresponds to a metadata companion blob.
+   *
+   * @param key - Key to check.
+   */
+  private static isMetadataKey(key: string): boolean {
+    return key.endsWith(METADATA_SUFFIX);
+  }
+}

--- a/test/unit/storage/accessors/AzureBlobDataAccessor.test.ts
+++ b/test/unit/storage/accessors/AzureBlobDataAccessor.test.ts
@@ -1,0 +1,653 @@
+import 'jest-rdf';
+import { Readable } from 'node:stream';
+import { BlobServiceClient, RestError } from '@azure/storage-blob';
+import { DataFactory } from 'n3';
+import type { Representation } from '../../../../src/http/representation/Representation';
+import { RepresentationMetadata } from '../../../../src/http/representation/RepresentationMetadata';
+import { AzureBlobDataAccessor } from '../../../../src/storage/accessors/AzureBlobDataAccessor';
+import { BasicETagHandler } from '../../../../src/storage/conditions/BasicETagHandler';
+import { APPLICATION_OCTET_STREAM } from '../../../../src/util/ContentTypes';
+import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
+import { UnsupportedMediaTypeHttpError } from '../../../../src/util/errors/UnsupportedMediaTypeHttpError';
+import type { Guarded } from '../../../../src/util/GuardedStream';
+import { SingleRootIdentifierStrategy } from '../../../../src/util/identifiers/SingleRootIdentifierStrategy';
+import { guardedStreamFrom, readableToString } from '../../../../src/util/StreamUtil';
+import { toLiteral } from '../../../../src/util/TermUtil';
+import { CONTENT_TYPE, DC, LDP, POSIX, RDF, SOLID_META, XSD } from '../../../../src/util/Vocabularies';
+
+const { namedNode, quad } = DataFactory;
+
+jest.mock('@azure/storage-blob', (): any => ({
+  BlobServiceClient: {
+    fromConnectionString: jest.fn(),
+  },
+  // The real class is needed so `instanceof` checks and error fields keep working
+  RestError: jest.requireActual('@azure/storage-blob').RestError,
+}));
+
+const now = new Date();
+
+/**
+ * The contents and properties of a fake blob.
+ */
+interface BlobEntry {
+  content: string;
+  contentType?: string;
+  contentLength?: number;
+  lastModified?: Date;
+}
+
+// In-memory state representing the blobs stored in the mocked Azure container
+let blobs: Map<string, BlobEntry>;
+// Can be used to make specific operations fail, with keys of the form `<operation>:<blobName>`
+let failures: Map<string, Error>;
+let blobClients: Map<string, any>;
+let blockBlobClients: Map<string, any>;
+
+function throwFailure(key: string): void {
+  const failure = failures.get(key);
+  if (failure) {
+    throw failure;
+  }
+}
+
+function createBlobClient(name: string): any {
+  return {
+    download: jest.fn(async(): Promise<any> => {
+      throwFailure(`download:${name}`);
+      const entry = blobs.get(name);
+      if (!entry) {
+        throw new RestError('The specified blob does not exist.', { statusCode: 404, code: 'BlobNotFound' });
+      }
+      return { readableStreamBody: Readable.from([ entry.content ]), lastModified: entry.lastModified };
+    }),
+    getProperties: jest.fn(async(): Promise<any> => {
+      throwFailure(`getProperties:${name}`);
+      const entry = blobs.get(name);
+      if (!entry) {
+        throw new RestError('The specified blob does not exist.', { statusCode: 404, code: 'BlobNotFound' });
+      }
+      return { contentType: entry.contentType, contentLength: entry.contentLength, lastModified: entry.lastModified };
+    }),
+    deleteIfExists: jest.fn(async(): Promise<any> => {
+      throwFailure(`delete:${name}`);
+      return { succeeded: blobs.delete(name) };
+    }),
+  };
+}
+
+function createBlockBlobClient(name: string): any {
+  return {
+    upload: jest.fn(async(body: string, contentLength: number): Promise<void> => {
+      throwFailure(`upload:${name}`);
+      blobs.set(name, { content: body, contentLength, lastModified: now });
+    }),
+    uploadStream: jest.fn(async(stream: Readable, bufferSize?: number, maxConcurrency?: number, options?: any):
+    Promise<void> => {
+      throwFailure(`upload:${name}`);
+      const content = await readableToString(stream);
+      blobs.set(name, {
+        content,
+        contentType: options?.blobHTTPHeaders?.blobContentType,
+        contentLength: content.length,
+        lastModified: now,
+      });
+    }),
+  };
+}
+
+function getBlobClientMock(name: string): any {
+  let client = blobClients.get(name);
+  if (!client) {
+    client = createBlobClient(name);
+    blobClients.set(name, client);
+  }
+  return client;
+}
+
+function getBlockBlobClientMock(name: string): any {
+  let client = blockBlobClients.get(name);
+  if (!client) {
+    client = createBlockBlobClient(name);
+    blockBlobClients.set(name, client);
+  }
+  return client;
+}
+
+/**
+ * Mimics the result of `listBlobsByHierarchy` with a `/` delimiter for the stored fake blobs.
+ */
+async function* listHierarchy(prefix: string): AsyncIterableIterator<any> {
+  const prefixes = new Set<string>();
+  for (const [ name, entry ] of blobs) {
+    if (!name.startsWith(prefix)) {
+      continue;
+    }
+    const remainder = name.slice(prefix.length);
+    const slashIndex = remainder.indexOf('/');
+    if (slashIndex >= 0) {
+      prefixes.add(name.slice(0, prefix.length + slashIndex + 1));
+    } else {
+      yield {
+        kind: 'blob',
+        name,
+        properties: {
+          contentType: entry.contentType,
+          contentLength: entry.contentLength,
+          lastModified: entry.lastModified,
+        },
+      };
+    }
+  }
+  for (const name of prefixes) {
+    yield { kind: 'prefix', name };
+  }
+}
+
+describe('An AzureBlobDataAccessor', (): void => {
+  const base = 'http://test.com/';
+  const connectionString = 'UseDevelopmentStorage=true';
+  const containerName = 'solid';
+  const identifierStrategy = new SingleRootIdentifierStrategy(base);
+  let containerClient: {
+    getBlobClient: jest.Mock;
+    getBlockBlobClient: jest.Mock;
+    listBlobsByHierarchy: jest.Mock;
+  };
+  let getContainerClient: jest.Mock;
+  let accessor: AzureBlobDataAccessor;
+  let metadata: RepresentationMetadata;
+  let data: Guarded<Readable>;
+
+  beforeEach(async(): Promise<void> => {
+    blobs = new Map();
+    failures = new Map();
+    blobClients = new Map();
+    blockBlobClients = new Map();
+
+    containerClient = {
+      getBlobClient: jest.fn(getBlobClientMock),
+      getBlockBlobClient: jest.fn(getBlockBlobClientMock),
+      listBlobsByHierarchy: jest.fn(
+        (delimiter: string, options?: { prefix?: string }): AsyncIterableIterator<any> =>
+          listHierarchy(options?.prefix ?? ''),
+      ),
+    };
+    getContainerClient = jest.fn().mockReturnValue(containerClient);
+    jest.mocked(BlobServiceClient.fromConnectionString).mockClear();
+    jest.mocked(BlobServiceClient.fromConnectionString).mockReturnValue({ getContainerClient } as any);
+
+    accessor = new AzureBlobDataAccessor(connectionString, containerName, identifierStrategy);
+
+    metadata = new RepresentationMetadata(APPLICATION_OCTET_STREAM);
+    data = guardedStreamFrom([ 'data' ]);
+  });
+
+  it('creates a client for the configured account and container.', async(): Promise<void> => {
+    expect(BlobServiceClient.fromConnectionString).toHaveBeenCalledTimes(1);
+    expect(BlobServiceClient.fromConnectionString).toHaveBeenCalledWith(connectionString);
+    expect(getContainerClient).toHaveBeenCalledTimes(1);
+    expect(getContainerClient).toHaveBeenCalledWith(containerName);
+  });
+
+  it('can only handle binary data.', async(): Promise<void> => {
+    await expect(accessor.canHandle({ binary: true } as Representation)).resolves.toBeUndefined();
+    const result = accessor.canHandle({ binary: false } as Representation);
+    await expect(result).rejects.toThrow(UnsupportedMediaTypeHttpError);
+    await expect(result).rejects.toThrow('Only binary data is supported.');
+  });
+
+  describe('getting data', (): void => {
+    it('throws a 404 if the identifier is not supported.', async(): Promise<void> => {
+      await expect(accessor.getData({ path: 'http://wrong.com/resource' })).rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('throws a 404 if the identifier does not match an existing blob.', async(): Promise<void> => {
+      await expect(accessor.getData({ path: `${base}resource` })).rejects.toThrow(NotFoundHttpError);
+      expect(getBlobClientMock(`${base}resource`).download).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws a 404 if the identifier matches a container.', async(): Promise<void> => {
+      blobs.set(`${base}container/`, { content: '', lastModified: now });
+      await expect(accessor.getData({ path: `${base}container/` })).rejects.toThrow(NotFoundHttpError);
+      expect(containerClient.getBlobClient).toHaveBeenCalledTimes(0);
+    });
+
+    it('returns the corresponding data.', async(): Promise<void> => {
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata)).resolves.toBeUndefined();
+      const stream = await accessor.getData({ path: `${base}resource` });
+      await expect(readableToString(stream)).resolves.toBe('data');
+      expect(getBlobClientMock(`${base}resource`).download).toHaveBeenCalledTimes(1);
+    });
+
+    it('converts 404 errors that only have a BlobNotFound code.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      failures.set(`download:${base}resource`, new RestError('no blob', { code: 'BlobNotFound' }));
+      await expect(accessor.getData({ path: `${base}resource` })).rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('propagates other errors when reading data.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      failures.set(`download:${base}resource`, new RestError('server error', { statusCode: 500 }));
+      await expect(accessor.getData({ path: `${base}resource` })).rejects.toThrow('server error');
+
+      failures.set(`download:${base}resource`, new Error('fatal'));
+      await expect(accessor.getData({ path: `${base}resource` })).rejects.toThrow('fatal');
+    });
+  });
+
+  describe('getting metadata', (): void => {
+    it('throws a 404 if the identifier does not match an existing blob.', async(): Promise<void> => {
+      await expect(accessor.getMetadata({ path: `${base}resource` })).rejects.toThrow(NotFoundHttpError);
+      await expect(accessor.getMetadata({ path: `${base}container/` })).rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('throws a 404 if the trailing slash does not match its type.', async(): Promise<void> => {
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata)).resolves.toBeUndefined();
+      await expect(accessor.getMetadata({ path: `${base}resource/` })).rejects.toThrow(NotFoundHttpError);
+      await expect(accessor.writeContainer({ path: `${base}container/` }, metadata)).resolves.toBeUndefined();
+      await expect(accessor.getMetadata({ path: `${base}container` })).rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('generates the metadata for a document.', async(): Promise<void> => {
+      blobs.set(
+        `${base}resource`,
+        { content: 'data', contentType: 'text/turtle', contentLength: 4, lastModified: now },
+      );
+      metadata = await accessor.getMetadata({ path: `${base}resource` });
+      expect(metadata.identifier.value).toBe(`${base}resource`);
+      expect(metadata.contentType).toBe('text/turtle');
+      expect(metadata.get(RDF.terms.type)?.value).toBe(LDP.Resource);
+      expect(metadata.get(POSIX.terms.size)).toEqualRdfTerm(toLiteral(4, XSD.terms.integer));
+      expect(metadata.get(DC.terms.modified)).toEqualRdfTerm(toLiteral(now.toISOString(), XSD.terms.dateTime));
+      expect(metadata.get(POSIX.terms.mtime))
+        .toEqualRdfTerm(toLiteral(Math.floor(now.getTime() / 1000), XSD.terms.integer));
+      // `dc:modified` is in the default graph
+      expect(metadata.quads(null, null, null, SOLID_META.terms.ResponseMetadata)).toHaveLength(2);
+    });
+
+    it('provides the required metadata for generating ETags.', async(): Promise<void> => {
+      blobs.set(
+        `${base}resource`,
+        { content: 'data', contentType: 'text/turtle', contentLength: 4, lastModified: now },
+      );
+      metadata = await accessor.getMetadata({ path: `${base}resource` });
+      expect(metadata.get(DC.terms.modified)).toBeDefined();
+      expect(metadata.contentType).toBeDefined();
+      expect(new BasicETagHandler().getETag(metadata)).toBe(`"${now.getTime()}-text/turtle"`);
+    });
+
+    it('generates the metadata for a container.', async(): Promise<void> => {
+      blobs.set(`${base}container/`, { content: '', contentLength: 0, lastModified: now });
+      metadata = await accessor.getMetadata({ path: `${base}container/` });
+      expect(metadata.identifier.value).toBe(`${base}container/`);
+      expect(metadata.getAll(RDF.terms.type)).toEqualRdfTermArray(
+        [ LDP.terms.Container, LDP.terms.BasicContainer, LDP.terms.Resource ],
+      );
+      expect(metadata.contentType).toBeUndefined();
+      expect(metadata.get(POSIX.terms.size)).toBeUndefined();
+      expect(metadata.get(DC.terms.modified)).toEqualRdfTerm(toLiteral(now.toISOString(), XSD.terms.dateTime));
+      // `dc:modified` is in the default graph
+      expect(metadata.quads(null, null, null, SOLID_META.terms.ResponseMetadata)).toHaveLength(1);
+    });
+
+    it('does not add timestamps or a size if the blob has no such properties.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data' });
+      metadata = await accessor.getMetadata({ path: `${base}resource` });
+      expect(metadata.contentType).toBeUndefined();
+      expect(metadata.get(DC.terms.modified)).toBeUndefined();
+      expect(metadata.get(POSIX.terms.mtime)).toBeUndefined();
+      expect(metadata.get(POSIX.terms.size)).toBeUndefined();
+    });
+
+    it('adds stored metadata when requesting document metadata.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      blobs.set(`${base}resource.meta`, { content: '<http://this> <http://is> <http://metadata>.', lastModified: now });
+      metadata = await accessor.getMetadata({ path: `${base}resource` });
+      expect(metadata.quads().some((entry): boolean => entry.subject.value === 'http://this')).toBe(true);
+    });
+
+    it('adds stored metadata when requesting container metadata.', async(): Promise<void> => {
+      blobs.set(`${base}container/`, { content: '', lastModified: now });
+      blobs.set(
+        `${base}container/.meta`,
+        { content: '<http://this> <http://is> <http://metadata>.', lastModified: now },
+      );
+      metadata = await accessor.getMetadata({ path: `${base}container/` });
+      expect(metadata.quads().some((entry): boolean => entry.subject.value === 'http://this')).toBe(true);
+    });
+
+    it('uses the metadata blob date if it is more recent.', async(): Promise<void> => {
+      const later = new Date(now.getTime() + 60000);
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      blobs.set(
+        `${base}resource.meta`,
+        { content: '<http://this> <http://is> <http://metadata>.', lastModified: later },
+      );
+      metadata = await accessor.getMetadata({ path: `${base}resource` });
+      expect(metadata.get(DC.terms.modified)).toEqualRdfTerm(toLiteral(later.toISOString(), XSD.terms.dateTime));
+    });
+
+    it('ignores the metadata blob date if it has none.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      blobs.set(`${base}resource.meta`, { content: '<http://this> <http://is> <http://metadata>.' });
+      metadata = await accessor.getMetadata({ path: `${base}resource` });
+      expect(metadata.get(DC.terms.modified)).toEqualRdfTerm(toLiteral(now.toISOString(), XSD.terms.dateTime));
+    });
+
+    it('throws an error if the metadata blob contains invalid data.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      blobs.set(`${base}resource.meta`, { content: 'invalid metadata!.', lastModified: now });
+      await expect(accessor.getMetadata({ path: `${base}resource` }))
+        .rejects.toThrow('Unexpected "invalid" on line 1.');
+    });
+
+    it('propagates other errors when requesting metadata.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      failures.set(`getProperties:${base}resource`, new RestError('server error', { statusCode: 500 }));
+      await expect(accessor.getMetadata({ path: `${base}resource` })).rejects.toThrow('server error');
+    });
+  });
+
+  describe('getting children', (): void => {
+    it('yields nothing for documents.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      const children = [];
+      for await (const child of accessor.getChildren({ path: `${base}resource` })) {
+        children.push(child);
+      }
+      expect(children).toHaveLength(0);
+      expect(containerClient.listBlobsByHierarchy).toHaveBeenCalledTimes(0);
+    });
+
+    it('throws a 404 if the identifier is not supported.', async(): Promise<void> => {
+      const children = accessor.getChildren({ path: 'http://wrong.com/container/' });
+      await expect(children.next()).rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('generates the children for a container.', async(): Promise<void> => {
+      blobs.set(`${base}container/`, { content: '', lastModified: now });
+      blobs.set(`${base}container/.meta`, { content: 'meta', lastModified: now });
+      blobs.set(
+        `${base}container/resource`,
+        { content: 'data', contentType: 'text/turtle', contentLength: 4, lastModified: now },
+      );
+      blobs.set(`${base}container/resource.meta`, { content: 'meta', lastModified: now });
+      blobs.set(`${base}container/sub/`, { content: '', lastModified: now });
+      blobs.set(`${base}container/sub/deep`, { content: 'data', lastModified: now });
+
+      const children = [];
+      for await (const child of accessor.getChildren({ path: `${base}container/` })) {
+        children.push(child);
+      }
+      expect(children).toHaveLength(2);
+      expect(new Set(children.map((child): string => child.identifier.value))).toEqual(new Set([
+        `${base}container/resource`,
+        `${base}container/sub/`,
+      ]));
+
+      const document = children.find((child): boolean => !child.identifier.value.endsWith('/'))!;
+      const documentTypes = document.getAll(RDF.terms.type).map((term): string => term.value);
+      expect(documentTypes).toContain(LDP.Resource);
+      expect(documentTypes).not.toContain(LDP.Container);
+      expect(document.get(DC.terms.modified)).toEqualRdfTerm(toLiteral(now.toISOString(), XSD.terms.dateTime));
+      expect(document.get(POSIX.terms.mtime))
+        .toEqualRdfTerm(toLiteral(Math.floor(now.getTime() / 1000), XSD.terms.integer));
+      expect(document.get(POSIX.terms.size)).toEqualRdfTerm(toLiteral(4, XSD.terms.integer));
+      // `dc:modified` is in the default graph
+      expect(document.quads(null, null, null, SOLID_META.terms.ResponseMetadata)).toHaveLength(2);
+
+      const container = children.find((child): boolean => child.identifier.value.endsWith('/'))!;
+      const containerTypes = container.getAll(RDF.terms.type).map((term): string => term.value);
+      expect(containerTypes).toContain(LDP.Resource);
+      expect(containerTypes).toContain(LDP.Container);
+      expect(containerTypes).toContain(LDP.BasicContainer);
+      expect(container.get(DC.terms.modified)).toBeUndefined();
+
+      expect(containerClient.listBlobsByHierarchy).toHaveBeenCalledTimes(1);
+      expect(containerClient.listBlobsByHierarchy).toHaveBeenCalledWith('/', { prefix: `${base}container/` });
+    });
+
+    it('handles listings that span multiple pages.', async(): Promise<void> => {
+      const prefix = `${base}container/`;
+      containerClient.listBlobsByHierarchy.mockImplementation((): AsyncIterableIterator<any> =>
+        (async function* (): AsyncIterableIterator<any> {
+          // First page, including the marker blob of the container itself and a companion blob
+          yield { kind: 'blob', name: prefix, properties: { lastModified: now, contentLength: 0 }};
+          yield { kind: 'blob', name: `${prefix}doc1`, properties: { lastModified: now, contentLength: 4 }};
+          yield { kind: 'blob', name: `${prefix}doc1.meta`, properties: { lastModified: now, contentLength: 9 }};
+          await Promise.resolve();
+          // Second page, including a stray marker blob
+          yield { kind: 'prefix', name: `${prefix}sub/` };
+          yield { kind: 'blob', name: `${prefix}doc2`, properties: { lastModified: now, contentLength: 4 }};
+          yield { kind: 'blob', name: `${prefix}stray/`, properties: { lastModified: now, contentLength: 0 }};
+        })());
+
+      const children = [];
+      for await (const child of accessor.getChildren({ path: prefix })) {
+        children.push(child);
+      }
+      expect(children).toHaveLength(3);
+      expect(children.map((child): string => child.identifier.value)).toEqual([
+        `${prefix}doc1`,
+        `${prefix}sub/`,
+        `${prefix}doc2`,
+      ]);
+      expect(containerClient.listBlobsByHierarchy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('writing a document', (): void => {
+    it('throws a 404 if the identifier is not supported.', async(): Promise<void> => {
+      await expect(accessor.writeDocument({ path: 'http://wrong.com/resource' }, data, metadata))
+        .rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('writes the data to the corresponding blob.', async(): Promise<void> => {
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata)).resolves.toBeUndefined();
+      expect(blobs.get(`${base}resource`)?.content).toBe('data');
+      expect(blobs.get(`${base}resource`)?.contentType).toBe(APPLICATION_OCTET_STREAM);
+      expect(blobs.has(`${base}resource.meta`)).toBe(false);
+      const blockBlobClient = getBlockBlobClientMock(`${base}resource`);
+      expect(blockBlobClient.uploadStream).toHaveBeenCalledTimes(1);
+      expect(blockBlobClient.uploadStream).toHaveBeenCalledWith(
+        data,
+        undefined,
+        undefined,
+        { blobHTTPHeaders: { blobContentType: APPLICATION_OCTET_STREAM }},
+      );
+    });
+
+    it('writes metadata to the corresponding metadata blob before the data.', async(): Promise<void> => {
+      metadata = new RepresentationMetadata(
+        { path: `${base}resource` },
+        { [CONTENT_TYPE]: 'text/turtle', 'http://example.com/likes': 'apples' },
+      );
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata)).resolves.toBeUndefined();
+      expect(blobs.get(`${base}resource`)?.content).toBe('data');
+      expect(blobs.get(`${base}resource`)?.contentType).toBe('text/turtle');
+      const companion = blobs.get(`${base}resource.meta`);
+      expect(companion?.contentType).toBe('text/turtle');
+      expect(companion?.content).toMatch(`<${base}resource> <http://example.com/likes> "apples".`);
+      expect(containerClient.getBlockBlobClient).toHaveBeenCalledTimes(2);
+      expect(containerClient.getBlockBlobClient).toHaveBeenNthCalledWith(1, `${base}resource.meta`);
+      expect(containerClient.getBlockBlobClient).toHaveBeenNthCalledWith(2, `${base}resource`);
+    });
+
+    it('does not write generated metadata to the metadata blob.', async(): Promise<void> => {
+      metadata = new RepresentationMetadata({ path: `${base}resource` }, {
+        [CONTENT_TYPE]: 'text/turtle',
+        [RDF.type]: [ LDP.terms.Resource ],
+        [DC.modified]: toLiteral(now.toISOString(), XSD.terms.dateTime),
+        'http://example.com/likes': 'apples',
+      });
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata)).resolves.toBeUndefined();
+      const content = blobs.get(`${base}resource.meta`)?.content;
+      expect(content?.trim()).toBe(`<${base}resource> <http://example.com/likes> "apples".`);
+    });
+
+    it('does not create a metadata blob if there is only generated metadata.', async(): Promise<void> => {
+      metadata.add(RDF.terms.type, LDP.terms.Resource);
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata)).resolves.toBeUndefined();
+      expect(blobs.has(`${base}resource.meta`)).toBe(false);
+      expect(getBlockBlobClientMock(`${base}resource.meta`).uploadStream).toHaveBeenCalledTimes(0);
+    });
+
+    it('deletes existing metadata if nothing new needs to be stored.', async(): Promise<void> => {
+      blobs.set(`${base}resource.meta`, { content: 'metadata!', lastModified: now });
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata)).resolves.toBeUndefined();
+      expect(blobs.has(`${base}resource.meta`)).toBe(false);
+      expect(getBlobClientMock(`${base}resource.meta`).deleteIfExists).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes the metadata blob if something went wrong writing the data.', async(): Promise<void> => {
+      failures.set(`upload:${base}resource`, new Error('error'));
+      metadata.add(namedNode('http://example.com/likes'), 'apples');
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata)).rejects.toThrow('error');
+      expect(blobs.has(`${base}resource.meta`)).toBe(false);
+      expect(getBlobClientMock(`${base}resource.meta`).deleteIfExists).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not remove the metadata blob if none was written.', async(): Promise<void> => {
+      failures.set(`upload:${base}resource`, new Error('error'));
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata)).rejects.toThrow('error');
+      // Only the deletion of the metadata write step itself, no rollback deletion
+      expect(getBlobClientMock(`${base}resource.meta`).deleteIfExists).toHaveBeenCalledTimes(1);
+      expect(getBlockBlobClientMock(`${base}resource.meta`).uploadStream).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('writing a container', (): void => {
+    it('throws a 404 if the identifier is not supported.', async(): Promise<void> => {
+      await expect(accessor.writeContainer({ path: 'http://wrong.com/container/' }, metadata))
+        .rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('creates a marker blob for the container.', async(): Promise<void> => {
+      await expect(accessor.writeContainer({ path: `${base}container/` }, metadata)).resolves.toBeUndefined();
+      expect(blobs.get(`${base}container/`)?.content).toBe('');
+      expect(blobs.has(`${base}container/.meta`)).toBe(false);
+      const blockBlobClient = getBlockBlobClientMock(`${base}container/`);
+      expect(blockBlobClient.upload).toHaveBeenCalledTimes(1);
+      expect(blockBlobClient.upload).toHaveBeenCalledWith('', 0);
+    });
+
+    it('writes metadata to the corresponding metadata blob.', async(): Promise<void> => {
+      metadata = new RepresentationMetadata({ path: `${base}container/` }, { 'http://example.com/likes': 'apples' });
+      await expect(accessor.writeContainer({ path: `${base}container/` }, metadata)).resolves.toBeUndefined();
+      expect(blobs.get(`${base}container/.meta`)?.content)
+        .toMatch(`<${base}container/> <http://example.com/likes> "apples".`);
+    });
+
+    it('overwrites existing metadata.', async(): Promise<void> => {
+      blobs.set(`${base}container/.meta`, { content: `<${base}container/> <http://example.com/likes> "pears".` });
+      metadata = new RepresentationMetadata({ path: `${base}container/` }, { 'http://example.com/likes': 'apples' });
+      await expect(accessor.writeContainer({ path: `${base}container/` }, metadata)).resolves.toBeUndefined();
+      const content = blobs.get(`${base}container/.meta`)?.content;
+      expect(content).toMatch('"apples"');
+      expect(content).not.toMatch('"pears"');
+    });
+
+    it('can overwrite the metadata of an existing container without overwriting children.', async(): Promise<void> => {
+      const identifier = { path: `${base}container/` };
+      await expect(accessor.writeContainer(identifier, new RepresentationMetadata(identifier)))
+        .resolves.toBeUndefined();
+      await expect(accessor.writeDocument({ path: `${base}container/resource` }, data, metadata))
+        .resolves.toBeUndefined();
+
+      const newMetadata = new RepresentationMetadata(identifier, { 'http://example.com/likes': 'apples' });
+      await expect(accessor.writeContainer(identifier, newMetadata)).resolves.toBeUndefined();
+
+      metadata = await accessor.getMetadata(identifier);
+      expect(metadata.get(namedNode('http://example.com/likes'))?.value).toBe('apples');
+
+      const children = [];
+      for await (const child of accessor.getChildren(identifier)) {
+        children.push(child);
+      }
+      expect(children).toHaveLength(1);
+      expect(children[0].identifier.value).toBe(`${base}container/resource`);
+      await expect(readableToString(await accessor.getData({ path: `${base}container/resource` })))
+        .resolves.toBe('data');
+    });
+
+    it('can write to the root container.', async(): Promise<void> => {
+      metadata = new RepresentationMetadata({ path: base }, { 'http://example.com/likes': 'apples' });
+      await expect(accessor.writeContainer({ path: base }, metadata)).resolves.toBeUndefined();
+      expect(blobs.get(base)?.content).toBe('');
+      expect(blobs.get(`${base}.meta`)?.content).toMatch(`<${base}> <http://example.com/likes> "apples".`);
+    });
+  });
+
+  describe('writing metadata', (): void => {
+    it('writes metadata to the metadata resource.', async(): Promise<void> => {
+      const resourceIdentifier = { path: `${base}resource` };
+      const inputMetadata = new RepresentationMetadata(resourceIdentifier, { [RDF.type]: LDP.terms.Resource });
+      await accessor.writeDocument(resourceIdentifier, data, inputMetadata);
+
+      const extraMetadata = new RepresentationMetadata(resourceIdentifier);
+      extraMetadata.addQuad(namedNode(`${base}a`), namedNode(`${base}b`), namedNode(`${base}c`));
+      await expect(accessor.writeMetadata(resourceIdentifier, extraMetadata)).resolves.toBeUndefined();
+
+      const outputMetadata = await accessor.getMetadata(resourceIdentifier);
+      expect(outputMetadata.quads(`${base}a`))
+        .toStrictEqual([ quad(namedNode(`${base}a`), namedNode(`${base}b`), namedNode(`${base}c`)) ]);
+      // The data itself remains unchanged
+      await expect(readableToString(await accessor.getData(resourceIdentifier))).resolves.toBe('data');
+    });
+  });
+
+  describe('deleting a resource', (): void => {
+    it('throws a 404 if the identifier does not match an existing entry.', async(): Promise<void> => {
+      await expect(accessor.deleteResource({ path: `${base}resource` })).rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('throws a 404 if the trailing slash does not match its type.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      blobs.set(`${base}container/`, { content: '', lastModified: now });
+      await expect(accessor.deleteResource({ path: `${base}resource/` })).rejects.toThrow(NotFoundHttpError);
+      await expect(accessor.deleteResource({ path: `${base}container` })).rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('removes the corresponding blobs.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      blobs.set(`${base}resource.meta`, { content: 'metadata', lastModified: now });
+      blobs.set(`${base}container/`, { content: '', lastModified: now });
+      blobs.set(`${base}container/.meta`, { content: 'metadata', lastModified: now });
+      await expect(accessor.deleteResource({ path: `${base}resource` })).resolves.toBeUndefined();
+      await expect(accessor.deleteResource({ path: `${base}container/` })).resolves.toBeUndefined();
+      expect(blobs.size).toBe(0);
+      expect(getBlobClientMock(`${base}resource`).deleteIfExists).toHaveBeenCalledTimes(1);
+      expect(getBlobClientMock(`${base}resource.meta`).deleteIfExists).toHaveBeenCalledTimes(1);
+      expect(getBlobClientMock(`${base}container/`).deleteIfExists).toHaveBeenCalledTimes(1);
+      expect(getBlobClientMock(`${base}container/.meta`).deleteIfExists).toHaveBeenCalledTimes(1);
+    });
+
+    it('can delete the root container and write to it again.', async(): Promise<void> => {
+      await expect(accessor.writeContainer({ path: base }, metadata)).resolves.toBeUndefined();
+      await expect(accessor.deleteResource({ path: base })).resolves.toBeUndefined();
+      await expect(accessor.getMetadata({ path: base })).rejects.toThrow(NotFoundHttpError);
+      await expect(accessor.writeContainer({ path: base }, new RepresentationMetadata({ path: base })))
+        .resolves.toBeUndefined();
+      metadata = await accessor.getMetadata({ path: base });
+      expect(metadata.getAll(RDF.terms.type)).toEqualRdfTermArray(
+        [ LDP.terms.Container, LDP.terms.BasicContainer, LDP.terms.Resource ],
+      );
+    });
+
+    it('converts 404 errors thrown while deleting.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      failures.set(
+        `delete:${base}resource.meta`,
+        new RestError('gone', { statusCode: 404, code: 'ContainerNotFound' }),
+      );
+      await expect(accessor.deleteResource({ path: `${base}resource` })).rejects.toThrow(NotFoundHttpError);
+    });
+
+    it('propagates other errors thrown while deleting.', async(): Promise<void> => {
+      blobs.set(`${base}resource`, { content: 'data', lastModified: now });
+      failures.set(`delete:${base}resource`, new Error('fatal'));
+      await expect(accessor.deleteResource({ path: `${base}resource` })).rejects.toThrow('fatal');
+    });
+  });
+});


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming; commits are unsigned (the agent has no access to the signing key), re-sign on rebase if wanted.

#### 📁 Related issues

None yet — the upstream template requires a related issue, so a feature-request issue must be opened on CommunitySolidServer/CommunitySolidServer before this is submitted there.

#### ✍️ Description

Adds an **Azure Blob Storage backend** (the Azure equivalent of S3): a new `AzureBlobDataAccessor` plus full configuration wiring, so a server can persist all pod data in a blob container:

```bash
community-solid-server -c @css:config/azure-blob-storage.json \
  --azureBlobConnectionString "<connection string>" --azureBlobContainer <container>
```

Design (each decision follows an existing accessor precedent):

- **Blob keys are full resource URLs** (same as `SparqlDataAccessor`'s graph names) — the simplest robust mapping: no base-URL variable is needed, and hierarchical listing works with the `/` delimiter since URLs are `/`-hierarchical.
- **Documents** are blobs; the content type is stored natively in the blob's `Content-Type` property — none of the file backend's extension-marker encoding is needed, and reads never list directories.
- **Containers** are zero-byte marker blobs whose key is the container URL, so empty containers exist and can hold metadata (the S3-convention answer to flat namespaces). No parent logic is needed, so root containers require no special casing.
- **Custom RDF metadata** lives in `<key>.meta` companion blobs (Turtle). The suffix matches the auxiliary suffix of the metadata strategy, which blocks direct writes to such identifiers at the store level, so companion blobs can never collide with user resources. Server-generated quads (LDP types, `dc:modified`, content type) are stripped before persisting and regenerated on read from native blob properties — mirroring `FileDataAccessor.writeMetadataFile` exactly, including deleting the companion when nothing custom remains and companion-first-with-rollback write ordering.
- `getChildren` streams `listBlobsByHierarchy('/', { prefix })`, which transparently pages (multi-page covered in tests), skipping markers and companions.
- Azure `RestError` 404/`BlobNotFound` maps to `NotFoundHttpError` in exactly the places `DataAccessorBasedStore.getNormalizedMetadata`'s slash disambiguation requires: the trailing slash is part of the key, so a document identifier of a stored container 404s and vice versa.
- Config chain mirrors the SPARQL backend end to end: data-accessor preset, backend store preset (no `RepresentationConvertingStore` — blobs hold binary natively), variables, CLI parameters, shorthand resolvers, and the top-level config (cloned from `sparql-endpoint.json`: pod-based, memory key-value/locker).

Verification:

- **Unit:** 45 tests replicating the `InMemoryDataAccessor` conformance matrix (404s incl. trailing-slash kind mismatches in both directions, metadata round-trips, generated-quad exclusion asserted on serialized companion content, multi-page listing, root lifecycle, error mapping, upload rollback, ETag prerequisites) — 100% coverage on the new class; full `jest.coverage.config.js test/unit` run green; `npm run build` and `npm run lint:eslint` clean.
- **Live end-to-end against Azurite** (Azure's official emulator): account + pod provisioning through the IDP entirely on blobs; Turtle + binary PUT/GET round-trips with correct content types; recursive parent creation; container listings; `ETag`/`Last-Modified` with a working conditional-GET 304; 404s; full delete lifecycle; zero server-log errors. (The only non-obvious status: deleting a non-empty container unauthenticated returns 401 before the 409 emptiness check — correct WebACL semantics, parent Write is required; the 409 path is unit-tested.)

Notes for review:

- **Not an `AtomicDataAccessor`** (blobs are overwritten in place), so it cannot sit under the quota `ValidatingDataAccessor`/`PassthroughDataAccessor` wrappers — noted in the class documentation. Atomicity via write-then-commit or blob leases is a possible follow-up.
- Azurite's current release rejects the SDK's newest API version date; the emulator needs `--skipApiVersionCheck` (or a newer Azurite) — relevant for a future CI job. Suggested follow-up: an integration test gated like `SparqlStorage.test.ts` (`describeIf('docker')`) with an `mcr.microsoft.com/azure-storage/azurite` service container.
- Hierarchical-namespace (ADLS Gen2) accounts may treat `/`-suffixed marker blobs differently; flat-namespace accounts are the intended target.
- Adds `@azure/storage-blob` as a regular dependency (the `ioredis`/`fetch-sparql-endpoint` precedent).
- Still to do before upstream submission: document the two new CLI parameters in `documentation/markdown/usage/starting-server.md` and add an `azure-blob` entry to `config/storage/README.md`, matching the existing backend rows.

This is a backwards-compatible feature addition, so the intended semver level is **semver.minor** (contributors cannot set the label). As a feature it should target the latest `versions/*` branch when submitted upstream, per the contributing guide — this fork PR targets `main` only because the fork carries no versions branch.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
