### PR TITLE
feat: Support JSON logging output

### DIFF
--- a/config/app/variables/cli/cli.json
+++ b/config/app/variables/cli/cli.json
@@ -38,6 +38,15 @@
         },
         {
           "@type": "YargsParameter",
+          "name": "loggingFormat",
+          "options": {
+            "requiresArg": true,
+            "type": "string",
+            "describe": "The format used to output log messages: 'pretty' or 'json'."
+          }
+        },
+        {
+          "@type": "YargsParameter",
           "name": "baseUrl",
           "options": {
             "alias": "b",

--- a/config/app/variables/resolver/resolver.json
+++ b/config/app/variables/resolver/resolver.json
@@ -21,6 +21,14 @@
           }
         },
         {
+          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:loggingFormat",
+          "CombinedShorthandResolver:_resolvers_value": {
+            "@type": "KeyExtractor",
+            "key": "loggingFormat",
+            "defaultValue": "pretty"
+          }
+        },
+        {
           "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:port",
           "CombinedShorthandResolver:_resolvers_value": {
             "@type": "KeyExtractor",

--- a/config/util/logging/winston.json
+++ b/config/util/logging/winston.json
@@ -5,7 +5,8 @@
       "comment": "Uses the winston library for logging",
       "@id": "urn:solid-server:default:LoggerFactory",
       "@type": "WinstonLoggerFactory",
-      "level": { "@id": "urn:solid-server:default:variable:loggingLevel" }
+      "level": { "@id": "urn:solid-server:default:variable:loggingLevel" },
+      "logFormat": { "@id": "urn:solid-server:default:variable:loggingFormat" }
     }
   ]
 }

--- a/config/util/variables/default.json
+++ b/config/util/variables/default.json
@@ -33,6 +33,11 @@
       "@type": "Variable"
     },
     {
+      "comment": "The format used to output log messages: 'pretty' or 'json'.",
+      "@id": "urn:solid-server:default:variable:loggingFormat",
+      "@type": "Variable"
+    },
+    {
       "comment": "Whether error stack traces should be shown in the server responses.",
       "@id": "urn:solid-server:default:variable:showStackTrace",
       "@type": "Variable"

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -56,6 +56,7 @@ to some commonly used settings:
 | `--baseUrl, -b`         | `http://localhost:$PORT/`  | The base URL used internally to generate URLs. Change this if your server does not run on `http://localhost:$PORT/`.                          |
 | `--socket`              |                            | The Unix Domain Socket on which the server should listen. `--baseUrl` must be set if this option is provided                                  |
 | `--loggingLevel, -l`    | `info`                     | The detail level of logging; useful for debugging problems. Use `debug` for full information.                                                 |
+| `--loggingFormat`       | `pretty`                   | The format used to output log messages: `pretty` for human-readable colorized lines, or `json` for a line of JSON per message.                |
 | `--config, -c`          | `@css:config/default.json` | The configuration(s) for the server. The default only stores data in memory; to persist to your filesystem, use `@css:config/file.json`       |
 | `--rootFilePath, -f`    | `./`                       | Root folder where the server stores data, when using a file-based configuration.                                                              |
 | `--sparqlEndpoint, -s`  |                            | URL of the SPARQL endpoint, when using a quadstore-based configuration.                                                                       |

--- a/src/logging/WinstonLoggerFactory.ts
+++ b/src/logging/WinstonLoggerFactory.ts
@@ -15,8 +15,7 @@ export type LogFormat = typeof LOG_FORMATS[number];
 /**
  * Uses the winston library to create loggers for the given logging level.
  * By default, it will print to the console with colorized logging levels.
- * The `json` format can be used instead to output every log entry
- * as a single line of JSON, which is easier to parse for log aggregators.
+ * The `json` format can be used instead to output every log entry as a single line of JSON.
  *
  * This creates instances of {@link WinstonLogger}.
  */
@@ -52,9 +51,6 @@ export class WinstonLoggerFactory implements LoggerFactory {
     }));
   }
 
-  /**
-   * Creates the winston format corresponding to the `logFormat` this factory was created with.
-   */
   protected createFormat(label: string): Logform.Format {
     if (this.logFormat === 'json') {
       return format.combine(

--- a/src/logging/WinstonLoggerFactory.ts
+++ b/src/logging/WinstonLoggerFactory.ts
@@ -1,21 +1,40 @@
-import type { TransformableInfo } from 'logform';
+import type { Logform } from 'winston';
 import { createLogger, format, transports } from 'winston';
 import type * as Transport from 'winston-transport';
 import type { Logger, LogMetadata } from './Logger';
 import type { LoggerFactory } from './LoggerFactory';
 import { WinstonLogger } from './WinstonLogger';
 
+export const LOG_FORMATS = [ 'pretty', 'json' ] as const;
+
+/**
+ * Different formats in which log messages can be output.
+ */
+export type LogFormat = typeof LOG_FORMATS[number];
+
 /**
  * Uses the winston library to create loggers for the given logging level.
  * By default, it will print to the console with colorized logging levels.
+ * The `json` format can be used instead to output every log entry
+ * as a single line of JSON, which is easier to parse for log aggregators.
  *
  * This creates instances of {@link WinstonLogger}.
  */
 export class WinstonLoggerFactory implements LoggerFactory {
   private readonly level: string;
+  private readonly logFormat: LogFormat;
 
-  public constructor(level: string) {
+  /**
+   * @param level - The most detailed level of log messages that should be output.
+   * @param logFormat - The format used to output log messages:
+   *                    `pretty` for human-readable colorized lines, or `json` for a line of JSON per message.
+   */
+  public constructor(level: string, logFormat = 'pretty') {
     this.level = level;
+    if (!(LOG_FORMATS as readonly string[]).includes(logFormat)) {
+      throw new Error(`Unknown log format ${logFormat}, expected one of ${LOG_FORMATS.join('/')}`);
+    }
+    this.logFormat = logFormat as LogFormat;
   }
 
   private readonly clusterInfo = (meta: LogMetadata): string => {
@@ -28,18 +47,33 @@ export class WinstonLoggerFactory implements LoggerFactory {
   public createLogger(label: string): Logger {
     return new WinstonLogger(createLogger({
       level: this.level,
-      format: format.combine(
-        format.label({ label }),
-        format.colorize(),
-        format.timestamp(),
-        format.metadata({ fillExcept: [ 'level', 'timestamp', 'label', 'message' ]}),
-        format.printf(
-          ({ level: levelInner, message, label: labelInner, timestamp, metadata: meta }: TransformableInfo): string =>
-            `${timestamp} [${labelInner}] {${this.clusterInfo(meta as LogMetadata)}} ${levelInner}: ${message}`,
-        ),
-      ),
+      format: this.createFormat(label),
       transports: this.createTransports(),
     }));
+  }
+
+  /**
+   * Creates the winston format corresponding to the `logFormat` this factory was created with.
+   */
+  protected createFormat(label: string): Logform.Format {
+    if (this.logFormat === 'json') {
+      return format.combine(
+        format.label({ label }),
+        format.timestamp(),
+        format.json(),
+      );
+    }
+    return format.combine(
+      format.label({ label }),
+      format.colorize(),
+      format.timestamp(),
+      format.metadata({ fillExcept: [ 'level', 'timestamp', 'label', 'message' ]}),
+      format.printf(
+        ({ level: levelInner, message, label: labelInner, timestamp, metadata: meta }: Logform.TransformableInfo):
+        string =>
+          `${timestamp} [${labelInner}] {${this.clusterInfo(meta as LogMetadata)}} ${levelInner}: ${message}`,
+      ),
+    );
   }
 
   protected createTransports(): Transport[] {

--- a/test/integration/Config.ts
+++ b/test/integration/Config.ts
@@ -56,6 +56,7 @@ export function getDefaultVariables(port: number, baseUrl?: string): Record<stri
     'urn:solid-server:default:variable:port': port,
     'urn:solid-server:default:variable:socket': null,
     'urn:solid-server:default:variable:loggingLevel': 'off',
+    'urn:solid-server:default:variable:loggingFormat': 'pretty',
     'urn:solid-server:default:variable:showStackTrace': true,
     'urn:solid-server:default:variable:seedConfig': null,
     'urn:solid-server:default:variable:workers': 1,

--- a/test/unit/logging/WinstonLoggerFactory.test.ts
+++ b/test/unit/logging/WinstonLoggerFactory.test.ts
@@ -74,4 +74,65 @@ describe('WinstonLoggerFactory', (): void => {
       [Symbol.for('message')]: `${now.toISOString()} [MyLabel] {Primary} ${level}: my message`,
     }));
   });
+
+  it('errors on unknown log formats.', async(): Promise<void> => {
+    expect((): WinstonLoggerFactory => new WinstonLoggerFactory('debug', 'unknown'))
+      .toThrow('Unknown log format unknown, expected one of pretty/json');
+  });
+
+  it('can be created with an explicit pretty format.', async(): Promise<void> => {
+    factory = new WinstonLoggerFactory('debug', 'pretty');
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'my message');
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    // Need to check level like this as it has color tags
+    const { level } = transport.write.mock.calls[0][0];
+    expect(transport.write.mock.calls[0][0][Symbol.for('message')])
+      .toBe(`${now.toISOString()} [MyLabel] {W-???} ${level}: my message`);
+  });
+
+  it('outputs a line of JSON per message when using the json format.', async(): Promise<void> => {
+    factory = new WinstonLoggerFactory('debug', 'json');
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'my message');
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    const line: string = transport.write.mock.calls[0][0][Symbol.for('message')];
+    // The JSON format does not apply any color tags
+    // eslint-disable-next-line no-control-regex
+    expect(line).not.toMatch(/\u001B/u);
+    expect(JSON.parse(line)).toEqual({
+      label: 'MyLabel',
+      level: 'debug',
+      message: 'my message',
+      timestamp: now.toISOString(),
+    });
+  });
+
+  it('includes the extra metadata in the JSON output.', async(): Promise<void> => {
+    factory = new WinstonLoggerFactory('debug', 'json');
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'my message', { isPrimary: true, pid: 0 });
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    const line: string = transport.write.mock.calls[0][0][Symbol.for('message')];
+    expect(JSON.parse(line)).toEqual({
+      label: 'MyLabel',
+      level: 'debug',
+      message: 'my message',
+      timestamp: now.toISOString(),
+      isPrimary: true,
+      pid: 0,
+    });
+  });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue must be created before this is submitted to CommunitySolidServer (the PR template requires one).

#### ✍️ Description

Production deployments currently can't get machine-parseable logs out of CSS: `WinstonLoggerFactory` always emits colorized human-oriented lines, so shipping logs to an aggregator (CloudWatch, ELK, Loki, Datadog) means regex-parsing ANSI-colored text.

This adds a `--loggingFormat` CLI option (env: `CSS_LOGGING_FORMAT`, default `pretty`):

- `pretty` — identical to today's output; no change for existing deployments.
- `json` — one flat JSON object per line, no color codes. Sample line from a `--loggingFormat json` boot:

  ```json
  {"isPrimary":true,"label":"HandlerServerConfigurator","level":"info","message":"Received GET request for /","pid":3436163,"timestamp":"2026-07-02T07:24:07.717Z"}
  ```

Unknown values fail fast at boot: `Error: Unknown log format yaml, expected one of pretty/json`.

Wiring follows the [new CLI parameter documentation](https://github.com/CommunitySolidServer/CommunitySolidServer/blob/main/documentation/markdown/usage/new-cli-parameter.md): variable declaration (`config/util/variables/default.json`), `YargsParameter` (`cli.json`), `KeyExtractor` with `defaultValue` (`resolver.json`), and a new optional `logFormat` constructor parameter on `WinstonLoggerFactory` (`LOG_FORMATS`/`LogFormat` exported, mirroring `LOG_LEVELS`/`LogLevel`). The parameter table in `starting-server.md` documents the option.

Notes for reviewers:

- Validation deliberately lives in the factory constructor rather than a yargs `choices` constraint, so config-file/programmatic instantiation gets the same fail-fast guarantee as the CLI.
- The first seconds of boot output come from Components.js's own logger, which is not created through `urn:solid-server:default:LoggerFactory` (only the level is handed over to it), so it stays colorized. Making Components.js follow the format would be a separate change.
- Smoke-tested: booting `config/default.json` with `--loggingFormat json` emits valid single-line JSON for every CSS line (sample above) and `GET /` returns 200; `--loggingFormat yaml` fails at boot with the error above; default boot output is unchanged.
- Touches the same `WinstonLoggerFactory` format code as the request-identifier logging PR (jeswr/CommunitySolidServer#41); whichever merges second needs a trivial rebase.

Intended semver level: **semver.minor** (backwards-compatible feature: new CLI option + new optional constructor parameter). On upstream submission this should therefore target the latest `versions/*` branch (currently `versions/next-major`) rather than `main`.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
