### PR TITLE
chore: Harden the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY . .
 # Install and build the Solid community server
 RUN npm ci && npm run build
 
-# Remove the development dependencies as the runtime stage only needs production dependencies.
-# --ignore-scripts prevents the root prepare script (a full build requiring development dependencies) from running.
+# The runtime stage only needs the production dependencies;
+# --ignore-scripts prevents the root prepare script (a full build) from running
 RUN npm prune --omit=dev --ignore-scripts
 
 
@@ -22,23 +22,19 @@ FROM node:18-alpine
 # Add contact informations for questions about the container
 LABEL maintainer="Solid Community Server Docker Image Maintainer <thomas.dupont@ugent.be>"
 
-# tini runs as PID 1, reaps zombie processes,
-# and forwards signals such as the SIGTERM from `docker stop` to the node process,
-# which would otherwise ignore them while running as PID 1.
+# Use tini as PID 1 to reap zombies and forward signals such as the SIGTERM from `docker stop` to node
 RUN apk add --no-cache tini
 
-# Container config & data dir for volume sharing.
-# Defaults to filestorage with /data directory (passed through CMD below).
-# Owned by the non-root node user (uid 1000) the server runs as,
-# so named volumes and bind mounts remain writable.
+# Container config & data dir for volume sharing
+# Defaults to filestorage with /data directory (passed through CMD below)
+# Owned by the non-root node user so mounted volumes stay writable
 RUN mkdir -p /config /data && chown node:node /config /data
 
 # Set current directory
 WORKDIR /community-server
 
-# Copy runtime files from build stage.
-# The application files stay owned by root so the server process cannot modify them;
-# all runtime writes go to /data (or wherever -f / CSS_ROOT_FILE_PATH points).
+# Copy runtime files from build stage
+# Application files stay root-owned so the runtime user cannot modify them
 COPY --from=build /community-server/package.json .
 COPY --from=build /community-server/bin ./bin
 COPY --from=build /community-server/config ./config
@@ -58,9 +54,7 @@ ENV NODE_ENV=production
 ENV CSS_CONFIG=config/file.json
 ENV CSS_ROOT_FILE_PATH=/data
 
-# Periodically check the health endpoint of the server.
-# The check follows the CSS_PORT environment variable if set;
-# it needs to be overridden when configuring the port through other means.
+# The health check follows CSS_PORT; override it when the port is configured through other means
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD node -e "fetch('http://localhost:' + (process.env.CSS_PORT ?? 3000) + '/.well-known/css/health').then((res) => process.exit(res.ok ? 0 : 1)).catch(() => process.exit(1))"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,12 @@ WORKDIR /community-server
 # Copy the dockerfile's context's community server files
 COPY . .
 
-# Install and build the Solid community server (prepare script cannot run in wd)
-RUN npm ci --unsafe-perm && npm run build
+# Install and build the Solid community server
+RUN npm ci && npm run build
+
+# Remove the development dependencies as the runtime stage only needs production dependencies.
+# --ignore-scripts prevents the root prepare script (a full build requiring development dependencies) from running.
+RUN npm prune --omit=dev --ignore-scripts
 
 
 
@@ -18,14 +22,23 @@ FROM node:18-alpine
 # Add contact informations for questions about the container
 LABEL maintainer="Solid Community Server Docker Image Maintainer <thomas.dupont@ugent.be>"
 
-# Container config & data dir for volume sharing
-# Defaults to filestorage with /data directory (passed through CMD below)
-RUN mkdir /config /data
+# tini runs as PID 1, reaps zombie processes,
+# and forwards signals such as the SIGTERM from `docker stop` to the node process,
+# which would otherwise ignore them while running as PID 1.
+RUN apk add --no-cache tini
+
+# Container config & data dir for volume sharing.
+# Defaults to filestorage with /data directory (passed through CMD below).
+# Owned by the non-root node user (uid 1000) the server runs as,
+# so named volumes and bind mounts remain writable.
+RUN mkdir -p /config /data && chown node:node /config /data
 
 # Set current directory
 WORKDIR /community-server
 
-# Copy runtime files from build stage
+# Copy runtime files from build stage.
+# The application files stay owned by root so the server process cannot modify them;
+# all runtime writes go to /data (or wherever -f / CSS_ROOT_FILE_PATH points).
 COPY --from=build /community-server/package.json .
 COPY --from=build /community-server/bin ./bin
 COPY --from=build /community-server/config ./config
@@ -36,9 +49,20 @@ COPY --from=build /community-server/templates ./templates
 # Informs Docker that the container listens on the specified network port at runtime
 EXPOSE 3000
 
-# Set command run by the container
-ENTRYPOINT [ "node", "bin/server.js" ]
+# Run as the non-root node user (uid 1000, gid 1000) provided by the base image
+USER node
+
+ENV NODE_ENV=production
 
 # By default run in filemode (overriden if passing alternative arguments or env vars)
 ENV CSS_CONFIG=config/file.json
 ENV CSS_ROOT_FILE_PATH=/data
+
+# Periodically check the health endpoint of the server.
+# The check follows the CSS_PORT environment variable if set;
+# it needs to be overridden when configuring the port through other means.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD node -e "fetch('http://localhost:' + (process.env.CSS_PORT ?? 3000) + '/.well-known/css/health').then((res) => process.exit(res.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+# Set command run by the container
+ENTRYPOINT [ "/sbin/tini", "--", "node", "bin/server.js" ]

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -107,6 +107,19 @@ docker run --rm -v ~/solid-config:/config -p 3000:3000 -it solidproject/communit
 docker run --rm -v ~/Solid:/data -p 3000:3000 -it -e CSS_CONFIG=config/file-no-setup.json -e CSS_LOGGING_LEVEL=debug solidproject/community-server
 ```
 
+The server in the container runs as the non-root `node` user with uid `1000` and gid `1000`.
+When bind-mounting a host directory on `/data`,
+make sure it is writable by uid `1000`,
+for example by running `chown -R 1000:1000 ~/Solid` on the host.
+Similarly, a directory mounted on `/config` needs to be readable by uid `1000`.
+
+The image contains a health check that periodically requests
+`http://localhost:3000/.well-known/css/health` inside the container.
+It follows the `CSS_PORT` environment variable if you use that to change the port;
+when changing the port in another way, such as the `--port` CLI argument,
+override the health check accordingly
+(for example with the `--health-cmd` flag of `docker run`).
+
 ### Using a Helm Chart
 
 The official [Helm](https://helm.sh/) Chart for Kubernetes deployment is maintained at


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the upstream PR template requires a linked issue, so before submitting this to CommunitySolidServer an issue must be opened there describing the current image's gaps (`node` as PID 1 so `docker stop` waits out the 10 s SIGKILL timeout, running as root, and shipping the full dev `node_modules`).

#### ✍️ Description

Hardens the production Docker image:

1. **tini as PID 1** (`apk add --no-cache tini`, `ENTRYPOINT [ "/sbin/tini", "--", "node", "bin/server.js" ]`). Today `node` runs as PID 1, where it ignores `docker stop`'s SIGTERM, so every stop is a 10 s wait followed by SIGKILL; tini forwards signals and reaps zombies, making the graceful-shutdown work (#43) reachable under `docker stop`. Arg/env pass-through is unchanged: `docker run <image> -c config/file.json`, `CSS_*` env vars, and the CI `--version` smoke test all still work (there was no `CMD` before either).
2. **Non-root**: `USER node` (uid/gid 1000 from the base image). `/config` and `/data` are chowned so named volumes and the default `CSS_ROOT_FILE_PATH=/data` stay writable. The application files deliberately stay root-owned and therefore read-only to the server process — the server only ever writes under `rootFilePath` (the `.internal/` stores and `FileSystemResourceLocker` locks), so nothing else needs write access. **Behaviour change**: bind-mounted host directories must be writable by uid 1000 (documented in `starting-server.md`).
3. **Production dependencies only**: `npm prune --omit=dev --ignore-scripts` in the build stage, before the existing `COPY --from=build … node_modules`. Prune (rather than a fresh `npm ci --omit=dev`) preserves install-script artifacts; `--ignore-scripts` avoids the root `prepare` script, which is a full build requiring the dev dependencies being removed. Verified from the lockfile that no production-tree package has install/postinstall scripts. The size reduction is estimated from the dev-dependency tree (~260 MB: jest, eslint, typedoc, componentsjs-generator) — **no reproducible before/after measurement exists yet** because the build box has no Docker; `docker image ls` on the CI-built image is the check.
4. **`ENV NODE_ENV=production`**, removal of the stale `npm ci --unsafe-perm` flag, and a **HEALTHCHECK** (a node `fetch` one-liner; honors `CSS_PORT`, and needs an override when the port is configured another way, e.g. via `--port` — documented).
5. Base image tag left untouched (dependabot owns version bumps).
6. Docs: `starting-server.md` gains bind-mount ownership (uid 1000) and health-check notes.

#### ⚠️ Depends on #48 (health endpoint)

The HEALTHCHECK targets `/.well-known/css/health`, which comes from #48 (`feat/health-endpoint`) — not on this branch or upstream `main`. Built alone, this image reports `unhealthy` (the container still runs; plain `docker run` ignores health, but compose/Swarm `service_healthy` gates would fail). This PR should land after, or rebased on, #48. Alternatively the HEALTHCHECK hunk could move into the #48 stack so the rest of the hardening lands independently; fallback if #48 stalls is pointing the check at `/` (works, but exercises the full LDP stack per probe).

#### 📋 Notes for review

- **No local Docker on the build box** — the Dockerfile was authored by careful reading, not built. CI/docker-build must validate: `docker build` succeeding (esp. `npm prune --omit=dev --ignore-scripts` on the alpine npm), the existing `docker run --version` smoke test, a non-root boot with a chowned `-v hostdir:/data` plus a pod write, `docker stop` terminating promptly (tini), the image size drop, and the multi-arch (arm/v7, arm64) builds.
- `eslint` currently sits in `dependencies`, so it survives the prune — out of scope here; #34 moves it to devDependencies as a separate PR.
- `starting-server.md` is also edited by #46/#48 — trivial rebase where they overlap.
- **Branch target / semver**: this is not a patch fix — the image's runtime behaviour changes (existing root-owned bind mounts stop working; dev tools are no longer in the image). When submitted upstream it should target the latest `versions/*` branch (currently `versions/next-major`), and the intended label is **semver.major** (stated in prose — contributors cannot set labels).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
