### PR TITLE
fix: Mark in-memory storage as single-threaded

### DIFF
--- a/src/storage/keyvalue/MemoryMapStorage.ts
+++ b/src/storage/keyvalue/MemoryMapStorage.ts
@@ -1,9 +1,14 @@
+import type { SingleThreaded } from '../../init/cluster/SingleThreaded';
 import type { KeyValueStorage } from './KeyValueStorage';
 
 /**
  * A {@link KeyValueStorage} which uses a JavaScript Map for internal storage.
+ *
+ * The Map is kept in the memory of a single process, so this storage is not threadsafe:
+ * in a multithreaded setup every worker would have its own copy and their state would diverge.
+ * It is therefore marked as {@link SingleThreaded}.
  */
-export class MemoryMapStorage<TValue> implements KeyValueStorage<string, TValue> {
+export class MemoryMapStorage<TValue> implements KeyValueStorage<string, TValue>, SingleThreaded {
   private readonly data: Map<string, TValue>;
 
   public constructor() {

--- a/src/storage/keyvalue/MemoryMapStorage.ts
+++ b/src/storage/keyvalue/MemoryMapStorage.ts
@@ -3,10 +3,6 @@ import type { KeyValueStorage } from './KeyValueStorage';
 
 /**
  * A {@link KeyValueStorage} which uses a JavaScript Map for internal storage.
- *
- * The Map is kept in the memory of a single process, so this storage is not threadsafe:
- * in a multithreaded setup every worker would have its own copy and their state would diverge.
- * It is therefore marked as {@link SingleThreaded}.
  */
 export class MemoryMapStorage<TValue> implements KeyValueStorage<string, TValue>, SingleThreaded {
   private readonly data: Map<string, TValue>;


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the upstream PR template requires one, so an issue should be created on CommunitySolidServer/CommunitySolidServer before this is submitted upstream.

#### ✍️ Description

`MemoryMapStorage` keeps its state in a per-process JavaScript `Map`, so in a multithreaded setup (`--workers > 1`) every worker holds its own copy and their state silently diverges: an account or OIDC entry written on one worker is invisible to the others. The boot-time cluster guard already rejects such setups for the other per-process in-memory components (`InMemoryDataAccessor`, `MemoryResourceLocker`, `WebSocketMap`, `StreamingHttpMap`), but `MemoryMapStorage` was never marked, so the broken configuration boots instead of failing fast.

This marks the class with the `SingleThreaded` interface, the same way the other in-memory classes are marked. Booting a configuration that uses memory-backed key-value storage with multiple workers now fails at startup with the guard's "is not threadsafe and should not be run in multithreaded setups!" error; single-worker setups are unaffected. The interface is type-only with no runtime surface (the emitted JS is unchanged), which is also why no unit test is added — the observable artifact is the generated Components.js metadata the guard inspects, and none of the four already-marked classes carries a marker test.

Intended as **semver.patch**, targeting `main` per the branch guidance (a fail-fast guard on a configuration that already misbehaved; no API change). Noting honestly that multi-worker boots of memory-backed configs change from silently diverging to erroring, in case the maintainer judges the level differently — contributors cannot set semver labels, so the checklist is left for the maintainer.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
