### PR TITLE
feat: Add a health endpoint

### DIFF
--- a/config/http/handler/default.json
+++ b/config/http/handler/default.json
@@ -1,6 +1,7 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
   "import": [
+    "css:config/http/handler/handlers/health.json",
     "css:config/http/handler/handlers/storage-description.json"
   ],
   "@graph": [
@@ -14,6 +15,7 @@
           "@id": "urn:solid-server:default:BaseHttpHandler",
           "@type": "WaterfallHandler",
           "handlers": [
+            { "@id": "urn:solid-server:default:HealthHandler" },
             { "@id": "urn:solid-server:default:StaticAssetHandler" },
             { "@id": "urn:solid-server:default:OidcHandler" },
             { "@id": "urn:solid-server:default:NotificationHttpHandler" },

--- a/config/http/handler/handlers/health.json
+++ b/config/http/handler/handlers/health.json
@@ -1,0 +1,11 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Responds to liveness requests so external tools can verify that the server is running.",
+      "@id": "urn:solid-server:default:HealthHandler",
+      "@type": "HealthHandler",
+      "path": "/.well-known/css/health"
+    }
+  ]
+}

--- a/config/http/handler/simple.json
+++ b/config/http/handler/simple.json
@@ -1,6 +1,7 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
   "import": [
+    "css:config/http/handler/handlers/health.json",
     "css:config/http/handler/handlers/storage-description.json"
   ],
   "@graph": [
@@ -14,6 +15,7 @@
           "@id": "urn:solid-server:default:BaseHttpHandler",
           "@type": "WaterfallHandler",
           "handlers": [
+            { "@id": "urn:solid-server:default:HealthHandler" },
             { "@id": "urn:solid-server:default:StaticAssetHandler" },
             { "@id": "urn:solid-server:default:StorageDescriptionHandler" },
             { "@id": "urn:solid-server:default:LdpHandler" }

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -73,6 +73,19 @@ They are prefixed with `CSS_` and converted from `camelCase` to `CAMEL_CASE`
 
 Command-line arguments will always override environment variables.
 
+## Verifying that the server is running
+
+The default configurations expose a health endpoint at `/.well-known/css/health`.
+A `GET` request to it returns a `200` response with body `{"status":"ok"}` once the server is up:
+
+```shell
+curl http://localhost:3000/.well-known/css/health
+```
+
+This is a liveness check only:
+it indicates that the server process is accepting HTTP requests,
+but does not verify the state of the backend storage.
+
 ## Alternative ways to run the server
 
 ### From source

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,6 +377,7 @@ export * from './server/description/StorageLocationStrategy';
 export * from './server/middleware/AcpHeaderHandler';
 export * from './server/middleware/CorsHandler';
 export * from './server/middleware/HeaderHandler';
+export * from './server/middleware/HealthHandler';
 export * from './server/middleware/StaticAssetHandler';
 export * from './server/middleware/WebSocketAdvertiser';
 

--- a/src/server/middleware/HealthHandler.ts
+++ b/src/server/middleware/HealthHandler.ts
@@ -1,0 +1,53 @@
+import { getLoggerFor } from '../../logging/LogUtil';
+import { APPLICATION_JSON } from '../../util/ContentTypes';
+import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import type { HttpHandlerInput } from '../HttpHandler';
+import { HttpHandler } from '../HttpHandler';
+
+/**
+ * Handler that responds to liveness requests on a fixed URL path.
+ * A 200 response only indicates that the server process is up and able to answer HTTP requests;
+ * no backend storage is verified.
+ */
+export class HealthHandler extends HttpHandler {
+  private readonly path: string;
+  private readonly logger = getLoggerFor(this);
+
+  /**
+   * Creates a handler that answers health requests on the given path.
+   *
+   * @param path - The URL path on which to respond to health requests.
+   */
+  public constructor(path = '/.well-known/css/health') {
+    super();
+    this.path = path;
+  }
+
+  public async canHandle({ request }: HttpHandlerInput): Promise<void> {
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      throw new NotImplementedHttpError('Only GET and HEAD requests are supported');
+    }
+    // Ignore the query string when comparing paths
+    const path = (request.url ?? '').split('?')[0];
+    if (path !== this.path) {
+      throw new NotImplementedHttpError(`Only requests to ${this.path} are supported`);
+    }
+  }
+
+  public async handle({ request, response }: HttpHandlerInput): Promise<void> {
+    this.logger.debug(`Responding to health request on ${request.url}`);
+    response.writeHead(200, {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'content-type': APPLICATION_JSON,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'cache-control': 'no-store',
+    });
+
+    // With HEAD, only write the headers
+    if (request.method === 'HEAD') {
+      response.end();
+    } else {
+      response.end(JSON.stringify({ status: 'ok' }));
+    }
+  }
+}

--- a/src/server/middleware/HealthHandler.ts
+++ b/src/server/middleware/HealthHandler.ts
@@ -14,8 +14,6 @@ export class HealthHandler extends HttpHandler {
   private readonly logger = getLoggerFor(this);
 
   /**
-   * Creates a handler that answers health requests on the given path.
-   *
    * @param path - The URL path on which to respond to health requests.
    */
   public constructor(path = '/.well-known/css/health') {
@@ -43,7 +41,6 @@ export class HealthHandler extends HttpHandler {
       'cache-control': 'no-store',
     });
 
-    // With HEAD, only write the headers
     if (request.method === 'HEAD') {
       response.end();
     } else {

--- a/test/unit/server/middleware/HealthHandler.test.ts
+++ b/test/unit/server/middleware/HealthHandler.test.ts
@@ -1,0 +1,85 @@
+import type { HttpRequest } from '../../../../src/server/HttpRequest';
+import type { HttpResponse } from '../../../../src/server/HttpResponse';
+import { HealthHandler } from '../../../../src/server/middleware/HealthHandler';
+import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
+
+describe('A HealthHandler', (): void => {
+  let request: HttpRequest;
+  let response: jest.Mocked<HttpResponse>;
+  let handler: HealthHandler;
+
+  beforeEach(async(): Promise<void> => {
+    request = { method: 'GET', url: '/.well-known/css/health' } as any;
+    response = {
+      writeHead: jest.fn(),
+      end: jest.fn(),
+    } as any;
+    handler = new HealthHandler();
+  });
+
+  it('rejects requests that are not GET or HEAD requests.', async(): Promise<void> => {
+    request.method = 'POST';
+    await expect(handler.canHandle({ request, response })).rejects.toThrow(NotImplementedHttpError);
+    expect(response.writeHead).toHaveBeenCalledTimes(0);
+    expect(response.end).toHaveBeenCalledTimes(0);
+  });
+
+  it('rejects requests without a URL.', async(): Promise<void> => {
+    delete request.url;
+    await expect(handler.canHandle({ request, response })).rejects.toThrow(NotImplementedHttpError);
+    expect(response.writeHead).toHaveBeenCalledTimes(0);
+    expect(response.end).toHaveBeenCalledTimes(0);
+  });
+
+  it('rejects requests targeting a different path.', async(): Promise<void> => {
+    request.url = '/other';
+    await expect(handler.canHandle({ request, response })).rejects.toThrow(NotImplementedHttpError);
+    expect(response.writeHead).toHaveBeenCalledTimes(0);
+    expect(response.end).toHaveBeenCalledTimes(0);
+  });
+
+  it('accepts GET requests targeting the health path.', async(): Promise<void> => {
+    await expect(handler.canHandle({ request, response })).resolves.toBeUndefined();
+  });
+
+  it('accepts HEAD requests targeting the health path.', async(): Promise<void> => {
+    request.method = 'HEAD';
+    await expect(handler.canHandle({ request, response })).resolves.toBeUndefined();
+  });
+
+  it('ignores the query string when comparing paths.', async(): Promise<void> => {
+    request.url = '/.well-known/css/health?abc=xyz';
+    await expect(handler.canHandle({ request, response })).resolves.toBeUndefined();
+  });
+
+  it('supports a custom path.', async(): Promise<void> => {
+    handler = new HealthHandler('/health');
+    request.url = '/health';
+    await expect(handler.canHandle({ request, response })).resolves.toBeUndefined();
+    request.url = '/.well-known/css/health';
+    await expect(handler.canHandle({ request, response })).rejects.toThrow(NotImplementedHttpError);
+  });
+
+  it('writes a 200 JSON response on GET requests.', async(): Promise<void> => {
+    await expect(handler.handleSafe({ request, response })).resolves.toBeUndefined();
+    expect(response.writeHead).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenCalledWith(200, {
+      'content-type': 'application/json',
+      'cache-control': 'no-store',
+    });
+    expect(response.end).toHaveBeenCalledTimes(1);
+    expect(response.end).toHaveBeenCalledWith('{"status":"ok"}');
+  });
+
+  it('writes no body on HEAD requests.', async(): Promise<void> => {
+    request.method = 'HEAD';
+    await expect(handler.handleSafe({ request, response })).resolves.toBeUndefined();
+    expect(response.writeHead).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenCalledWith(200, {
+      'content-type': 'application/json',
+      'cache-control': 'no-store',
+    });
+    expect(response.end).toHaveBeenCalledTimes(1);
+    expect(response.end).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — an upstream issue still needs to be created before this is submitted to CommunitySolidServer (the upstream template requires a linked issue).

#### ✍️ Description

CSS has no health endpoint: a Kubernetes/ELB/Docker health probe today has to hit `GET /`, which traverses the full parse → authorize → store → convert LDP stack and can fail for reasons unrelated to process health.

This adds a minimal liveness endpoint:

- A new `HealthHandler` (`src/server/middleware/`) answers `GET`/`HEAD` on a configurable path (default `/.well-known/css/health`, consistent with the existing `.well-known/css/` namespace) with `200`, `Content-Type: application/json`, `Cache-Control: no-store`, and body `{"status":"ok"}` (no body on HEAD). Query strings are ignored; every other request falls through the waterfall untouched.
- It is wired as the first member of the `BaseHttpHandler` waterfall in `config/http/handler/default.json` and `simple.json`, so probes cost no LDP work.
- Documented in `starting-server.md` ("Verifying that the server is running").

Deliberately liveness-only — it does not probe storage, so a `200` only means the process is accepting HTTP requests. A readiness variant (storage checks) would be a separate follow-up if wanted.

Notes for review:

- Path comparison is exact: `/.well-known/css/health/` (trailing slash) falls through to the LDP handler by design; slash-tolerance is easy to add if preferred.
- `simple.json` gets the same wiring for parity with `default.json`; that hunk can be dropped if a minimal diff is preferred.
- Verified locally: `npm run build` (including components generation for the new handler), the full unit suite with the 100% `./src` coverage gate, and zero-warning lint are all green; a booted `config/default.json` answers `curl /.well-known/css/health` with `200 {"status":"ok"}` and the expected headers, HEAD returns no body, and normal LDP requests are unaffected.

This is a backwards-compatible feature addition, so the intended semver level is **semver.minor** (contributors cannot set the label). Per the branch rules, the upstream submission should target the latest `versions/*` branch (currently `versions/next-major`), not `main` — this fork-internal draft targets `main` only for review here.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
