### PR TITLE
fix: Write file resources atomically

### DIFF
--- a/src/storage/accessors/AtomicFileDataAccessor.ts
+++ b/src/storage/accessors/AtomicFileDataAccessor.ts
@@ -38,7 +38,9 @@ export class AtomicFileDataAccessor extends FileDataAccessor implements AtomicDa
     const tempFilePath = joinFilePath(this.tempFilePath, `temp-${randomUUID()}.txt`);
 
     try {
-      await this.writeDataFile(tempFilePath, data);
+      // Stream directly instead of using `writeDataFile`:
+      // the write already targets a temporary file, so another temporary file would be redundant.
+      await this.streamToFile(tempFilePath, data);
 
       // Check if we already have a corresponding file with a different extension
       await this.verifyExistingExtension(link);

--- a/src/storage/accessors/AtomicFileDataAccessor.ts
+++ b/src/storage/accessors/AtomicFileDataAccessor.ts
@@ -38,8 +38,7 @@ export class AtomicFileDataAccessor extends FileDataAccessor implements AtomicDa
     const tempFilePath = joinFilePath(this.tempFilePath, `temp-${randomUUID()}.txt`);
 
     try {
-      // Stream directly instead of using `writeDataFile`:
-      // the write already targets a temporary file, so another temporary file would be redundant.
+      // The target is already a temporary file, so the extra temporary file of `writeDataFile` is not needed
       await this.streamToFile(tempFilePath, data);
 
       // Check if we already have a corresponding file with a different extension

--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -369,14 +369,10 @@ export class FileDataAccessor implements DataAccessor {
 
   /**
    * Helper function without extra validation checking to create a data file.
-   * The data will first be streamed to a temporary file in the same folder,
-   * which only gets renamed to the requested path after all data was written successfully.
-   * This prevents an interrupted write, for example due to a server crash,
-   * from leaving behind a partially written file at the destination.
-   *
-   * The temporary file name ends with the metadata suffix,
-   * ensuring a leftover temporary file is never interpreted as a resource by a {@link FileIdentifierMapper},
-   * in case the server stops before the file could be removed.
+   * Streams to a temporary file in the same folder and only renames it to the requested path on success,
+   * so an interrupted write can never leave a partial file at the destination.
+   * The temporary name ends with the metadata suffix
+   * so a leftover file is never interpreted as a resource by a {@link FileIdentifierMapper}.
    *
    * @param path - The filepath of the file to be created.
    * @param data - The data to be put in the file.
@@ -389,9 +385,7 @@ export class FileDataAccessor implements DataAccessor {
       await this.streamToFile(tempFilePath, data);
       await rename(tempFilePath, path);
     } catch (error: unknown) {
-      // Clean up the temporary file.
-      // The error that interrupted the write is more relevant to the caller,
-      // so if the cleanup fails as well, only the original error gets thrown.
+      // Only log a cleanup failure since the error that interrupted the write is more relevant to the caller
       try {
         await remove(tempFilePath);
       } catch (removeError: unknown) {

--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -1,10 +1,12 @@
+import { randomUUID } from 'node:crypto';
 import type { Readable } from 'node:stream';
 import type { Stats } from 'fs-extra';
-import { createReadStream, createWriteStream, ensureDir, lstat, opendir, remove, stat } from 'fs-extra';
+import { createReadStream, createWriteStream, ensureDir, lstat, opendir, remove, rename, stat } from 'fs-extra';
 import type { Representation } from '../../http/representation/Representation';
 import { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import { getLoggerFor } from '../../logging/LogUtil';
+import { createErrorMessage } from '../../util/errors/ErrorUtil';
 import { NotFoundHttpError } from '../../util/errors/NotFoundHttpError';
 import { isSystemError } from '../../util/errors/SystemError';
 import { UnsupportedMediaTypeHttpError } from '../../util/errors/UnsupportedMediaTypeHttpError';
@@ -367,11 +369,45 @@ export class FileDataAccessor implements DataAccessor {
 
   /**
    * Helper function without extra validation checking to create a data file.
+   * The data will first be streamed to a temporary file in the same folder,
+   * which only gets renamed to the requested path after all data was written successfully.
+   * This prevents an interrupted write, for example due to a server crash,
+   * from leaving behind a partially written file at the destination.
+   *
+   * The temporary file name ends with the metadata suffix,
+   * ensuring a leftover temporary file is never interpreted as a resource by a {@link FileIdentifierMapper},
+   * in case the server stops before the file could be removed.
    *
    * @param path - The filepath of the file to be created.
    * @param data - The data to be put in the file.
    */
   protected async writeDataFile(path: string, data: Readable): Promise<void> {
+    // The temporary file needs to be in the same folder to guarantee the rename call does not cross devices
+    const folder = path.slice(0, path.lastIndexOf('/') + 1);
+    const tempFilePath = joinFilePath(folder, `.tmp-${randomUUID()}.meta`);
+    try {
+      await this.streamToFile(tempFilePath, data);
+      await rename(tempFilePath, path);
+    } catch (error: unknown) {
+      // Clean up the temporary file.
+      // The error that interrupted the write is more relevant to the caller,
+      // so if the cleanup fails as well, only the original error gets thrown.
+      try {
+        await remove(tempFilePath);
+      } catch (removeError: unknown) {
+        this.logger.warn(`Unable to remove temporary file ${tempFilePath}: ${createErrorMessage(removeError)}`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Helper function that streams the given data directly to the given file location.
+   *
+   * @param path - The filepath of the file to be created.
+   * @param data - The data to be put in the file.
+   */
+  protected async streamToFile(path: string, data: Readable): Promise<void> {
     return new Promise((resolve, reject): void => {
       const writeStream = createWriteStream(path);
       data.pipe(writeStream);

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -70,6 +70,12 @@ describe('A FileDataAccessor', (): void => {
       await expect(readableToString(stream)).resolves.toBe('data');
     });
 
+    it('does not return the data of a leftover temporary file.', async(): Promise<void> => {
+      cache.data = { '.tmp-3d3e58f6-b2d5-40a1-b06e-71b6b16ee286.meta': 'partial', resource: 'data' };
+      const stream = await accessor.getData({ path: `${base}resource` });
+      await expect(readableToString(stream)).resolves.toBe('data');
+    });
+
     it('throws an error if something else went wrong.', async(): Promise<void> => {
       jest.requireMock('fs-extra').stat = (): any => {
         throw new Error('error');
@@ -213,6 +219,23 @@ describe('A FileDataAccessor', (): void => {
       }
     });
 
+    it('does not show leftover temporary files as children of a container.', async(): Promise<void> => {
+      cache.data = {
+        container: {
+          resource: 'data',
+          '.tmp-3d3e58f6-b2d5-40a1-b06e-71b6b16ee286.meta': 'partial',
+        },
+      };
+
+      const children = [];
+      for await (const child of accessor.getChildren({ path: `${base}container/` })) {
+        children.push(child);
+      }
+
+      expect(children).toHaveLength(1);
+      expect(children[0].identifier.value).toBe(`${base}container/resource`);
+    });
+
     it('does not generate IANA URIs for children with invalid content-types.', async(): Promise<void> => {
       cache.data = {
         container: {
@@ -283,6 +306,18 @@ describe('A FileDataAccessor', (): void => {
       expect(cache.data.resource).toBe('data');
     });
 
+    it('writes the data through a temporary file in the same folder.', async(): Promise<void> => {
+      const renameSpy = jest.spyOn(jest.requireMock('fs-extra'), 'rename');
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata)).resolves.toBeUndefined();
+      expect(cache.data.resource).toBe('data');
+      expect(renameSpy).toHaveBeenCalledTimes(1);
+      expect(renameSpy).toHaveBeenLastCalledWith(
+        expect.stringMatching(/^uploads\/\.tmp-[^/]+\.meta$/u),
+        `${rootFilePath}/resource`,
+      );
+      expect(Object.keys(cache.data).filter((name): boolean => name.startsWith('.tmp-'))).toHaveLength(0);
+    });
+
     it('writes metadata to the corresponding metadata file.', async(): Promise<void> => {
       metadata = new RepresentationMetadata(
         { path: `${base}res.ttl` },
@@ -323,6 +358,50 @@ describe('A FileDataAccessor', (): void => {
       };
       await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata))
         .rejects.toThrow('error');
+    });
+
+    it('removes the temporary file and keeps the destination if the data stream errors.', async(): Promise<void> => {
+      cache.data = { resource: 'original' };
+      data.read = (): any => {
+        data.emit('error', new Error('data error'));
+        return null;
+      };
+      const renameSpy = jest.spyOn(jest.requireMock('fs-extra'), 'rename');
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata))
+        .rejects.toThrow('data error');
+      expect(renameSpy).toHaveBeenCalledTimes(0);
+      expect(cache.data.resource).toBe('original');
+      expect(Object.keys(cache.data).filter((name): boolean => name.startsWith('.tmp-'))).toHaveLength(0);
+    });
+
+    it('throws the original error if removing the temporary file fails.', async(): Promise<void> => {
+      data.read = (): any => {
+        data.emit('error', new Error('data error'));
+        return null;
+      };
+      const removeSpy = jest.spyOn(jest.requireMock('fs-extra'), 'remove')
+        .mockImplementation(async(filePath: string): Promise<void> => {
+          if (/\/\.tmp-[^/]+\.meta$/u.test(filePath)) {
+            throw new Error('remove error');
+          }
+        });
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata))
+        .rejects.toThrow('data error');
+      expect(removeSpy).toHaveBeenCalledTimes(2);
+      expect(Object.keys(cache.data).filter((name): boolean => name.startsWith('.tmp-'))).toHaveLength(1);
+    });
+
+    it('removes the temporary file if renaming it to the destination fails.', async(): Promise<void> => {
+      const renameSpy = jest.spyOn(jest.requireMock('fs-extra'), 'rename').mockImplementation((): any => {
+        throw new Error('rename error');
+      });
+      const removeSpy = jest.spyOn(jest.requireMock('fs-extra'), 'remove');
+      await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata))
+        .rejects.toThrow('rename error');
+      expect(renameSpy).toHaveBeenCalledTimes(1);
+      expect(removeSpy).toHaveBeenCalledTimes(2);
+      expect(cache.data.resource).toBeUndefined();
+      expect(Object.keys(cache.data).filter((name): boolean => name.startsWith('.tmp-'))).toHaveLength(0);
     });
 
     it('deletes the metadata file if something went wrong writing the file.', async(): Promise<void> => {


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — the CSS template requires a related issue, so an upstream issue describing the torn-write corruption must be created before this is submitted to CommunitySolidServer.

#### ✍️ Description

`FileDataAccessor.writeDataFile` streams request bodies directly to the final destination path, so any crash, OOM kill, or `SIGKILL` mid-`PUT` leaves a truncated file that is afterwards served as the valid resource. The file backend also stores all `/.internal` state (accounts, OIDC keys/grants) through this same accessor, so a torn write there can corrupt login or token-verification state.

This PR makes the write atomic: `writeDataFile` now streams to a temporary file in the same folder (so the rename cannot cross devices) and `rename`s it over the destination on success. On any error the temporary file is removed — best effort; a cleanup failure is only logged so the original error reaches the caller — and the destination is never touched, so an interrupted write always leaves the previous version intact.

The streaming logic is factored into a `protected streamToFile` helper. `AtomicFileDataAccessor` calls it directly for its data path, since that already targets its own temporary file — going through `writeDataFile` would add a redundant second temp+rename. Its data path therefore keeps its exact prior syscall profile, and its metadata writes become atomic too.

**Why an orphaned temporary file can never surface as a resource** (if the server dies before cleanup): the name is `.tmp-<randomUUID()>.meta`, in the destination's own folder.

- Directory listings skip it: `getChildMetadata` skips entries flagged `isMetadata`, which `isMetadataPath` sets for any path ending in `.meta` — as the temp name does (no shipped mapper overrides this).
- Document lookup never resolves to it: `ExtensionBasedMapper` only matches a directory entry whose remainder after the resource name is empty or `$.`-prefixed, and a fully random name never starts with a resource name. (A `<destination>.tmp-x` suffix scheme would fail this check — hence the random name.)

A boot-time sweep of crash-orphaned temp files would be a follow-up nicety, not needed for correctness. `fsync` is deliberately not added: the goal is atomicity (no torn files), not durability, on a throughput-sensitive server; an opt-in `fsync`-before-rename could be a follow-up. Hardening the `/.internal` JSON stores against torn reads rides on this same write path and is planned as a separate PR.

**Performance.** The deterministic cost is one extra `rename` syscall per data/metadata write in the plain `FileDataAccessor` (the write itself is unchanged); `AtomicFileDataAccessor`'s data path is syscall-identical to before. An indicative local A/B (repeated concurrent `PUT`s to a public container, 15 connections × 12 s × 3 runs per side) measured 82/98/79 req/s baseline vs 81/101/86 req/s atomic — within run-to-run noise — but the exact benchmark script was not preserved, so the op-count delta is the reproducible evidence.

**Branch target + semver** (stated in prose — contributors cannot set labels): opened against `main` on this fork for review, but on upstream submission it should target the latest `versions/*` branch (`versions/next-major`), because it adds a `protected` method (`streamToFile`) to `FileDataAccessor`'s extension surface and changes on-disk write behaviour. Intended level: **semver.minor** (backwards-compatible). The motivating fix itself is patch-level, so `semver.patch` + `main` is defensible if the maintainers consider the helper internal.

Tests extend the existing `FileDataAccessor` unit tests with regression cases: an orphaned temp file is not served as data and not listed as a container child; data is written through a same-folder temp file with exactly one rename; on a stream error the temp file is removed and the destination kept; the original error is preserved when cleanup fails; the temp file is removed on rename failure. Both accessor suites pass with the 100% coverage thresholds.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
