### PR TITLE
feat: Add hardening response headers

### DIFF
--- a/config/http/middleware/handlers/constant-headers.json
+++ b/config/http/middleware/handlers/constant-headers.json
@@ -17,6 +17,18 @@
         {
           "HeaderHandler:_headers_key": "Accept-Ranges",
           "HeaderHandler:_headers_value": "bytes"
+        },
+        {
+          "HeaderHandler:_headers_key": "X-Content-Type-Options",
+          "HeaderHandler:_headers_value": "nosniff"
+        },
+        {
+          "HeaderHandler:_headers_key": "Referrer-Policy",
+          "HeaderHandler:_headers_value": "no-referrer"
+        },
+        {
+          "HeaderHandler:_headers_key": "X-Frame-Options",
+          "HeaderHandler:_headers_value": "DENY"
         }
       ]
     }

--- a/test/integration/Middleware.test.ts
+++ b/test/integration/Middleware.test.ts
@@ -61,6 +61,15 @@ describe('An http server with middleware', (): void => {
     }));
   });
 
+  it('sets hardening headers against sniffing, framing and referrer leakage.', async(): Promise<void> => {
+    const res = await request(server).get('/');
+    expect(res.header).toEqual(expect.objectContaining({
+      'x-content-type-options': 'nosniff',
+      'referrer-policy': 'no-referrer',
+      'x-frame-options': 'DENY',
+    }));
+  });
+
   it('returns all relevant headers for an OPTIONS request.', async(): Promise<void> => {
     const res = await request(server)
       .options('/')


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready)

#### 📁 Related issues

None yet — an upstream issue still needs to be created via <https://github.com/CommunitySolidServer/CommunitySolidServer/issues/new/choose> before this is submitted upstream (the PR template requires one).

#### ✍️ Description

A public Solid server serves arbitrary user-uploaded content same-origin, but the constant-header middleware only sets `Vary`, `X-Powered-By` and `Accept-Ranges` — none of the standard browser-hardening headers. That leaves MIME-sniffing (stored XSS) and clickjacking avenues against other data on the same host.

This adds three always-safe static headers to the existing `HeaderHandler` in `config/http/middleware/handlers/constant-headers.json` — a config-value change only, no new code or component:

- `X-Content-Type-Options: nosniff` — a user-uploaded resource cannot be MIME-sniffed into active content.
- `Referrer-Policy: no-referrer` — pod URLs embed WebIDs and container paths, and Solid auth never relies on `Referer`, so full suppression leaks nothing and breaks no flow.
- `X-Frame-Options: DENY` — the served IdP/UI templates and `src/` contain no framing usage, so `DENY` is safe (no need to downgrade to `SAMEORIGIN`).

Two related headers were considered and deliberately left out, as each needs more than a constant header. `Strict-Transport-Security` is only meaningful over HTTPS and must not be emitted on plain-http deployments, so it needs conditional wiring on the base-URL scheme. A `Content-Security-Policy` (or `sandbox`) on user content would break legitimate Solid apps that load scripts/styles from pod resources, so it needs a per-response-type policy. Both would be separate PRs.

`test/integration/Middleware.test.ts` (the file asserting the existing constant headers) gains one test covering the three new headers; the `HeaderHandler` unit test uses its own inline headers and is unaffected. Build, lint, the full unit suite (with the 100% coverage gate) and the touched integration file run green locally.

Intended as **semver.minor** — a backwards-compatible feature addition (contributors cannot set the label). Per the branch rule it should therefore target the latest `versions/*` branch (currently `versions/next-major`) when submitted upstream, not `main`.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
