### PR TITLE
fix: Resolve the koa security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12944,9 +12944,9 @@
       }
     },
     "node_modules/koa": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
-      "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz",
+      "integrity": "sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^1.3.5",
@@ -26984,9 +26984,9 @@
       "dev": true
     },
     "koa": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
-      "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz",
+      "integrity": "sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==",
       "requires": {
         "accepts": "^1.3.5",
         "cache-content-type": "^1.0.0",
@@ -27840,7 +27840,7 @@
         "got": "^13.0.0",
         "jose": "^5.1.3",
         "jsesc": "^3.0.2",
-        "koa": "^2.14.2",
+        "koa": "^2.16.4",
         "nanoid": "^5.0.4",
         "object-hash": "^3.0.0",
         "oidc-token-hash": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,9 @@
     "yargs": "^17.7.2",
     "yup": "^1.3.2"
   },
+  "overrides": {
+    "koa": "^2.16.4"
+  },
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue must be created at CommunitySolidServer/CommunitySolidServer before this is submitted upstream (the PR template requires one).

#### ✍️ Description

`npm audit --omit=dev` reports two HIGH advisories against `koa@2.16.1`, reachable only through `oidc-provider@8.4.3` → `koa` (CSS's sole koa dependency path):

- **GHSA-jgmv-j7ww-jx2x** (CVE-2025-8129): open redirect via the Referrer header in `ctx.redirect('back')`. Patched in koa 2.16.2.
- **GHSA-7gcc-r8m5-44qm**: Host-header injection via `ctx.hostname` (koa splits `Host` on the first colon without RFC 3986 validation). Patched in koa 2.16.4.

The fix is a `package.json` override (`"overrides": { "koa": "^2.16.4" }`) plus the regenerated lockfile. After it, `npm audit --omit=dev` reports 0 high / 0 critical and no koa findings (the 9 pre-existing moderates — comunica→uuid and js-yaml — are unrelated). The override is semver-safe: koa 2.16.4 satisfies oidc-provider's declared `^2.14.2`, and koa's dependency list is identical between 2.16.1 and 2.16.4, so the rest of the transitive tree is unchanged.

Why not bump `oidc-provider` instead: no 8.x release pins a patched koa (they all declare caret ranges), so a bump would not guarantee the fixed version while pulling in far more behaviour change.

Neither advisory appears exploitable in CSS today: `ctx.redirect('back')` is never called on the production path (CSS enters koa only through `provider.callback()` in `src/identity/OidcHttpHandler.ts`), and oidc-provider does not consume the affected `ctx.hostname` getter on its request path. This is therefore hygiene / defense-in-depth — it clears the audit and hardens the host-trust surface for deployments behind a Host-forwarding proxy (CSS sets `provider.proxy = true`).

Validation note for reviewers: this is a manifest/lockfile-only change and the local checkout was not reinstalled, so koa 2.16.4 has not been executed here. The meaningful validation is a fresh `npm ci` (confirming koa@2.16.4 resolves) plus the identity/OIDC integration suites, which exercise the koa-backed `provider.callback()` path — CI covers both.

Intended semver level: **semver.patch** (backwards-compatible dependency fix; contributors cannot set labels). Targets `main` — no interface or configuration-behaviour change, so no `versions/*` branch is needed.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
