### PR TITLE
fix: Log server errors at error level

### DIFF
--- a/src/server/ParsingHttpHandler.ts
+++ b/src/server/ParsingHttpHandler.ts
@@ -89,6 +89,16 @@ export class ParsingHttpHandler extends HttpHandler {
       );
     }
 
-    return this.errorHandler.handleSafe({ error: error as HttpError, request });
+    const httpError = error as HttpError;
+    if (httpError.statusCode >= 500) {
+      this.logger.error(`Request failed with server error: ${httpError.name}: ${createErrorMessage(httpError)}`);
+      if (httpError.stack) {
+        this.logger.error(httpError.stack);
+      }
+    } else {
+      this.logger.debug(`Request failed with client error: ${httpError.name}: ${createErrorMessage(httpError)}`);
+    }
+
+    return this.errorHandler.handleSafe({ error: httpError, request });
   }
 }

--- a/test/unit/server/ParsingHttpHandler.test.ts
+++ b/test/unit/server/ParsingHttpHandler.test.ts
@@ -4,13 +4,23 @@ import type { ErrorHandler } from '../../../src/http/output/error/ErrorHandler';
 import { ResponseDescription } from '../../../src/http/output/response/ResponseDescription';
 import type { ResponseWriter } from '../../../src/http/output/ResponseWriter';
 import { BasicRepresentation } from '../../../src/http/representation/BasicRepresentation';
+import type { Logger } from '../../../src/logging/Logger';
+import { getLoggerFor } from '../../../src/logging/LogUtil';
 import type { HttpRequest } from '../../../src/server/HttpRequest';
 import type { HttpResponse } from '../../../src/server/HttpResponse';
 import type { OperationHttpHandler } from '../../../src/server/OperationHttpHandler';
 import { ParsingHttpHandler } from '../../../src/server/ParsingHttpHandler';
 import { BadRequestHttpError } from '../../../src/util/errors/BadRequestHttpError';
+import { InternalServerError } from '../../../src/util/errors/InternalServerError';
+
+jest.mock('../../../src/logging/LogUtil', (): any => {
+  const logger: Logger =
+    { error: jest.fn(), debug: jest.fn(), verbose: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
 
 describe('A ParsingHttpHandler', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
   const request: HttpRequest = {} as any;
   const response: HttpResponse = {} as any;
   const body = new BasicRepresentation();
@@ -23,6 +33,8 @@ describe('A ParsingHttpHandler', (): void => {
   let handler: ParsingHttpHandler;
 
   beforeEach(async(): Promise<void> => {
+    // Clearing the logger mock
+    jest.clearAllMocks();
     requestParser = { handleSafe: jest.fn().mockResolvedValue(operation) } as any;
     errorHandler = { handleSafe: jest.fn().mockResolvedValue(errorResponse) } as any;
     responseWriter = { handleSafe: jest.fn() } as any;
@@ -74,5 +86,36 @@ describe('A ParsingHttpHandler', (): void => {
     expect(errorHandler.handleSafe.mock.calls[0][0].error.cause).toBe(error);
     expect(responseWriter.handleSafe).toHaveBeenCalledTimes(1);
     expect(responseWriter.handleSafe).toHaveBeenLastCalledWith({ response, result: errorResponse });
+  });
+
+  it('logs client errors at debug level.', async(): Promise<void> => {
+    const error = new BadRequestHttpError('bad data');
+    source.handleSafe.mockRejectedValueOnce(error);
+    await expect(handler.handle({ request, response })).resolves.toBeUndefined();
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenLastCalledWith('Request failed with client error: BadRequestHttpError: bad data');
+    expect(logger.error).toHaveBeenCalledTimes(0);
+  });
+
+  it('logs server errors at error level, including the stack trace.', async(): Promise<void> => {
+    const error = new InternalServerError('server broke');
+    source.handleSafe.mockRejectedValueOnce(error);
+    await expect(handler.handle({ request, response })).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(2);
+    expect(logger.error)
+      .toHaveBeenNthCalledWith(1, 'Request failed with server error: InternalServerError: server broke');
+    expect(logger.error).toHaveBeenNthCalledWith(2, error.stack);
+    expect(logger.debug).toHaveBeenCalledTimes(0);
+  });
+
+  it('logs server errors without a stack trace if there is none.', async(): Promise<void> => {
+    const error = new InternalServerError('server broke');
+    delete error.stack;
+    source.handleSafe.mockRejectedValueOnce(error);
+    await expect(handler.handle({ request, response })).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error)
+      .toHaveBeenLastCalledWith('Request failed with server error: InternalServerError: server broke');
+    expect(logger.debug).toHaveBeenCalledTimes(0);
   });
 });

--- a/test/unit/server/ParsingHttpHandler.test.ts
+++ b/test/unit/server/ParsingHttpHandler.test.ts
@@ -33,7 +33,6 @@ describe('A ParsingHttpHandler', (): void => {
   let handler: ParsingHttpHandler;
 
   beforeEach(async(): Promise<void> => {
-    // Clearing the logger mock
     jest.clearAllMocks();
     requestParser = { handleSafe: jest.fn().mockResolvedValue(operation) } as any;
     errorHandler = { handleSafe: jest.fn().mockResolvedValue(errorResponse) } as any;


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the upstream template requires a related issue, so one needs to be created on CommunitySolidServer/CommunitySolidServer before this is submitted there.

#### ✍️ Description

A 500 response can currently be produced with zero log output above verbose level: `ParsingHttpHandler.handleError` hands the error to the `ErrorHandler` without logging, and the response writer emits the status silently. Operators cannot alert on server error rate — the most basic production signal.

`handleError` now logs:

* **≥ 500** at `error` level: `Request failed with server error: <name>: <message>`, followed by the stack as a second error-level entry when present. Because non-`HttpError`s are wrapped in `InternalServerError` first, every 500 path is covered.
* **< 500** at `debug` level: client errors are routine and often expected, so keeping them out of `info` avoids log noise.

Response behaviour is completely unchanged.

Note for review: for wrapped non-`HttpError`s the logged stack is the `InternalServerError` wrapper's stack (the cause is preserved in the message); logging the cause's stack instead would be a reasonable alternative.

This targets `main`: it only adds logging, with no interface or config-behaviour change, so the intended semver level is **semver.patch** (stated in prose — contributors cannot set labels). Verified with the full unit suite (100% `./src` coverage thresholds) and eslint at zero warnings.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
