### PR TITLE
feat: Log the identity of successful token grants

### DIFF
--- a/src/identity/configuration/IdentityProviderFactory.ts
+++ b/src/identity/configuration/IdentityProviderFactory.ts
@@ -164,6 +164,9 @@ export class IdentityProviderFactory implements ProviderFactory {
 
     this.captureErrorResponses(provider);
 
+    // Log the identity for which a token gets issued
+    this.configureGrantLogging(provider);
+
     return provider;
   }
 
@@ -203,6 +206,25 @@ export class IdentityProviderFactory implements ProviderFactory {
       }) as AcceptFn;
 
       return next();
+    });
+  }
+
+  /**
+   * Registers a listener that logs the client and account identifiers of every successful token grant,
+   * so operators can see which identity acquired a token at production log levels.
+   * Only identifiers are logged, never token values or secrets.
+   */
+  private configureGrantLogging(provider: Provider): void {
+    provider.on('grant.success', (ctx: KoaContextWithOIDC): void => {
+      const { Account: account, AccessToken: accessToken, Client: client } = ctx.oidc.entities;
+      const grantType = (ctx.oidc.params?.grant_type ?? 'unknown') as string;
+      let message = `Issued ${grantType} token for client ${client?.clientId ?? 'unknown'}`;
+      // Client credentials grants have no associated account
+      const accountId = account?.accountId ?? accessToken?.accountId;
+      if (accountId) {
+        message += ` and account ${accountId}`;
+      }
+      this.logger.info(message);
     });
   }
 

--- a/src/identity/configuration/IdentityProviderFactory.ts
+++ b/src/identity/configuration/IdentityProviderFactory.ts
@@ -210,8 +210,7 @@ export class IdentityProviderFactory implements ProviderFactory {
   }
 
   /**
-   * Registers a listener that logs the client and account identifiers of every successful token grant,
-   * so operators can see which identity acquired a token at production log levels.
+   * Registers a listener that logs the client and account identifiers of every successful token grant.
    * Only identifiers are logged, never token values or secrets.
    */
   private configureGrantLogging(provider: Provider): void {

--- a/src/identity/interaction/client-credentials/ClientCredentialsAdapterFactory.ts
+++ b/src/identity/interaction/client-credentials/ClientCredentialsAdapterFactory.ts
@@ -46,7 +46,7 @@ export class ClientCredentialsAdapter extends PassthroughAdapter {
         return payload;
       }
 
-      this.logger.debug(`Authenticating as ${credentials.webId} using client credentials`);
+      this.logger.info(`Authenticating as ${credentials.webId} using client credentials token ${label}`);
 
       /* eslint-disable @typescript-eslint/naming-convention */
       payload = {

--- a/test/unit/identity/configuration/IdentityProviderFactory.test.ts
+++ b/test/unit/identity/configuration/IdentityProviderFactory.test.ts
@@ -77,7 +77,6 @@ describe('An IdentityProviderFactory', (): void => {
   });
 
   beforeEach(async(): Promise<void> => {
-    // Clearing the logger mock
     jest.clearAllMocks();
 
     // Disabling devInteractions to prevent warnings when testing the path

--- a/test/unit/identity/configuration/IdentityProviderFactory.test.ts
+++ b/test/unit/identity/configuration/IdentityProviderFactory.test.ts
@@ -11,13 +11,21 @@ import type {
 import type { Interaction } from '../../../../src/identity/interaction/InteractionHandler';
 import type { InteractionRoute } from '../../../../src/identity/interaction/routing/InteractionRoute';
 import type { AdapterFactory } from '../../../../src/identity/storage/AdapterFactory';
+import type { Logger } from '../../../../src/logging/Logger';
+import { getLoggerFor } from '../../../../src/logging/LogUtil';
 import type { KeyValueStorage } from '../../../../src/storage/keyvalue/KeyValueStorage';
 import { extractErrorTerms } from '../../../../src/util/errors/HttpErrorUtil';
 import { OAuthHttpError } from '../../../../src/util/errors/OAuthHttpError';
 import type { Configuration, errors, KoaContextWithOIDC } from '../../../../templates/types/oidc-provider';
 
+jest.mock('../../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn(), warn: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+
 jest.mock('oidc-provider', (): any => {
-  const fn = jest.fn((issuer: string, config: Configuration): any => ({ issuer, config, use: jest.fn() }));
+  const fn = jest.fn((issuer: string, config: Configuration): any =>
+    ({ issuer, config, use: jest.fn(), on: jest.fn() }));
   // The base export is the Provider class, but we also need some of the deeper exports like interactionPolicy
   (fn as any).interactionPolicy = jest.requireActual('oidc-provider').interactionPolicy;
   return fn;
@@ -39,6 +47,7 @@ const routes = {
 };
 
 describe('An IdentityProviderFactory', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
   let jestWorkerId: string | undefined;
   let nodeEnv: string | undefined;
   let baseConfig: Configuration;
@@ -68,6 +77,9 @@ describe('An IdentityProviderFactory', (): void => {
   });
 
   beforeEach(async(): Promise<void> => {
+    // Clearing the logger mock
+    jest.clearAllMocks();
+
     // Disabling devInteractions to prevent warnings when testing the path
     // where we use the actual library instead of a mock.
     baseConfig = { claims: { webid: [ 'webid', 'client_webid' ]}, features: { devInteractions: { enabled: false }}};
@@ -332,6 +344,66 @@ describe('An IdentityProviderFactory', (): void => {
     expect(ctx.accepts('something')).toBe('type');
     expect(oldAccept).toHaveBeenCalledTimes(1);
     expect(oldAccept).toHaveBeenLastCalledWith('something');
+  });
+
+  it('logs the client and account of a successful token grant.', async(): Promise<void> => {
+    const provider = await factory.getProvider();
+    expect(provider.on).toHaveBeenCalledTimes(1);
+    expect(provider.on).toHaveBeenLastCalledWith('grant.success', expect.any(Function));
+    // eslint-disable-next-line jest/unbound-method
+    const listener = jest.mocked(provider.on).mock.calls[0][1] as (ctx: KoaContextWithOIDC) => void;
+
+    const grantCtx = {
+      oidc: {
+        params: { grant_type: 'authorization_code' },
+        entities: {
+          Client: { clientId: 'clientId' },
+          Account: { accountId: webId },
+        },
+      },
+    } as any;
+    listener(grantCtx);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenLastCalledWith(
+      `Issued authorization_code token for client clientId and account ${webId}`,
+    );
+  });
+
+  it('logs successful token grants without an account entity.', async(): Promise<void> => {
+    const provider = await factory.getProvider();
+    expect(provider.on).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line jest/unbound-method
+    const listener = jest.mocked(provider.on).mock.calls[0][1] as (ctx: KoaContextWithOIDC) => void;
+
+    const grantCtx = {
+      oidc: {
+        params: { grant_type: 'client_credentials' },
+        entities: {
+          Client: { clientId: 'token_123' },
+        },
+      },
+    } as any;
+    listener(grantCtx);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenLastCalledWith('Issued client_credentials token for client token_123');
+  });
+
+  it('falls back to the access token account when logging grants with missing entities.', async(): Promise<void> => {
+    const provider = await factory.getProvider();
+    expect(provider.on).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line jest/unbound-method
+    const listener = jest.mocked(provider.on).mock.calls[0][1] as (ctx: KoaContextWithOIDC) => void;
+
+    const grantCtx = {
+      oidc: {
+        entities: {
+          AccessToken: { accountId: webId },
+        },
+      },
+    } as any;
+    listener(grantCtx);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenLastCalledWith(`Issued unknown token for client unknown and account ${webId}`);
   });
 
   it('avoids dynamic imports when testing with Jest.', async(): Promise<void> => {

--- a/test/unit/identity/interaction/client-credentials/ClientCredentialsAdapterFactory.test.ts
+++ b/test/unit/identity/interaction/client-credentials/ClientCredentialsAdapterFactory.test.ts
@@ -9,8 +9,16 @@ import type {
 } from '../../../../../src/identity/interaction/client-credentials/util/ClientCredentialsStore';
 import type { WebIdStore } from '../../../../../src/identity/interaction/webid/util/WebIdStore';
 import type { AdapterFactory } from '../../../../../src/identity/storage/AdapterFactory';
+import type { Logger } from '../../../../../src/logging/Logger';
+import { getLoggerFor } from '../../../../../src/logging/LogUtil';
+
+jest.mock('../../../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { error: jest.fn(), info: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
 
 describe('A ClientCredentialsAdapterFactory', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
   const webId = 'http://example.com/card#me';
   const id = '123456';
   const accountId = 'accountId;';
@@ -25,6 +33,9 @@ describe('A ClientCredentialsAdapterFactory', (): void => {
   let factory: ClientCredentialsAdapterFactory;
 
   beforeEach(async(): Promise<void> => {
+    // Clearing the logger mock
+    jest.clearAllMocks();
+
     sourceAdapter = {
       find: jest.fn(),
     } satisfies Partial<Adapter> as any;
@@ -78,6 +89,10 @@ describe('A ClientCredentialsAdapterFactory', (): void => {
     expect(credentialsStore.findByLabel).toHaveBeenLastCalledWith(label);
     expect(credentialsStore.delete).toHaveBeenCalledTimes(1);
     expect(credentialsStore.delete).toHaveBeenLastCalledWith(id);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith(
+      `Client credentials token ${label} contains WebID that is no longer linked to the account. Removing...`,
+    );
   });
 
   it('returns valid client_credentials Client metadata if a matching token was found.', async(): Promise<void> => {
@@ -93,5 +108,9 @@ describe('A ClientCredentialsAdapterFactory', (): void => {
     expect(sourceAdapter.find).toHaveBeenLastCalledWith(label);
     expect(credentialsStore.findByLabel).toHaveBeenCalledTimes(1);
     expect(credentialsStore.findByLabel).toHaveBeenLastCalledWith(label);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenLastCalledWith(
+      `Authenticating as ${webId} using client credentials token ${label}`,
+    );
   });
 });

--- a/test/unit/identity/interaction/client-credentials/ClientCredentialsAdapterFactory.test.ts
+++ b/test/unit/identity/interaction/client-credentials/ClientCredentialsAdapterFactory.test.ts
@@ -33,7 +33,6 @@ describe('A ClientCredentialsAdapterFactory', (): void => {
   let factory: ClientCredentialsAdapterFactory;
 
   beforeEach(async(): Promise<void> => {
-    // Clearing the logger mock
     jest.clearAllMocks();
 
     sourceAdapter = {


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the CSS PR template requires a linked issue, so an upstream issue describing the gap (no identity is logged for successful token issuance at production log levels) must be created via <https://github.com/CommunitySolidServer/CommunitySolidServer/issues/new/choose> before this is submitted upstream.

#### ✍️ Description

Successful token issuance is invisible at production log levels: `POST /.oidc/token` logs no identity at `info`, so an operator cannot see which client obtained a token or for which account. This PR makes every successful grant observable, so operators can see which identity acquired a token at production log levels. Two changes:

1. `IdentityProviderFactory` registers a `grant.success` listener that logs the grant type, client id, and (when present) account id at `info`, e.g.
    * `Issued authorization_code token for client <clientId> and account <webId>`
    * `Issued client_credentials token for client token_123` (no account entity on that flow)

    The `Client`/`Account`/`AccessToken` entities are read defensively since each can be absent depending on the grant type; when the `Account` entity is absent, the account id falls back to the access token's. Refresh grants logging too is intentional. Only identifiers are ever logged — never token values or secrets.
2. `ClientCredentialsAdapterFactory` raises its `Authenticating as <webId> using client credentials token <label>` line from `debug` to `info` and adds the token label, so the stored client-credentials token path is attributable as well (it fires when such a token authenticates at the token endpoint).

Together with the companion request-logging PRs on this fork (jeswr/CommunitySolidServer#41 and jeswr/CommunitySolidServer#42), these lines make token issuance → token usage traceable end to end.

When submitted upstream, this should target the latest `versions/*` branch (a backwards-compatible feature addition, not a patch fix). Intended semver level: **semver.minor** — stated in prose because contributors cannot set labels.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
