### PR TITLE
fix: Fail fast when a migration confirmation is needed without a TTY

### DIFF
--- a/src/init/migration/V6MigrationInitializer.ts
+++ b/src/init/migration/V6MigrationInitializer.ts
@@ -141,6 +141,15 @@ export class V6MigrationInitializer extends Initializer {
 
     // Ask the user for confirmation
     if (!this.skipConfirmation) {
+      // Fail fast if there is no TTY, such as when running in Docker or as a systemd service,
+      // as the prompt below would otherwise wait forever for input that can never arrive.
+      if (!process.stdin.isTTY) {
+        throw new Error([
+          'A v6 data migration is required, but no TTY is available to ask for confirmation.',
+          'Either start the server interactively to confirm the migration,',
+          'or start it with the --confirmMigration flag to migrate without confirmation.',
+        ].join(' '));
+      }
       const readline = createInterface({ input: process.stdin, output: process.stdout });
       const answer = await new Promise<string>((resolve): void => {
         readline.question([

--- a/src/init/migration/V6MigrationInitializer.ts
+++ b/src/init/migration/V6MigrationInitializer.ts
@@ -141,8 +141,7 @@ export class V6MigrationInitializer extends Initializer {
 
     // Ask the user for confirmation
     if (!this.skipConfirmation) {
-      // Fail fast if there is no TTY, such as when running in Docker or as a systemd service,
-      // as the prompt below would otherwise wait forever for input that can never arrive.
+      // Without a TTY the prompt below would wait forever for input that can never arrive.
       if (!process.stdin.isTTY) {
         throw new Error([
           'A v6 data migration is required, but no TTY is available to ask for confirmation.',

--- a/test/unit/init/migration/V6MigrationInitializer.test.ts
+++ b/test/unit/init/migration/V6MigrationInitializer.test.ts
@@ -224,8 +224,12 @@ describe('A V6MigrationInitializer', (): void => {
   });
 
   describe('with prompts enabled', (): void => {
+    const originalIsTTY = process.stdin.isTTY;
+
     beforeEach(async(): Promise<void> => {
       jest.clearAllMocks();
+      questionMock.mockImplementation((input, callback): void => callback('y'));
+      (process.stdin as { isTTY?: boolean }).isTTY = true;
 
       initializer = new V6MigrationInitializer({
         versionKey,
@@ -237,6 +241,10 @@ describe('A V6MigrationInitializer', (): void => {
         newSetupStorage,
         skipConfirmation: false,
       });
+    });
+
+    afterEach((): void => {
+      (process.stdin as { isTTY?: boolean }).isTTY = originalIsTTY;
     });
 
     it('shows a prompt before migrating the data.', async(): Promise<void> => {
@@ -252,6 +260,28 @@ describe('A V6MigrationInitializer', (): void => {
     it('throws an error to stop the server if no positive answer is received.', async(): Promise<void> => {
       questionMock.mockImplementation((input, callback): void => callback('n'));
       await expect(initializer.handle()).rejects.toThrow('Stopping server as migration was cancelled.');
+      expect(newAccountStorage.create).toHaveBeenCalledTimes(0);
+    });
+
+    it('throws an error instead of prompting if stdin is not a TTY.', async(): Promise<void> => {
+      (process.stdin as { isTTY?: boolean }).isTTY = false;
+      await expect(initializer.handle()).rejects.toThrow(
+        'A v6 data migration is required, but no TTY is available to ask for confirmation. ' +
+        'Either start the server interactively to confirm the migration, ' +
+        'or start it with the --confirmMigration flag to migrate without confirmation.',
+      );
+      expect(questionMock).toHaveBeenCalledTimes(0);
+      expect(newAccountStorage.create).toHaveBeenCalledTimes(0);
+    });
+
+    it('throws an error instead of prompting if the TTY status of stdin is unknown.', async(): Promise<void> => {
+      (process.stdin as { isTTY?: boolean }).isTTY = undefined;
+      await expect(initializer.handle()).rejects.toThrow(
+        'A v6 data migration is required, but no TTY is available to ask for confirmation. ' +
+        'Either start the server interactively to confirm the migration, ' +
+        'or start it with the --confirmMigration flag to migrate without confirmation.',
+      );
+      expect(questionMock).toHaveBeenCalledTimes(0);
       expect(newAccountStorage.create).toHaveBeenCalledTimes(0);
     });
   });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an issue must be created on CommunitySolidServer/CommunitySolidServer before this is submitted upstream (the template requires one).

#### ✍️ Description

When a v6→v7 data migration is needed and `--confirmMigration` is not set, `V6MigrationInitializer` awaits `readline.question()` on stdin. Without a TTY — a Docker container, a systemd service — that prompt waits forever for input that can never arrive, so the boot hangs silently: no error, no log, just a server that never comes up. An operator upgrading a containerized deployment hits this on the first restart.

The initializer now checks `process.stdin.isTTY` before prompting and fails fast with an actionable error instead:

> A v6 data migration is required, but no TTY is available to ask for confirmation. Either start the server interactively to confirm the migration, or start it with the --confirmMigration flag to migrate without confirmation.

The interactive path and `--confirmMigration` behaviour are unchanged. Tests cover both `isTTY === false` and `isTTY === undefined` (each asserting the prompt is never created and no migration runs), saving and restoring the real descriptor around each case.

This is a backwards-compatible bug fix — **semver.patch**, targeting `main` (no interface, signature, or config-behaviour change).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
