### PR TITLE
feat: Add a unique request identifier to log messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -311,6 +311,7 @@ export * from './init/ServerInitializer';
 
 // Logging
 export * from './logging/LazyLoggerFactory';
+export * from './logging/LogContext';
 export * from './logging/Logger';
 export * from './logging/LoggerFactory';
 export * from './logging/LogLevel';

--- a/src/logging/LogContext.ts
+++ b/src/logging/LogContext.ts
@@ -1,0 +1,48 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
+
+const requestIdStorage = new AsyncLocalStorage<string>();
+
+/**
+ * Runs the given function within a logging context that has a newly generated request identifier.
+ * Log messages emitted while the function, or any asynchronous work it starts, is running
+ * will include this identifier in their metadata.
+ *
+ * @param fn - The function to run.
+ *
+ * @returns The result of calling the given function.
+ */
+export function runWithRequestId<T>(fn: () => T): T {
+  return requestIdStorage.run(randomUUID(), fn);
+}
+
+/**
+ * Returns the request identifier of the current logging context,
+ * or `undefined` when called outside a {@link runWithRequestId} context.
+ */
+export function getRequestId(): string | undefined {
+  return requestIdStorage.getStore();
+}
+
+/**
+ * Binds the given function to the request identifier of the current logging context.
+ * This is needed when a function can be called from outside the current asynchronous context,
+ * such as an event listener that gets invoked by an external emitter,
+ * as the identifier would otherwise be lost.
+ * The `this` binding the function gets called with is preserved,
+ * matching the behavior of `AsyncLocalStorage.bind`.
+ *
+ * @param fn - The function to bind.
+ *
+ * @returns The bound function, or the original function when there is no request identifier.
+ */
+export function bindToCurrentRequestId<TArgs extends unknown[], TOut>(fn: (...args: TArgs) => TOut):
+(...args: TArgs) => TOut {
+  const requestId = requestIdStorage.getStore();
+  if (typeof requestId === 'undefined') {
+    return fn;
+  }
+  return function(this: unknown, ...args: TArgs): TOut {
+    return requestIdStorage.run(requestId, (): TOut => fn.call(this, ...args));
+  };
+}

--- a/src/logging/LogContext.ts
+++ b/src/logging/LogContext.ts
@@ -25,12 +25,11 @@ export function getRequestId(): string | undefined {
 }
 
 /**
- * Binds the given function to the request identifier of the current logging context.
- * This is needed when a function can be called from outside the current asynchronous context,
- * such as an event listener that gets invoked by an external emitter,
- * as the identifier would otherwise be lost.
- * The `this` binding the function gets called with is preserved,
- * matching the behavior of `AsyncLocalStorage.bind`.
+ * Binds the given function to the request identifier of the current logging context,
+ * preserving its `this` binding.
+ * Event listeners need this as they run in the asynchronous context of the emit,
+ * not the one in which they were attached.
+ * Behaves like `AsyncLocalStorage.bind`, which requires a newer Node version than is supported.
  *
  * @param fn - The function to bind.
  *

--- a/src/logging/Logger.ts
+++ b/src/logging/Logger.ts
@@ -1,4 +1,5 @@
 import cluster from 'node:cluster';
+import { getRequestId } from './LogContext';
 import type { LogLevel } from './LogLevel';
 
 export interface LogMetadata {
@@ -6,6 +7,8 @@ export interface LogMetadata {
   isPrimary: boolean;
   /** The process id of the current process */
   pid: number;
+  /** The unique identifier of the request during whose handling this message was logged */
+  requestId?: string;
 }
 
 /**
@@ -97,10 +100,17 @@ export interface Logger extends SimpleLogger {
 export abstract class BaseLogger implements Logger {
   public abstract log(level: LogLevel, message: string, meta?: LogMetadata): Logger;
 
-  private readonly getMeta = (): LogMetadata => ({
-    pid: process.pid,
-    isPrimary: cluster.isPrimary,
-  });
+  private readonly getMeta = (): LogMetadata => {
+    const meta: LogMetadata = {
+      pid: process.pid,
+      isPrimary: cluster.isPrimary,
+    };
+    const requestId = getRequestId();
+    if (requestId) {
+      meta.requestId = requestId;
+    }
+    return meta;
+  };
 
   public error(message: string): Logger {
     return this.log('error', message, this.getMeta());

--- a/src/logging/WinstonLoggerFactory.ts
+++ b/src/logging/WinstonLoggerFactory.ts
@@ -25,6 +25,13 @@ export class WinstonLoggerFactory implements LoggerFactory {
     return `W-${meta.pid ?? '???'}`;
   };
 
+  private readonly requestInfo = (meta: LogMetadata): string => {
+    if (meta.requestId) {
+      return ` [${meta.requestId}]`;
+    }
+    return '';
+  };
+
   public createLogger(label: string): Logger {
     return new WinstonLogger(createLogger({
       level: this.level,
@@ -35,7 +42,8 @@ export class WinstonLoggerFactory implements LoggerFactory {
         format.metadata({ fillExcept: [ 'level', 'timestamp', 'label', 'message' ]}),
         format.printf(
           ({ level: levelInner, message, label: labelInner, timestamp, metadata: meta }: TransformableInfo): string =>
-            `${timestamp} [${labelInner}] {${this.clusterInfo(meta as LogMetadata)}} ${levelInner}: ${message}`,
+            `${timestamp} [${labelInner}] {${this.clusterInfo(meta as LogMetadata)}}` +
+            `${this.requestInfo(meta as LogMetadata)} ${levelInner}: ${message}`,
         ),
       ),
       transports: this.createTransports(),

--- a/src/server/HandlerServerConfigurator.ts
+++ b/src/server/HandlerServerConfigurator.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
+import { bindToCurrentRequestId, runWithRequestId } from '../logging/LogContext';
 import { getLoggerFor } from '../logging/LogUtil';
 import { isError } from '../util/errors/ErrorUtil';
 import { guardStream } from '../util/GuardedStream';
@@ -32,27 +33,28 @@ export class HandlerServerConfigurator extends ServerConfigurator {
     server.on(
       'request',
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      async(request: IncomingMessage, response: ServerResponse): Promise<void> => {
-        try {
-          this.logger.info(`Received ${request.method} request for ${request.url}`);
-          const guardedRequest = guardStream(request);
-          guardedRequest.on('error', this.errorLogger);
-          await this.handler.handleSafe({ request: guardedRequest, response });
-        } catch (error: unknown) {
-          const errMsg = this.createErrorMessage(error);
-          this.logger.error(errMsg);
-          if (response.headersSent) {
-            response.end();
-          } else {
-            response.setHeader('Content-Type', 'text/plain; charset=utf-8');
-            response.writeHead(500).end(errMsg);
+      async(request: IncomingMessage, response: ServerResponse): Promise<void> =>
+        runWithRequestId(async(): Promise<void> => {
+          try {
+            this.logger.info(`Received ${request.method} request for ${request.url}`);
+            const guardedRequest = guardStream(request);
+            guardedRequest.on('error', bindToCurrentRequestId(this.errorLogger));
+            await this.handler.handleSafe({ request: guardedRequest, response });
+          } catch (error: unknown) {
+            const errMsg = this.createErrorMessage(error);
+            this.logger.error(errMsg);
+            if (response.headersSent) {
+              response.end();
+            } else {
+              response.setHeader('Content-Type', 'text/plain; charset=utf-8');
+              response.writeHead(500).end(errMsg);
+            }
+          } finally {
+            if (!response.headersSent) {
+              response.writeHead(404).end();
+            }
           }
-        } finally {
-          if (!response.headersSent) {
-            response.writeHead(404).end();
-          }
-        }
-      },
+        }),
     );
   }
 

--- a/test/unit/logging/LogContext.test.ts
+++ b/test/unit/logging/LogContext.test.ts
@@ -1,0 +1,81 @@
+import { bindToCurrentRequestId, getRequestId, runWithRequestId } from '../../../src/logging/LogContext';
+
+const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
+
+describe('LogContext', (): void => {
+  describe('#getRequestId', (): void => {
+    it('returns undefined outside a request context.', async(): Promise<void> => {
+      expect(getRequestId()).toBeUndefined();
+    });
+
+    it('returns the generated identifier within a request context.', async(): Promise<void> => {
+      runWithRequestId((): void => {
+        expect(getRequestId()).toMatch(uuidRegex);
+      });
+    });
+  });
+
+  describe('#runWithRequestId', (): void => {
+    it('returns the result of the given function.', async(): Promise<void> => {
+      expect(runWithRequestId((): number => 5)).toBe(5);
+    });
+
+    it('generates a new identifier for every context.', async(): Promise<void> => {
+      const requestId = runWithRequestId((): string | undefined => getRequestId());
+      const requestId2 = runWithRequestId((): string | undefined => getRequestId());
+      expect(requestId).toMatch(uuidRegex);
+      expect(requestId2).toMatch(uuidRegex);
+      expect(requestId).not.toBe(requestId2);
+    });
+
+    it('retains the identifier across asynchronous calls.', async(): Promise<void> => {
+      await runWithRequestId(async(): Promise<void> => {
+        const requestId = getRequestId();
+        await new Promise<void>((resolve): void => {
+          setImmediate(resolve);
+        });
+        expect(getRequestId()).toBe(requestId);
+      });
+      expect(getRequestId()).toBeUndefined();
+    });
+  });
+
+  describe('#bindToCurrentRequestId', (): void => {
+    it('returns the input function when there is no request context.', async(): Promise<void> => {
+      const fn = jest.fn();
+      expect(bindToCurrentRequestId(fn)).toBe(fn);
+      expect(fn).toHaveBeenCalledTimes(0);
+    });
+
+    it('restores the request identifier when the function is called outside the context.', async(): Promise<void> => {
+      const fn = jest.fn((input: string): string => `${input}:${getRequestId()}`);
+      let bound: (input: string) => string;
+      const requestId = runWithRequestId((): string | undefined => {
+        bound = bindToCurrentRequestId(fn);
+        return getRequestId();
+      });
+      expect(getRequestId()).toBeUndefined();
+      expect(bound!('result')).toBe(`result:${requestId}`);
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(fn).toHaveBeenLastCalledWith('result');
+      expect(getRequestId()).toBeUndefined();
+    });
+
+    it('preserves the this binding of the bound function.', async(): Promise<void> => {
+      let captured: string | undefined;
+      const object = {
+        id: 'myId',
+        capture(this: { id: string }): void {
+          captured = `${this.id}:${getRequestId()}`;
+        },
+      };
+      const requestId = runWithRequestId((): string | undefined => {
+        // eslint-disable-next-line jest/unbound-method
+        object.capture = bindToCurrentRequestId(object.capture);
+        return getRequestId();
+      });
+      object.capture();
+      expect(captured).toBe(`myId:${requestId}`);
+    });
+  });
+});

--- a/test/unit/logging/Logger.test.ts
+++ b/test/unit/logging/Logger.test.ts
@@ -1,3 +1,4 @@
+import { getRequestId, runWithRequestId } from '../../../src/logging/LogContext';
 import { BaseLogger, WrappingLogger } from '../../../src/logging/Logger';
 import type { LogMetadata, SimpleLogger } from '../../../src/logging/Logger';
 
@@ -54,6 +55,15 @@ describe('Logger', (): void => {
       logger.silly('my message');
       expect(logger.log).toHaveBeenCalledTimes(1);
       expect(logger.log).toHaveBeenCalledWith('silly', 'my message', metadata);
+    });
+
+    it('includes the request identifier when logging within a request context.', async(): Promise<void> => {
+      const requestId = runWithRequestId((): string | undefined => {
+        logger.info('my message');
+        return getRequestId();
+      });
+      expect(logger.log).toHaveBeenCalledTimes(1);
+      expect(logger.log).toHaveBeenCalledWith('info', 'my message', { ...metadata, requestId });
     });
   });
 

--- a/test/unit/logging/WinstonLoggerFactory.test.ts
+++ b/test/unit/logging/WinstonLoggerFactory.test.ts
@@ -74,4 +74,18 @@ describe('WinstonLoggerFactory', (): void => {
       [Symbol.for('message')]: `${now.toISOString()} [MyLabel] {Primary} ${level}: my message`,
     }));
   });
+
+  it('adds the request identifier to the output when there is one.', async(): Promise<void> => {
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'my message', { isPrimary: true, pid: 0, requestId: '4c079dca' });
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    // Need to check level like this as it has color tags
+    const { level } = transport.write.mock.calls[0][0];
+    expect(transport.write.mock.calls[0][0][Symbol.for('message')])
+      .toBe(`${now.toISOString()} [MyLabel] {Primary} [4c079dca] ${level}: my message`);
+  });
 });

--- a/test/unit/server/HandlerServerConfigurator.test.ts
+++ b/test/unit/server/HandlerServerConfigurator.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events';
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
+import { getRequestId } from '../../../src/logging/LogContext';
 import type { Logger } from '../../../src/logging/Logger';
 import { getLoggerFor } from '../../../src/logging/LogUtil';
 import { HandlerServerConfigurator } from '../../../src/server/HandlerServerConfigurator';
@@ -122,6 +123,49 @@ describe('A HandlerServerConfigurator', (): void => {
 
     expect(logger.error).toHaveBeenCalledTimes(1);
     expect(logger.error).toHaveBeenLastCalledWith('Request error: bad request');
+  });
+
+  it('handles every request within a context that has a unique request identifier.', async(): Promise<void> => {
+    let infoRequestId: string | undefined;
+    let handlerRequestId: string | undefined;
+    logger.info.mockImplementationOnce((): any => {
+      infoRequestId = getRequestId();
+    });
+    handler.handleSafe.mockImplementationOnce(async(): Promise<void> => {
+      handlerRequestId = getRequestId();
+      (response as any).headersSent = true;
+    });
+    server.emit('request', request, response);
+    await flushPromises();
+
+    expect(handler.handleSafe).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(handlerRequestId).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(infoRequestId).toBe(handlerRequestId);
+    expect(getRequestId()).toBeUndefined();
+  });
+
+  it('keeps the request identifier for request errors emitted outside the request context.', async(): Promise<void> => {
+    let handlerRequestId: string | undefined;
+    let errorRequestId: string | undefined;
+    logger.error.mockImplementationOnce((): any => {
+      errorRequestId = getRequestId();
+    });
+    handler.handleSafe.mockImplementationOnce(async(): Promise<void> => {
+      handlerRequestId = getRequestId();
+      (response as any).headersSent = true;
+    });
+    server.emit('request', request, response);
+    await flushPromises();
+
+    // This emit happens outside the request context created by the configurator
+    expect(getRequestId()).toBeUndefined();
+    request.emit('error', new Error('late error'));
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith('Request error: late error');
+    expect(errorRequestId).toBe(handlerRequestId);
+    expect(errorRequestId).toMatch(/^[0-9a-f-]{36}$/u);
   });
 
   it('prints the stack trace if that option is enabled.', async(): Promise<void> => {


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — an upstream issue describing the missing request correlation must be created before this is submitted to CommunitySolidServer (the upstream PR template requires one).

#### ✍️ Description

When several requests are in flight, their log lines interleave with no way to attribute a line to a request: `Received GET request for /` followed by twenty `WebAclReader`/`ParsingHttpHandler` lines could belong to any of them. That makes production debugging — and correlating server logs with client-reported failures — needlessly hard.

This PR gives every request a generated identifier (`crypto.randomUUID()`) and includes it in the metadata of every log message emitted while that request is being handled:

- New `src/logging/LogContext.ts`: a module-global `AsyncLocalStorage` (same module-global idiom as `LogUtil`) behind three helpers — `runWithRequestId(fn)`, `getRequestId()`, and `bindToCurrentRequestId(fn)`. The bind helper exists because EventEmitter listeners run in the async context of the *emit*, not where they were attached — a socket error after a client abort would otherwise lose the id. It hand-rolls `AsyncLocalStorage.bind` because that API needs Node ≥ 18.16 while `engines` allows ≥ 18.0.
- `HandlerServerConfigurator` runs the entire request listener inside `runWithRequestId` and attaches the request error logger through `bindToCurrentRequestId`, so late request-stream errors keep their id.
- `LogMetadata` gains an optional `requestId`, added by `BaseLogger.getMeta` only when inside a request context; `WinstonLoggerFactory` prints it after the cluster info:

  ```text
  2026-07-02T07:33:31.751Z [HandlerServerConfigurator] {Primary} [60070c29-9623-4f36-87a7-3333d828b146] info: Received GET request for /.well-known/openid-configuration
  2026-07-02T07:33:31.758Z [HandlerServerConfigurator] {Primary} [53cbc793-d5ed-4c27-a253-30ddc3e671a5] info: Received GET request for /
  2026-07-02T07:33:31.767Z [WebAclReader] {Primary} [53cbc793-d5ed-4c27-a253-30ddc3e671a5] info: Found applicable ACL document http://localhost:3462/.acl
  2026-07-02T07:33:54.831Z [HandlerServerConfigurator] {Primary} [8d2246c3-06a7-49e5-b9f3-fed4b7779bdc] error: Request error: aborted
  ```

  Real smoke-test output: two concurrent requests get distinct ids, the `WebAclReader` line correlates to the right request, startup lines carry no id, and the last line — a PUT aborted mid-upload — keeps its id because the error listener is bound to the request context. With the JSON logging PR (#40) the id appears as a `requestId` field automatically.

#### 📋 Notes for review

- **Performance**: `AsyncLocalStorage` enables async-context propagation, which has a known cost on Node < 24 (Node 24's AsyncContextFrame makes it near-free). Indicative A/B on a 2-core dev machine (live server on the same machine, `config/file.json`, 2 alternating runs per side, zero request errors). This was an ad-hoc local load harness — no reproducible committed command exists, so treat the numbers as directional only:

  | scenario | `main` (run 1 / 2) | this PR (run 1 / 2) |
  |---|---|---|
  | static GET | 668 / 775 rps | 634 / 683 rps |
  | LDP GET (hot resource) | 71 / 73 rps | 78 / 73 rps |
  | LDP GET (spread) | 76 / 71 rps | 64 / 55 rps |
  | LDP PUT | 50 / 57 rps | 52 / 53 rps |
  | container listing (100 children) | 14 / 15 rps | 14 / 14 rps |

  Run-to-run variance on that machine (baseline static GET alone spans ±8%) exceeds most deltas; the LDP scenarios are within noise. The static path — minimal per-request work, so most sensitive to per-request overhead — suggests a mid-single-digit percentage cost on Node 22. Boot time unchanged. If that cost matters for a deployment profile, the context wrapper is a one-line candidate for a config toggle; happy to add it if wanted.
- Follow-ups deliberately not included: echoing the id as an `X-Request-Id` response header, honoring client-supplied correlation ids (spoofing / log-injection questions to settle first), and the WebSocket upgrade path.
- Trivial-conflict warning with #40 (JSON logging) — same `WinstonLoggerFactory` format region, trivial rebase for whichever merges second.
- Full unit suite with the 100% `./src` coverage gate is green; `lint` has zero warnings.
- **Branch target + semver**: this is a backwards-compatible feature addition — new exported helpers plus a new optional `LogMetadata` field — so the intended semver level is **minor** (stated in prose; contributors cannot set the label). As a non-patch change it should target the latest `versions/*` branch upstream (currently `versions/next-major`), not `main`; this fork copy targets `main` only for staging.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
