### PR TITLE
fix: Stop the server gracefully on SIGINT and SIGTERM

### DIFF
--- a/src/init/AppRunner.ts
+++ b/src/init/AppRunner.ts
@@ -30,6 +30,17 @@ const CORE_CLI_PARAMETERS = {
 const ENV_VAR_PREFIX = 'CSS';
 
 /**
+ * Process signals that stop the server.
+ */
+const STOP_SIGNALS: NodeJS.Signals[] = [ 'SIGINT', 'SIGTERM' ];
+
+/**
+ * Time in milliseconds the server gets to stop gracefully after receiving a stop signal
+ * before the process is exited forcefully.
+ */
+const SHUTDOWN_TIMEOUT = 30_000;
+
+/**
  * Parameters that can be used to instantiate the server through code.
  */
 export interface AppRunnerInput {
@@ -162,6 +173,54 @@ export class AppRunner {
       this.logger.error(`Could not start the server: ${createErrorMessage(error)}`);
       this.resolveError('Could not start the server', error);
     }
+    this.registerStopSignals(app);
+  }
+
+  /**
+   * Stops the given {@link App} when the process receives a stop signal (SIGINT/SIGTERM),
+   * so the server shuts down gracefully:
+   * all finalizers run, releasing resources such as file locks and open connections.
+   * The handlers are registered with `once`,
+   * so sending a second signal terminates the process immediately with the default signal behavior.
+   * Should stopping take longer than {@link SHUTDOWN_TIMEOUT} milliseconds,
+   * the process is exited forcefully.
+   *
+   * @param app - The application to stop when a signal is received.
+   */
+  protected registerStopSignals(app: App): void {
+    for (const signal of STOP_SIGNALS) {
+      process.once(signal, (): void => {
+        this.logger.info(`Received ${signal}. Stopping the server.`);
+        const timer = setTimeout((): void => {
+          this.logger.error(`Stopping the server timed out after ${SHUTDOWN_TIMEOUT} ms. Exiting forcefully.`);
+          this.exitProcess(1);
+        }, SHUTDOWN_TIMEOUT);
+        // The timer should not prevent the process from exiting once stopping finishes
+        timer.unref();
+        app.stop().then(
+          (): void => {
+            clearTimeout(timer);
+            this.logger.info('Server stopped.');
+            this.exitProcess(0);
+          },
+          (error: unknown): void => {
+            clearTimeout(timer);
+            this.logger.error(`Could not stop the server: ${createErrorMessage(error)}`);
+            this.exitProcess(1);
+          },
+        );
+      });
+    }
+  }
+
+  /**
+   * Exits the Node.js process with the given exit code.
+   *
+   * @param code - The exit code for the process.
+   */
+  private exitProcess(code: number): void {
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(code);
   }
 
   /**

--- a/src/init/AppRunner.ts
+++ b/src/init/AppRunner.ts
@@ -29,15 +29,8 @@ const CORE_CLI_PARAMETERS = {
 
 const ENV_VAR_PREFIX = 'CSS';
 
-/**
- * Process signals that stop the server.
- */
 const STOP_SIGNALS: NodeJS.Signals[] = [ 'SIGINT', 'SIGTERM' ];
 
-/**
- * Time in milliseconds the server gets to stop gracefully after receiving a stop signal
- * before the process is exited forcefully.
- */
 const SHUTDOWN_TIMEOUT = 30_000;
 
 /**
@@ -177,13 +170,9 @@ export class AppRunner {
   }
 
   /**
-   * Stops the given {@link App} when the process receives a stop signal (SIGINT/SIGTERM),
-   * so the server shuts down gracefully:
-   * all finalizers run, releasing resources such as file locks and open connections.
-   * The handlers are registered with `once`,
-   * so sending a second signal terminates the process immediately with the default signal behavior.
-   * Should stopping take longer than {@link SHUTDOWN_TIMEOUT} milliseconds,
-   * the process is exited forcefully.
+   * Stops the given {@link App} when the process receives a stop signal, so all finalizers run.
+   * The handlers are registered with `once`, so a second signal terminates the process immediately.
+   * Should stopping take longer than {@link SHUTDOWN_TIMEOUT} milliseconds, the process is exited forcefully.
    *
    * @param app - The application to stop when a signal is received.
    */
@@ -213,11 +202,6 @@ export class AppRunner {
     }
   }
 
-  /**
-   * Exits the Node.js process with the given exit code.
-   *
-   * @param code - The exit code for the process.
-   */
   private exitProcess(code: number): void {
     // eslint-disable-next-line unicorn/no-process-exit
     process.exit(code);

--- a/test/unit/init/AppRunner.test.ts
+++ b/test/unit/init/AppRunner.test.ts
@@ -67,6 +67,7 @@ const clusterManager: jest.Mocked<ClusterManager> = {
 
 const app: jest.Mocked<App> = {
   start: jest.fn(),
+  stop: jest.fn(),
   clusterManager,
 } as any;
 
@@ -134,6 +135,7 @@ jest.mock(
 jest.spyOn(process, 'cwd').mockReturnValue('/var/cwd');
 const write = jest.spyOn(process.stderr, 'write').mockImplementation(jest.fn());
 const exit = jest.spyOn(process, 'exit').mockImplementation(jest.fn() as any);
+const processOnce = jest.spyOn(process, 'once').mockImplementation(jest.fn() as any);
 
 describe('AppRunner', (): void => {
   beforeEach((): void => {
@@ -773,6 +775,55 @@ describe('AppRunner', (): void => {
       expect(write).toHaveBeenCalledTimes(0);
 
       expect(exit).toHaveBeenCalledTimes(0);
+    });
+
+    it('registers handlers that stop the server when receiving a stop signal.', async(): Promise<void> => {
+      app.stop.mockResolvedValueOnce(undefined);
+      await new AppRunner().runCli([ 'node', 'script' ]);
+
+      expect(processOnce).toHaveBeenCalledTimes(2);
+      expect(processOnce).toHaveBeenNthCalledWith(1, 'SIGINT', expect.any(Function));
+      expect(processOnce).toHaveBeenNthCalledWith(2, 'SIGTERM', expect.any(Function));
+
+      const handler = processOnce.mock.calls[1][1] as () => void;
+      handler();
+      await flushPromises();
+
+      expect(app.stop).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenLastCalledWith(0);
+    });
+
+    it('exits the process with code 1 if stopping the server errors.', async(): Promise<void> => {
+      app.stop.mockRejectedValueOnce(new Error('halting failure'));
+      await new AppRunner().runCli([ 'node', 'script' ]);
+
+      const handler = processOnce.mock.calls[0][1] as () => void;
+      handler();
+      await flushPromises();
+
+      expect(app.stop).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenLastCalledWith(1);
+    });
+
+    it('exits the process forcefully if stopping the server times out.', async(): Promise<void> => {
+      // This promise never resolves, simulating a stop call that hangs
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      app.stop.mockReturnValueOnce(new Promise((): void => {}));
+      await new AppRunner().runCli([ 'node', 'script' ]);
+      jest.useFakeTimers();
+
+      const handler = processOnce.mock.calls[1][1] as () => void;
+      handler();
+      expect(app.stop).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenCalledTimes(0);
+
+      jest.advanceTimersByTime(30_000);
+
+      expect(exit).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenLastCalledWith(1);
+      jest.useRealTimers();
     });
   });
 


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the upstream template requires a related issue, so one describing the missing shutdown handling must be created on CommunitySolidServer/CommunitySolidServer before this is submitted there.

#### ✍️ Description

Nothing in the server registers a `SIGTERM`/`SIGINT` handler (`bin/server.js` only attaches `uncaughtExceptionMonitor`), so `App.stop()` and the whole `Finalizer` chain — `ServerInitializer`'s `server.close()`, `FileSystemResourceLocker`'s lock-folder cleanup, the Redis finalizers — never run in a CLI or Docker deployment. Every `docker stop`, Kubernetes pod rotation, or Ctrl+C is effectively a hard kill: in-flight writes are truncated (the file accessor writes directly to the destination path), lock files are left behind, and connections are severed.

This PR wires stop signals to the existing graceful-stop machinery in `AppRunner.runCli` (the CLI path; programmatic `create()`/`run()` users are unaffected):

- On the first `SIGINT`/`SIGTERM`: log, call `app.stop()` (running all finalizers), then exit 0 — or exit 1 if stopping fails.
- Handlers are registered with `process.once`, so a **second** signal falls through to the default signal behavior and terminates immediately (the standard double-Ctrl+C escape hatch).
- If stopping hangs, a 30-second timer force-exits with code 1. The timer is `unref`ed so it never keeps a finished process alive, and is cleared once stop settles. 30s sits just under Kubernetes' default termination grace; operators lowering `terminationGracePeriodSeconds` below that should account for it.

Notes for review:

- In cluster mode each process (primary and workers) registers its own handlers and stops itself; a coordinated primary→worker drain would be a follow-up.
- In the official Docker image `node` runs as PID 1, where `SIGTERM`'s default disposition is ignored — this PR makes the handler work once the signal arrives, but the image would additionally benefit from `tini`/`docker run --init` so signals reach node reliably in all runtimes. That is a separate Dockerfile change.
- A refinement worth discussing: calling `server.closeIdleConnections()` before finalization, so keep-alive sockets don't ride out the grace period; long-lived notification connections (WebSocket/streaming) currently keep `server.close()` pending until the force-exit timer fires.

Intended semver level (in prose — contributors cannot set the labels): **semver.minor** — new behavior on the CLI path plus a new protected method on `AppRunner`. Per the checklist that means the upstream submission should target the latest `versions/*` branch (currently `versions/next-major`), not `main`; the commit type may then also want to be `feat:` rather than `fix:`, since the subject becomes a CHANGELOG line.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
