### PR TITLE
fix: Back off and budget cluster worker restarts

### DIFF
--- a/src/init/cluster/ClusterManager.ts
+++ b/src/init/cluster/ClusterManager.ts
@@ -34,6 +34,34 @@ function toClusterMode(workers: number): ClusterMode {
 }
 
 /**
+ * Base delay, in milliseconds, before a replacement is forked for a worker that exited unexpectedly.
+ * The actual delay doubles for every restart that already happened
+ * within the last {@link WORKER_RESTART_WINDOW_MS} milliseconds.
+ */
+const WORKER_RESTART_BASE_DELAY_MS = 100;
+
+/**
+ * Upper bound, in milliseconds, on the exponential backoff delay between worker restarts.
+ * This is a safeguard in case the other restart constants get tuned to values
+ * where the doubling would otherwise grow unbounded.
+ */
+const WORKER_RESTART_MAX_DELAY_MS = 30_000;
+
+/**
+ * Length, in milliseconds, of the rolling window in which worker restarts are counted.
+ * Restarts older than this no longer count towards {@link WORKER_RESTART_BUDGET} or the backoff delay.
+ */
+const WORKER_RESTART_WINDOW_MS = 60_000;
+
+/**
+ * Maximum number of worker restarts within {@link WORKER_RESTART_WINDOW_MS} milliseconds.
+ * Once this budget is spent, unexpectedly exiting workers are no longer replaced,
+ * so a deterministic worker crash can not degenerate into a tight fork loop.
+ * The primary process keeps running; an external supervisor is expected to restart the server.
+ */
+const WORKER_RESTART_BUDGET = 5;
+
+/**
  * This class is responsible for deciding how many affective workers are needed.
  * It also contains the logic for respawning workers when they are killed by the os.
  *
@@ -50,6 +78,11 @@ export class ClusterManager {
   private readonly logger = getLoggerFor(this);
   private readonly workers: number;
   private readonly clusterMode: ClusterMode;
+  /**
+   * Timestamps, in epoch milliseconds, of recent worker restarts.
+   * Entries older than {@link WORKER_RESTART_WINDOW_MS} milliseconds get pruned on every unexpected worker exit.
+   */
+  private restartTimestamps: number[] = [];
 
   public constructor(workers: number) {
     const cores = cpus().length;
@@ -84,11 +117,38 @@ export class ClusterManager {
     });
 
     cluster.on('exit', (worker: Worker, code: number, signal: string): void => {
+      if (worker.exitedAfterDisconnect) {
+        this.logger.info(`Worker ${worker.process.pid} exited intentionally with code ${code} and signal ${signal}. ` +
+          `Not starting a new worker.`);
+        return;
+      }
+
+      const now = Date.now();
+      this.restartTimestamps = this.restartTimestamps
+        .filter((timestamp): boolean => now - timestamp < WORKER_RESTART_WINDOW_MS);
+
+      if (this.restartTimestamps.length >= WORKER_RESTART_BUDGET) {
+        this.logger.error(`Worker ${worker.process.pid} died with code ${code} and signal ${signal}. ` +
+          `Not starting a new worker: crash loop exceeded the budget of ${WORKER_RESTART_BUDGET} restarts ` +
+          `in the last ${WORKER_RESTART_WINDOW_MS} ms.`);
+        return;
+      }
+
+      const delay = Math.min(
+        WORKER_RESTART_BASE_DELAY_MS * 2 ** this.restartTimestamps.length,
+        WORKER_RESTART_MAX_DELAY_MS,
+      );
+      this.restartTimestamps.push(now);
       this.logger.warn(`Worker ${worker.process.pid} died with code ${code} and signal ${signal}`);
-      this.logger.warn('Starting a new worker');
-      cluster.fork().on('message', (msg: string): void => {
-        this.logger.info(msg);
-      });
+      this.logger.warn(`Starting a new worker in ${delay} ms ` +
+        `(restart ${this.restartTimestamps.length} of ${WORKER_RESTART_BUDGET} ` +
+        `in the last ${WORKER_RESTART_WINDOW_MS} ms)`);
+      // `unref` so a pending refork timer never keeps a stopping primary process alive
+      setTimeout((): void => {
+        cluster.fork().on('message', (msg: string): void => {
+          this.logger.info(msg);
+        });
+      }, delay).unref();
     });
   }
 

--- a/src/init/cluster/ClusterManager.ts
+++ b/src/init/cluster/ClusterManager.ts
@@ -34,30 +34,26 @@ function toClusterMode(workers: number): ClusterMode {
 }
 
 /**
- * Base delay, in milliseconds, before a replacement is forked for a worker that exited unexpectedly.
- * The actual delay doubles for every restart that already happened
- * within the last {@link WORKER_RESTART_WINDOW_MS} milliseconds.
+ * Base delay, in milliseconds, before a replacement worker is forked after an unexpected exit.
+ * Doubles for every restart within the last {@link WORKER_RESTART_WINDOW_MS} milliseconds.
  */
 const WORKER_RESTART_BASE_DELAY_MS = 100;
 
 /**
  * Upper bound, in milliseconds, on the exponential backoff delay between worker restarts.
- * This is a safeguard in case the other restart constants get tuned to values
- * where the doubling would otherwise grow unbounded.
  */
 const WORKER_RESTART_MAX_DELAY_MS = 30_000;
 
 /**
- * Length, in milliseconds, of the rolling window in which worker restarts are counted.
- * Restarts older than this no longer count towards {@link WORKER_RESTART_BUDGET} or the backoff delay.
+ * Length, in milliseconds, of the rolling window in which worker restarts
+ * count towards {@link WORKER_RESTART_BUDGET} and the backoff delay.
  */
 const WORKER_RESTART_WINDOW_MS = 60_000;
 
 /**
  * Maximum number of worker restarts within {@link WORKER_RESTART_WINDOW_MS} milliseconds.
- * Once this budget is spent, unexpectedly exiting workers are no longer replaced,
- * so a deterministic worker crash can not degenerate into a tight fork loop.
- * The primary process keeps running; an external supervisor is expected to restart the server.
+ * Once this budget is spent, unexpectedly exiting workers are no longer replaced;
+ * the primary keeps running so an external supervisor can restart the server.
  */
 const WORKER_RESTART_BUDGET = 5;
 
@@ -78,10 +74,6 @@ export class ClusterManager {
   private readonly logger = getLoggerFor(this);
   private readonly workers: number;
   private readonly clusterMode: ClusterMode;
-  /**
-   * Timestamps, in epoch milliseconds, of recent worker restarts.
-   * Entries older than {@link WORKER_RESTART_WINDOW_MS} milliseconds get pruned on every unexpected worker exit.
-   */
   private restartTimestamps: number[] = [];
 
   public constructor(workers: number) {
@@ -143,7 +135,7 @@ export class ClusterManager {
       this.logger.warn(`Starting a new worker in ${delay} ms ` +
         `(restart ${this.restartTimestamps.length} of ${WORKER_RESTART_BUDGET} ` +
         `in the last ${WORKER_RESTART_WINDOW_MS} ms)`);
-      // `unref` so a pending refork timer never keeps a stopping primary process alive
+      // Unreffing the timer prevents a pending refork from keeping a stopping primary process alive.
       setTimeout((): void => {
         cluster.fork().on('message', (msg: string): void => {
           this.logger.info(msg);

--- a/test/unit/init/cluster/ClusterManager.test.ts
+++ b/test/unit/init/cluster/ClusterManager.test.ts
@@ -10,16 +10,19 @@ jest.mock('node:os', (): any => ({
   cpus: jest.fn().mockImplementation((): any => [{}, {}, {}, {}, {}, {}]),
 }));
 
-const mockWorker = new EventEmitter() as any;
-mockWorker.process = { pid: 666 };
-
 describe('A ClusterManager', (): void => {
-  const emitter = new EventEmitter();
   const mockCluster = jest.requireMock('node:cluster');
-  const mockLogger = { info: jest.fn(), warn: jest.fn() };
+  const mockLogger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
   jest.spyOn(LogUtil, 'getLoggerFor').mockImplementation((): any => mockLogger);
+  let emitter: EventEmitter;
+  let mockWorker: any;
 
-  beforeAll((): void => {
+  beforeEach((): void => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    emitter = new EventEmitter();
+    mockWorker = new EventEmitter() as any;
+    mockWorker.process = { pid: 666 };
     Object.assign(mockCluster, {
       fork: jest.fn().mockImplementation((): any => mockWorker),
       on: jest.fn().mockImplementation(emitter.on.bind(emitter)),
@@ -27,6 +30,10 @@ describe('A ClusterManager', (): void => {
       isMaster: true,
       isWorker: false,
     });
+  });
+
+  afterEach((): void => {
+    jest.useRealTimers();
   });
 
   it('can handle workers input as string.', (): void => {
@@ -70,7 +77,6 @@ describe('A ClusterManager', (): void => {
     const cm = new ClusterManager(-1);
     const workers = cpus().length - 1;
     expect(cpus()).toHaveLength(workers + 1);
-    Object.assign(cm, { logger: mockLogger });
 
     cm.spawnWorkers();
 
@@ -81,26 +87,132 @@ describe('A ClusterManager', (): void => {
     }
 
     expect(cluster.on).toHaveBeenCalledWith('online', expect.any(Function));
+    expect(cluster.on).toHaveBeenCalledWith('exit', expect.any(Function));
     expect(cluster.fork).toHaveBeenCalledTimes(workers);
     expect(mockLogger.info).toHaveBeenLastCalledWith(`All ${workers} requested workers have been started.`);
-
-    expect(cluster.on).toHaveBeenCalledWith('exit', expect.any(Function));
-    const code = 333;
-    const signal = 'exiting';
-    mockCluster.emit('exit', mockWorker, code, signal);
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      `Worker ${mockWorker.process.pid} died with code ${code} and signal ${signal}`,
-    );
-    expect(mockLogger.warn).toHaveBeenCalledWith(`Starting a new worker`);
   });
 
   it('can receive message from spawned workers.', (): void => {
     const cm = new ClusterManager(2);
-    Object.assign(cm, { logger: mockLogger });
 
     cm.spawnWorkers();
     const msg = 'Hi from worker!';
     mockWorker.emit('message', msg);
     expect(mockLogger.info).toHaveBeenCalledWith(msg);
+  });
+
+  it('forks a replacement worker only after the base backoff delay.', (): void => {
+    const cm = new ClusterManager(2);
+    cm.spawnWorkers();
+    expect(cluster.fork).toHaveBeenCalledTimes(2);
+
+    mockCluster.emit('exit', mockWorker, 333, 'SIGKILL');
+    expect(mockLogger.warn).toHaveBeenCalledWith('Worker 666 died with code 333 and signal SIGKILL');
+    expect(mockLogger.warn)
+      .toHaveBeenCalledWith('Starting a new worker in 100 ms (restart 1 of 5 in the last 60000 ms)');
+    expect(cluster.fork).toHaveBeenCalledTimes(2);
+
+    jest.advanceTimersByTime(99);
+    expect(cluster.fork).toHaveBeenCalledTimes(2);
+    jest.advanceTimersByTime(1);
+    expect(cluster.fork).toHaveBeenCalledTimes(3);
+
+    const msg = 'Hi from replacement worker!';
+    mockWorker.emit('message', msg);
+    expect(mockLogger.info).toHaveBeenCalledWith(msg);
+  });
+
+  it('doubles the refork delay for every restart within the rolling window.', (): void => {
+    const cm = new ClusterManager(2);
+    cm.spawnWorkers();
+
+    mockCluster.emit('exit', mockWorker, 1, 'SIGSEGV');
+    expect(mockLogger.warn)
+      .toHaveBeenCalledWith('Starting a new worker in 100 ms (restart 1 of 5 in the last 60000 ms)');
+    jest.advanceTimersByTime(100);
+    expect(cluster.fork).toHaveBeenCalledTimes(3);
+
+    mockCluster.emit('exit', mockWorker, 1, 'SIGSEGV');
+    expect(mockLogger.warn)
+      .toHaveBeenCalledWith('Starting a new worker in 200 ms (restart 2 of 5 in the last 60000 ms)');
+    jest.advanceTimersByTime(199);
+    expect(cluster.fork).toHaveBeenCalledTimes(3);
+    jest.advanceTimersByTime(1);
+    expect(cluster.fork).toHaveBeenCalledTimes(4);
+
+    mockCluster.emit('exit', mockWorker, 1, 'SIGSEGV');
+    expect(mockLogger.warn)
+      .toHaveBeenCalledWith('Starting a new worker in 400 ms (restart 3 of 5 in the last 60000 ms)');
+    jest.advanceTimersByTime(400);
+    expect(cluster.fork).toHaveBeenCalledTimes(5);
+  });
+
+  it('stops reforking and logs an error when the restart budget is exceeded.', (): void => {
+    const cm = new ClusterManager(2);
+    cm.spawnWorkers();
+
+    // Spend the full restart budget of 5 restarts
+    for (let i = 0; i < 5; i++) {
+      mockCluster.emit('exit', mockWorker, 1, 'SIGSEGV');
+      jest.advanceTimersByTime(100 * (2 ** i));
+    }
+    expect(cluster.fork).toHaveBeenCalledTimes(7);
+    expect(mockLogger.warn).toHaveBeenCalledTimes(10);
+    expect(mockLogger.error).toHaveBeenCalledTimes(0);
+
+    mockCluster.emit('exit', mockWorker, 1, 'SIGSEGV');
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Worker 666 died with code 1 and signal SIGSEGV. ' +
+      'Not starting a new worker: crash loop exceeded the budget of 5 restarts in the last 60000 ms.',
+    );
+    expect(mockLogger.warn).toHaveBeenCalledTimes(10);
+
+    jest.advanceTimersByTime(30_000);
+    expect(cluster.fork).toHaveBeenCalledTimes(7);
+  });
+
+  it('does not refork or consume the restart budget when a worker exited after disconnect.', (): void => {
+    const cm = new ClusterManager(2);
+    cm.spawnWorkers();
+
+    mockWorker.exitedAfterDisconnect = true;
+    mockCluster.emit('exit', mockWorker, 0, 'SIGTERM');
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Worker 666 exited intentionally with code 0 and signal SIGTERM. Not starting a new worker.',
+    );
+    expect(mockLogger.warn).toHaveBeenCalledTimes(0);
+    jest.advanceTimersByTime(60_000);
+    expect(cluster.fork).toHaveBeenCalledTimes(2);
+
+    // An unexpected exit afterwards still starts at the base delay
+    mockWorker.exitedAfterDisconnect = false;
+    mockCluster.emit('exit', mockWorker, 1, 'SIGSEGV');
+    expect(mockLogger.warn)
+      .toHaveBeenCalledWith('Starting a new worker in 100 ms (restart 1 of 5 in the last 60000 ms)');
+    jest.advanceTimersByTime(100);
+    expect(cluster.fork).toHaveBeenCalledTimes(3);
+  });
+
+  it('resets the restart budget once previous restarts fall outside the rolling window.', (): void => {
+    const cm = new ClusterManager(2);
+    cm.spawnWorkers();
+
+    for (let i = 0; i < 5; i++) {
+      mockCluster.emit('exit', mockWorker, 1, 'SIGSEGV');
+      jest.advanceTimersByTime(100 * (2 ** i));
+    }
+    mockCluster.emit('exit', mockWorker, 1, 'SIGSEGV');
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(cluster.fork).toHaveBeenCalledTimes(7);
+
+    // Wait until all previous restarts are outside the rolling window
+    jest.advanceTimersByTime(60_000);
+    mockCluster.emit('exit', mockWorker, 1, 'SIGSEGV');
+    expect(mockLogger.warn)
+      .toHaveBeenCalledWith('Starting a new worker in 100 ms (restart 1 of 5 in the last 60000 ms)');
+    jest.advanceTimersByTime(100);
+    expect(cluster.fork).toHaveBeenCalledTimes(8);
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an issue must be created on CommunitySolidServer/CommunitySolidServer before this is submitted upstream (the PR template requires one).

#### ✍️ Description

In cluster mode, `ClusterManager` reforks a replacement worker immediately and unconditionally on every worker `exit`. A deterministic crash (for example a bad config value read at request time, or an OOM replayed by a retrying client) turns into a tight fork loop that pegs the CPUs and floods the logs. There is also no distinction between a crash and an intentional shutdown.

This PR changes the `exit` handling:

- Workers that exited intentionally (`worker.exitedAfterDisconnect`) are logged at info level and not replaced, and do not consume the restart budget.
- Replacement forks back off exponentially: a 100 ms base delay that doubles for every restart within a rolling 60 s window. The delay is capped at 30 s; the cap exists purely as a safeguard so the doubling cannot grow unbounded if the other constants are ever retuned.
- At most 5 restarts happen per rolling window. Once that budget is spent, further crashes are logged at error level (with pid/code/signal and the budget context) and workers are no longer replaced. The primary keeps running, so an external supervisor (systemd, Kubernetes, …) can restart the server rather than the host being exhausted by the fork loop. Restart timestamps are pruned to the window on every unexpected exit, so both the backoff exponent and the budget reset once earlier restarts age out of the window.
- Refork timers are `unref()`ed so a pending refork never keeps a stopping primary process alive. The existing `Worker <pid> died …` warning and the worker `message` → log wiring are preserved.

Notes for reviewers:

- The restart budget is global rather than per worker slot: the current code has no per-slot identity, and a deterministic crash hits all workers alike. The trade-off is that several independent one-off crashes across different workers within one window would also pause reforking; per-slot tracking is a possible follow-up if wanted.
- Replacement workers now appear at least 100 ms after a crash rather than instantly.
- Complements the graceful-shutdown change in #43: that PR drains workers on signals; this one prevents crash recovery from becoming a self-inflicted denial of service.

Intended semver level: **semver.minor** — no interface or config changes, but the restart behaviour changes observably (delayed reforks, budget cut-off), which is more than a pure bugfix. Per the contribution guidelines that means the upstream submission should target the latest `versions/*` branch (currently `versions/next-major`) rather than `main`; this fork PR targets `main` only for review purposes.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
