### PR TITLE
perf: Skip stack-trace capture for client-error control flow

### DIFF
--- a/src/server/HandlerServerConfigurator.ts
+++ b/src/server/HandlerServerConfigurator.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
 import { getLoggerFor } from '../logging/LogUtil';
 import { isError } from '../util/errors/ErrorUtil';
+import { HttpError } from '../util/errors/HttpError';
 import { guardStream } from '../util/GuardedStream';
 import type { HttpHandler } from './HttpHandler';
 import { ServerConfigurator } from './ServerConfigurator';
@@ -22,10 +23,25 @@ export class HandlerServerConfigurator extends ServerConfigurator {
   private readonly handler: HttpHandler;
   private readonly showStackTrace: boolean;
 
+  /**
+   * Creates a new configurator with the given settings.
+   *
+   * @param handler - The handler that will handle all incoming requests.
+   * @param showStackTrace - If error stack traces should be part of error outputs.
+   *   When enabled, this also sets {@link HttpError.captureStackTraces} to `true`,
+   *   so errors that skip stack trace capturing by default, for performance reasons,
+   *   capture complete stack traces as well.
+   *   This guarantees that `error.stack` contains stack frames
+   *   whenever it is used to create an error message,
+   *   as that only happens when `showStackTrace` is enabled.
+   */
   public constructor(handler: HttpHandler, showStackTrace = false) {
     super();
     this.handler = handler;
     this.showStackTrace = showStackTrace;
+    if (showStackTrace) {
+      HttpError.captureStackTraces = true;
+    }
   }
 
   public async handle(server: Server): Promise<void> {
@@ -58,6 +74,9 @@ export class HandlerServerConfigurator extends ServerConfigurator {
 
   /**
    * Creates a readable error message based on the error and the `showStackTrace` parameter.
+   * `error.stack` is only used when `showStackTrace` is enabled,
+   * in which case the constructor made sure {@link HttpError.captureStackTraces} is enabled,
+   * so the stack always contains complete stack frames here.
    */
   private createErrorMessage(error: unknown): string {
     if (!isError(error)) {

--- a/src/server/HandlerServerConfigurator.ts
+++ b/src/server/HandlerServerConfigurator.ts
@@ -23,23 +23,12 @@ export class HandlerServerConfigurator extends ServerConfigurator {
   private readonly handler: HttpHandler;
   private readonly showStackTrace: boolean;
 
-  /**
-   * Creates a new configurator with the given settings.
-   *
-   * @param handler - The handler that will handle all incoming requests.
-   * @param showStackTrace - If error stack traces should be part of error outputs.
-   *   When enabled, this also sets {@link HttpError.captureStackTraces} to `true`,
-   *   so errors that skip stack trace capturing by default, for performance reasons,
-   *   capture complete stack traces as well.
-   *   This guarantees that `error.stack` contains stack frames
-   *   whenever it is used to create an error message,
-   *   as that only happens when `showStackTrace` is enabled.
-   */
   public constructor(handler: HttpHandler, showStackTrace = false) {
     super();
     this.handler = handler;
     this.showStackTrace = showStackTrace;
     if (showStackTrace) {
+      // Stack traces need to be captured if they are going to be shown
       HttpError.captureStackTraces = true;
     }
   }
@@ -74,9 +63,6 @@ export class HandlerServerConfigurator extends ServerConfigurator {
 
   /**
    * Creates a readable error message based on the error and the `showStackTrace` parameter.
-   * `error.stack` is only used when `showStackTrace` is enabled,
-   * in which case the constructor made sure {@link HttpError.captureStackTraces} is enabled,
-   * so the stack always contains complete stack frames here.
    */
   private createErrorMessage(error: unknown): string {
     if (!isError(error)) {

--- a/src/util/errors/HttpError.ts
+++ b/src/util/errors/HttpError.ts
@@ -22,6 +22,23 @@ export function generateHttpErrorUri(statusCode: number): NamedNode {
  * All errors inheriting from this should fix the status code thereby hiding the HTTP internals from other components.
  */
 export class HttpError<T extends number = number> extends Error implements HttpErrorOptions {
+  /**
+   * Determines whether stack traces are captured when constructing errors that are used for control flow.
+   * This covers all errors with a status code below 500, and the 501 status code,
+   * as those are thrown constantly while checking which handler in a chain supports a request.
+   * Capturing their stack traces is expensive and the result is almost never used,
+   * so it is disabled by default.
+   * Server errors (status code 500 and above, except for 501) always capture a stack trace,
+   * regardless of this value, as those indicate bugs and get logged.
+   *
+   * When capturing is disabled, the `stack` field of such an error is still a defined string,
+   * containing the usual `Name: message` header line, but without any stack frames.
+   *
+   * A {@link HandlerServerConfigurator} sets this value to `true` when its `showStackTrace` option is enabled,
+   * so stack traces are guaranteed to be complete on deployments where they get shown.
+   */
+  public static captureStackTraces = false;
+
   public readonly statusCode: T;
   public readonly cause?: unknown;
   public readonly errorCode: string;
@@ -36,7 +53,16 @@ export class HttpError<T extends number = number> extends Error implements HttpE
    * @param options - Optional options.
    */
   public constructor(statusCode: T, name: string, message?: string, options: HttpErrorOptions = {}) {
+    // Any statement is allowed before `super()` as long as `this` is not accessed,
+    // so the stack trace capture performed by the `Error` constructor can be suppressed
+    // by temporarily setting `Error.stackTraceLimit` to 0.
+    // See the documentation of `captureStackTraces` for why this is done.
+    const previousLimit = Error.stackTraceLimit;
+    if (!HttpError.captureStackTraces && (statusCode < 500 || statusCode === 501)) {
+      Error.stackTraceLimit = 0;
+    }
     super(message);
+    Error.stackTraceLimit = previousLimit;
     this.statusCode = statusCode;
     this.name = name;
     this.cause = options.cause;

--- a/src/util/errors/HttpError.ts
+++ b/src/util/errors/HttpError.ts
@@ -23,19 +23,12 @@ export function generateHttpErrorUri(statusCode: number): NamedNode {
  */
 export class HttpError<T extends number = number> extends Error implements HttpErrorOptions {
   /**
-   * Determines whether stack traces are captured when constructing errors that are used for control flow.
-   * This covers all errors with a status code below 500, and the 501 status code,
-   * as those are thrown constantly while checking which handler in a chain supports a request.
-   * Capturing their stack traces is expensive and the result is almost never used,
-   * so it is disabled by default.
-   * Server errors (status code 500 and above, except for 501) always capture a stack trace,
-   * regardless of this value, as those indicate bugs and get logged.
-   *
-   * When capturing is disabled, the `stack` field of such an error is still a defined string,
-   * containing the usual `Name: message` header line, but without any stack frames.
-   *
-   * A {@link HandlerServerConfigurator} sets this value to `true` when its `showStackTrace` option is enabled,
-   * so stack traces are guaranteed to be complete on deployments where they get shown.
+   * Determines whether stack traces are captured when constructing errors that are used for control flow,
+   * which covers all errors with a status code below 500, and the 501 status code.
+   * Such errors get thrown constantly while checking which handler in a chain supports a request,
+   * so capturing their stack traces is expensive while the result is almost never used.
+   * Server errors always capture a stack trace, as those indicate bugs and get logged.
+   * When capturing is disabled, the `stack` field still contains the `Name: message` line, but no stack frames.
    */
   public static captureStackTraces = false;
 
@@ -53,10 +46,7 @@ export class HttpError<T extends number = number> extends Error implements HttpE
    * @param options - Optional options.
    */
   public constructor(statusCode: T, name: string, message?: string, options: HttpErrorOptions = {}) {
-    // Any statement is allowed before `super()` as long as `this` is not accessed,
-    // so the stack trace capture performed by the `Error` constructor can be suppressed
-    // by temporarily setting `Error.stackTraceLimit` to 0.
-    // See the documentation of `captureStackTraces` for why this is done.
+    // Setting `Error.stackTraceLimit` to 0 makes the `Error` constructor skip the expensive stack trace capture
     const previousLimit = Error.stackTraceLimit;
     if (!HttpError.captureStackTraces && (statusCode < 500 || statusCode === 501)) {
       Error.stackTraceLimit = 0;

--- a/test/unit/server/HandlerServerConfigurator.test.ts
+++ b/test/unit/server/HandlerServerConfigurator.test.ts
@@ -5,6 +5,7 @@ import type { Logger } from '../../../src/logging/Logger';
 import { getLoggerFor } from '../../../src/logging/LogUtil';
 import { HandlerServerConfigurator } from '../../../src/server/HandlerServerConfigurator';
 import type { HttpHandler } from '../../../src/server/HttpHandler';
+import { HttpError } from '../../../src/util/errors/HttpError';
 import { flushPromises } from '../../util/Util';
 
 jest.mock('../../../src/logging/LogUtil', (): any => {
@@ -49,6 +50,11 @@ describe('A HandlerServerConfigurator', (): void => {
 
     listener = new HandlerServerConfigurator(handler);
     await listener.handle(server);
+  });
+
+  afterEach(async(): Promise<void> => {
+    // Prevent side effects on other tests as this is a static field
+    HttpError.captureStackTraces = false;
   });
 
   it('sends incoming requests to the handler.', async(): Promise<void> => {
@@ -139,5 +145,20 @@ describe('A HandlerServerConfigurator', (): void => {
     expect(response.writeHead).toHaveBeenLastCalledWith(500);
     expect(response.end).toHaveBeenCalledTimes(1);
     expect(response.end).toHaveBeenLastCalledWith(`${error.stack}\n`);
+  });
+
+  it('does not enable HttpError stack trace capturing if showStackTrace is disabled.', async(): Promise<void> => {
+    // The listener created in `beforeEach` has `showStackTrace` disabled
+    expect(HttpError.captureStackTraces).toBe(false);
+    const error = new HttpError(404, 'NotFoundHttpError', 'dummyError');
+    expect(error.stack).toBe('NotFoundHttpError: dummyError');
+  });
+
+  it('enables HttpError stack trace capturing if showStackTrace is enabled.', async(): Promise<void> => {
+    expect(HttpError.captureStackTraces).toBe(false);
+    listener = new HandlerServerConfigurator(handler, true);
+    expect(HttpError.captureStackTraces).toBe(true);
+    const error = new HttpError(404, 'NotFoundHttpError', 'dummyError');
+    expect(error.stack).toContain('\n    at ');
   });
 });

--- a/test/unit/util/errors/HttpError.test.ts
+++ b/test/unit/util/errors/HttpError.test.ts
@@ -3,7 +3,7 @@ import { RepresentationMetadata } from '../../../../src/http/representation/Repr
 import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
 import { ConflictHttpError } from '../../../../src/util/errors/ConflictHttpError';
 import { ForbiddenHttpError } from '../../../../src/util/errors/ForbiddenHttpError';
-import { generateHttpErrorUri } from '../../../../src/util/errors/HttpError';
+import { generateHttpErrorUri, HttpError } from '../../../../src/util/errors/HttpError';
 import type { HttpErrorClass } from '../../../../src/util/errors/HttpError';
 import { InternalServerError } from '../../../../src/util/errors/InternalServerError';
 import { MethodNotAllowedHttpError } from '../../../../src/util/errors/MethodNotAllowedHttpError';
@@ -131,6 +131,39 @@ describe('HttpError', (): void => {
         .toBe(`${SOLID_ERROR.namespace}H304`);
       expect(instance.metadata.get(HTTP.terms.statusCodeNumber)?.value).toBe('304');
       expect(instance.metadata.get(HH.terms.etag)?.value).toBe(eTag);
+    });
+  });
+
+  describe('stack trace capturing', (): void => {
+    const originalLimit = Error.stackTraceLimit;
+
+    afterEach((): void => {
+      HttpError.captureStackTraces = false;
+    });
+
+    it('does not capture stack frames for client errors by default.', (): void => {
+      const error = new NotFoundHttpError('my message');
+      expect(error.stack).toBe('NotFoundHttpError: my message');
+      expect(Error.stackTraceLimit).toBe(originalLimit);
+    });
+
+    it('does not capture stack frames for the control flow 501 error by default.', (): void => {
+      const error = new NotImplementedHttpError('my message');
+      expect(error.stack).toBe('NotImplementedHttpError: my message');
+      expect(Error.stackTraceLimit).toBe(originalLimit);
+    });
+
+    it('captures stack frames for client errors if captureStackTraces is enabled.', (): void => {
+      HttpError.captureStackTraces = true;
+      const error = new NotFoundHttpError('my message');
+      expect(error.stack).toContain('\n    at ');
+      expect(Error.stackTraceLimit).toBe(originalLimit);
+    });
+
+    it('always captures stack frames for server errors.', (): void => {
+      const error = new InternalServerError('my message');
+      expect(error.stack).toContain('\n    at ');
+      expect(Error.stackTraceLimit).toBe(originalLimit);
     });
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the upstream template requires a related issue, so one describing the control-flow stack-capture cost must be created on CommunitySolidServer/CommunitySolidServer before this is submitted there.

#### ✍️ Description

CPU-profiling a hot LDP GET workload showed the `HttpError` constructor consuming **7.6% of request-path CPU**. Instrumentation counted **61,037 error constructions for 1,070 successful requests — 57 per request** (46× `NotImplementedHttpError` from `canHandle` probing in the Waterfall/Union handler chains, 11× `NotFoundHttpError` from auxiliary/`.meta` lookups). Every one captures a deep async stack trace that nothing ever reads: these are pure control-flow errors.

`HttpError` now skips the V8 stack snapshot for **client-error classes (4xx and the control-flow 501)** by zeroing `Error.stackTraceLimit` immediately before `super(message)` and unconditionally restoring it right after. Server errors (≥ 500 except 501) always capture stacks — they indicate bugs and get logged.

Why this is safe:

- `error.stack` stays a defined string (the `Name: message` header line survives), so all "if stack defined" consumers (`ErrorToJsonConverter`, `SafeErrorHandler`, …) behave as before, and `.stack` remains assignable (`IdentityProviderFactory` copies oidc-provider stacks onto errors).
- **Debugging escape hatch**: the new static `HttpError.captureStackTraces` (default `false`). `HandlerServerConfigurator` sets it to `true` when constructed with `showStackTrace`, so running with `--showStackTrace` restores full stacks everywhere. `error.stack` frames are only *read* (in `createErrorMessage`) when `showStackTrace` is on — exactly the case in which capture is re-enabled, so shown stacks are always complete.
- All `.stack` readers in `src/` and `.stack` assertions in `test/` were audited; the two cross-instance assertions use stacks copied from plain `Error`s (unaffected).

Alternative considered: reducing the 57 constructions per request (error-free `canHandle` probing) would remove the cost at the root, but it is a much more invasive architectural change to handler semantics. This PR removes most of the cost without touching them; construction-count reduction can be a follow-up investigation.

**Benchmarks.** The deterministic evidence is the instrumented construction count above (a counter in the `HttpError` constructor under the workload below). The wall-clock numbers come from a local ad-hoc load harness that is not part of this repo — there is no reproducible in-repo command — so treat them as directional only. Setup: 2 shared cores, `config/file.json`, 20 concurrent connections × 60 s, 2 alternating runs per side; zero request errors in all runs.

| Scenario | `main` | this PR | Δ rps |
|---|---|---|---|
| LDP GET (hot resource) | 106 / 106 rps | 108 / 117 rps | **+6.1%** |
| LDP GET (spread) | 95 / 85 rps | 104 / 104 rps | **+15.6%** |
| LDP PUT | 78 / 75 rps | 79 / 79 rps | +3.3% |
| Container listing (100 children) | 19 / 19 rps | 18 / 19 rps | ~flat |

p50 latency dropped on every LDP scenario (hot GET 178→165 ms, spread 213→181 ms). The harness's separate-boot root-GET scenario was too noisy to read (~1,000 rps saturates the shared box), so it was re-measured with both servers booted simultaneously and load alternating between them: `main` 759/817/843 rps vs this PR 878/948/909 rps — **+13%**, with every pair separated in the same direction.

**Branch target and semver.** The upstream submission should target the latest `versions/*` branch (`versions/next-major`) rather than `main`: this adds a public static field and observably changes `stack` contents for client errors unless `--showStackTrace` is enabled. Intended semver level: **minor** (backwards-compatible feature addition; stated in prose since contributors cannot set labels). No `RELEASE_NOTES.md` entry — the generated CHANGELOG covers it.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
