### PR TITLE
feat: Log the access token identifier for authenticated requests

### DIFF
--- a/src/authentication/BearerWebIdExtractor.ts
+++ b/src/authentication/BearerWebIdExtractor.ts
@@ -30,8 +30,7 @@ export class BearerWebIdExtractor extends CredentialsExtractor {
     try {
       const payload = await this.verify(authorization!);
       const { webid: webId, client_id: clientId, iss: issuer } = payload;
-      // The type of the verified payload omits `jti`,
-      // but JWT access tokens issued by the server always contain one
+      // The payload type omits `jti`, but JWT access tokens issued by the server always contain one.
       const tokenId = (payload as { jti?: string }).jti;
       this.logger.info(`Verified credentials via Bearer access token. WebID: ${webId
       }, client ID: ${clientId ?? 'none'}, issuer: ${issuer}, token ID: ${tokenId ?? 'none'}`);

--- a/src/authentication/BearerWebIdExtractor.ts
+++ b/src/authentication/BearerWebIdExtractor.ts
@@ -28,9 +28,13 @@ export class BearerWebIdExtractor extends CredentialsExtractor {
     const { headers: { authorization }} = request;
 
     try {
-      const { webid: webId, client_id: clientId, iss: issuer } = await this.verify(authorization!);
+      const payload = await this.verify(authorization!);
+      const { webid: webId, client_id: clientId, iss: issuer } = payload;
+      // The type of the verified payload omits `jti`,
+      // but JWT access tokens issued by the server always contain one
+      const tokenId = (payload as { jti?: string }).jti;
       this.logger.info(`Verified credentials via Bearer access token. WebID: ${webId
-      }, client ID: ${clientId}, issuer: ${issuer}`);
+      }, client ID: ${clientId ?? 'none'}, issuer: ${issuer}, token ID: ${tokenId ?? 'none'}`);
       const credentials: Credentials = { agent: { webId }, issuer: { url: issuer }};
       if (clientId) {
         credentials.client = { clientId };

--- a/src/authentication/DPoPWebIdExtractor.ts
+++ b/src/authentication/DPoPWebIdExtractor.ts
@@ -54,8 +54,7 @@ export class DPoPWebIdExtractor extends CredentialsExtractor {
         },
       );
       const { webid: webId, client_id: clientId, iss: issuer } = payload;
-      // The type of the verified payload omits `jti`,
-      // but JWT access tokens issued by the server always contain one
+      // The payload type omits `jti`, but JWT access tokens issued by the server always contain one.
       const tokenId = (payload as { jti?: string }).jti;
       this.logger.info(`Verified WebID via DPoP-bound access token. WebID: ${webId
       }, client ID: ${clientId ?? 'none'}, issuer: ${issuer}, token ID: ${tokenId ?? 'none'}`);

--- a/src/authentication/DPoPWebIdExtractor.ts
+++ b/src/authentication/DPoPWebIdExtractor.ts
@@ -45,7 +45,7 @@ export class DPoPWebIdExtractor extends CredentialsExtractor {
     // Validate the Authorization and DPoP header headers
     // and extract the WebID provided by the client
     try {
-      const { webid: webId, client_id: clientId, iss: issuer } = await this.verify(
+      const payload = await this.verify(
         authorization!,
         {
           header: dpop as string,
@@ -53,8 +53,12 @@ export class DPoPWebIdExtractor extends CredentialsExtractor {
           url: originalUrl.path,
         },
       );
+      const { webid: webId, client_id: clientId, iss: issuer } = payload;
+      // The type of the verified payload omits `jti`,
+      // but JWT access tokens issued by the server always contain one
+      const tokenId = (payload as { jti?: string }).jti;
       this.logger.info(`Verified WebID via DPoP-bound access token. WebID: ${webId
-      }, client ID: ${clientId}, issuer: ${issuer}`);
+      }, client ID: ${clientId ?? 'none'}, issuer: ${issuer}, token ID: ${tokenId ?? 'none'}`);
       const credentials: Credentials = { agent: { webId }, issuer: { url: issuer }};
       if (clientId) {
         credentials.client = { clientId };

--- a/test/unit/authentication/BearerWebIdExtractor.test.ts
+++ b/test/unit/authentication/BearerWebIdExtractor.test.ts
@@ -1,21 +1,38 @@
 import type { SolidTokenVerifierFunction } from '@solid/access-token-verifier';
 import type { SolidAccessTokenPayload } from '@solid/access-token-verifier/dist/type/SolidAccessTokenPayload';
 import { BearerWebIdExtractor } from '../../../src/authentication/BearerWebIdExtractor';
+import type { Logger } from '../../../src/logging/Logger';
+import { getLoggerFor } from '../../../src/logging/LogUtil';
 import type { HttpRequest } from '../../../src/server/HttpRequest';
 import { BadRequestHttpError } from '../../../src/util/errors/BadRequestHttpError';
 import { NotImplementedHttpError } from '../../../src/util/errors/NotImplementedHttpError';
 
 let clientId: string | undefined;
-const solidTokenVerifier = jest.fn(async(): Promise<SolidAccessTokenPayload> =>
-  ({ aud: 'solid', exp: 1234, iat: 1234, iss: 'example.com/idp', webid: 'http://alice.example/card#me', client_id: clientId }));
+let tokenId: string | undefined;
+const solidTokenVerifier = jest.fn(async(): Promise<SolidAccessTokenPayload> => ({
+  aud: 'solid',
+  exp: 1234,
+  iat: 1234,
+  iss: 'example.com/idp',
+  webid: 'http://alice.example/card#me',
+  client_id: clientId,
+  jti: tokenId,
+} as SolidAccessTokenPayload));
 jest.mock('@solid/access-token-verifier', (): any =>
   ({ createSolidTokenVerifier: (): SolidTokenVerifierFunction => solidTokenVerifier }));
 
+jest.mock('../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { info: jest.fn(), warn: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+
 describe('A BearerWebIdExtractor', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
   const webIdExtractor = new BearerWebIdExtractor();
 
   beforeEach((): void => {
     clientId = undefined;
+    tokenId = undefined;
   });
 
   afterEach((): void => {
@@ -77,6 +94,23 @@ describe('A BearerWebIdExtractor', (): void => {
       await expect(result).resolves.toEqual(
         { agent: { webId: 'http://alice.example/card#me' }, issuer: { url: 'example.com/idp' }, client: { clientId }},
       );
+    });
+
+    it('logs placeholders when the token has no client ID or token ID.', async(): Promise<void> => {
+      await webIdExtractor.handleSafe(request);
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenLastCalledWith('Verified credentials via Bearer access token. ' +
+        'WebID: http://alice.example/card#me, client ID: none, issuer: example.com/idp, token ID: none');
+    });
+
+    it('logs the client ID and token ID when the token contains them.', async(): Promise<void> => {
+      clientId = 'http://client.example.com/#me';
+      tokenId = '5b9ba391-023b-40de-b4c4-3e4d92a10979';
+      await webIdExtractor.handleSafe(request);
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenLastCalledWith('Verified credentials via Bearer access token. ' +
+        'WebID: http://alice.example/card#me, client ID: http://client.example.com/#me, ' +
+        'issuer: example.com/idp, token ID: 5b9ba391-023b-40de-b4c4-3e4d92a10979');
     });
   });
 

--- a/test/unit/authentication/DPoPWebIdExtractor.test.ts
+++ b/test/unit/authentication/DPoPWebIdExtractor.test.ts
@@ -1,24 +1,42 @@
 import type { SolidTokenVerifierFunction } from '@solid/access-token-verifier';
 import type { SolidAccessTokenPayload } from '@solid/access-token-verifier/dist/type/SolidAccessTokenPayload';
 import { DPoPWebIdExtractor } from '../../../src/authentication/DPoPWebIdExtractor';
+import type { Logger } from '../../../src/logging/Logger';
+import { getLoggerFor } from '../../../src/logging/LogUtil';
 import type { HttpRequest } from '../../../src/server/HttpRequest';
 import { BadRequestHttpError } from '../../../src/util/errors/BadRequestHttpError';
 import { NotImplementedHttpError } from '../../../src/util/errors/NotImplementedHttpError';
 import { StaticAsyncHandler } from '../../util/StaticAsyncHandler';
 
 let clientId: string | undefined;
-const solidTokenVerifier = jest.fn(async(): Promise<SolidAccessTokenPayload> =>
-  ({ aud: 'solid', exp: 1234, iat: 1234, iss: 'example.com/idp', webid: 'http://alice.example/card#me', client_id: clientId }));
+let tokenId: string | undefined;
+const solidTokenVerifier = jest.fn(async(): Promise<SolidAccessTokenPayload> => ({
+  aud: 'solid',
+  exp: 1234,
+  iat: 1234,
+  iss: 'example.com/idp',
+  webid: 'http://alice.example/card#me',
+  client_id: clientId,
+  jti: tokenId,
+} as SolidAccessTokenPayload));
 jest.mock('@solid/access-token-verifier', (): any =>
   ({ createSolidTokenVerifier: (): SolidTokenVerifierFunction => solidTokenVerifier }));
 
+jest.mock('../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { info: jest.fn(), warn: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+
 describe('A DPoPWebIdExtractor', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
   const targetExtractor = new StaticAsyncHandler(true, { path: 'http://example.org/foo/bar' });
   const webIdExtractor = new DPoPWebIdExtractor(targetExtractor);
 
   beforeEach((): void => {
     jest.clearAllMocks();
     jest.spyOn(targetExtractor, 'handle');
+    clientId = undefined;
+    tokenId = undefined;
   });
 
   describe('on a request without Authorization header', (): void => {
@@ -99,6 +117,23 @@ describe('A DPoPWebIdExtractor', (): void => {
       await expect(result).resolves.toEqual(
         { agent: { webId: 'http://alice.example/card#me' }, issuer: { url: 'example.com/idp' }, client: { clientId }},
       );
+    });
+
+    it('logs placeholders when the token has no client ID or token ID.', async(): Promise<void> => {
+      await webIdExtractor.handleSafe(request);
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenLastCalledWith('Verified WebID via DPoP-bound access token. ' +
+        'WebID: http://alice.example/card#me, client ID: none, issuer: example.com/idp, token ID: none');
+    });
+
+    it('logs the client ID and token ID when the token contains them.', async(): Promise<void> => {
+      clientId = 'http://client.example.com/#me';
+      tokenId = '5b9ba391-023b-40de-b4c4-3e4d92a10979';
+      await webIdExtractor.handleSafe(request);
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenLastCalledWith('Verified WebID via DPoP-bound access token. ' +
+        'WebID: http://alice.example/card#me, client ID: http://client.example.com/#me, ' +
+        'issuer: example.com/idp, token ID: 5b9ba391-023b-40de-b4c4-3e4d92a10979');
     });
   });
 


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue still needs to be created before this is submitted to CommunitySolidServer (the upstream PR template requires one). Builds on the request-id logging change in #41.

#### ✍️ Description

The `Verified WebID …` / `Verified credentials …` info line that the two access-token extractors emit for every authenticated request now includes the access token's `jti`, and optional identity claims that are absent log as `none`:

```text
Verified WebID via DPoP-bound access token. WebID: https://…/card#me, client ID: my-app_7d3e…, issuer: https://…, token ID: 5b9ba391-023b-40de-b4c4-3e4d92a10979
```

With request identifiers (#41), each request's log lines already resolve to a (WebID, client ID) pair, but two devices running the same app for the same user were indistinguishable. JWT access tokens issued by CSS always carry a stable `jti` (oidc-provider includes it unconditionally, and CSS forces the JWT access-token format), so `token ID` is a stable per-token "session" key: grouping log lines by it follows one client session across requests. The verifier already returns the full token payload — the extractors were simply discarding the claim; the payload's TS type omits `jti`, which both hid that it was available and is why the extractors now read it through a cast.

Previously, tokens without a `client_id` claim logged `client ID: undefined`: the template interpolated the raw value, while the truthiness check that gates `credentials.client` only ran afterwards. The `none` placeholder introduced for `token ID` (external issuers may omit `jti`) now applies to `client ID` as well, so both optional claims render consistently.

`Credentials` is deliberately **not** extended with the token id — this is a log-only change. Threading `jti` into `Credentials` (e.g. for per-token rate limiting) would be a separate design discussion.

Both extractor suites now assert the exact log line (previously untested), covering the placeholder and fully-populated variants; the DPoP suite also gained the missing `clientId` reset between tests.

**Branch target and semver**: backwards compatible — no interface, signature, or configuration changes — so this targets `main` (breaking changes would target the latest `versions/*` branch). Intended semver level: **semver.minor**, a backwards-compatible feature addition (stated in prose since contributors cannot set the label).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
