### PR TITLE
fix: Avoid re-walking storage for every write chunk in quota checks

### DIFF
--- a/src/storage/quota/QuotaStrategy.ts
+++ b/src/storage/quota/QuotaStrategy.ts
@@ -1,5 +1,3 @@
-// These two eslint lines are needed to store 'this' in a variable so it can be used
-// in the PassThrough of createQuotaGuard
 import { PassThrough } from 'node:stream';
 import type { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
@@ -86,14 +84,20 @@ export abstract class QuotaStrategy {
    */
   public async createQuotaGuard(identifier: ResourceIdentifier): Promise<Guarded<PassThrough>> {
     let total = 0;
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const that = this;
     const { reporter } = this;
+
+    // The available space is computed a single time, before any chunk is streamed, instead of
+    // for every chunk. The space occupied by everything other than the resource being written
+    // does not change while a single write is streaming, so it can be captured once and reused.
+    // Re-walking the filesystem (getTotalSpaceUsed) for every chunk turned each write into an
+    // O(chunks * storage size) operation and was a denial-of-service lever when quota is enabled.
+    // The rejection point is unchanged: a write is refused as soon as its cumulative byte count
+    // exceeds the space that was available before the write started.
+    const availableSpace = await this.getAvailableSpace(identifier);
 
     return guardStream(new PassThrough({
       async transform(this, chunk: unknown, enc: string, done: () => void): Promise<void> {
         total += await reporter.calculateChunkSize(chunk);
-        const availableSpace = await that.getAvailableSpace(identifier);
         if (availableSpace.amount < total) {
           this.destroy(new PayloadHttpError(
             `Quota exceeded by ${total - availableSpace.amount} ${availableSpace.unit} during write`,

--- a/src/storage/quota/QuotaStrategy.ts
+++ b/src/storage/quota/QuotaStrategy.ts
@@ -86,13 +86,8 @@ export abstract class QuotaStrategy {
     let total = 0;
     const { reporter } = this;
 
-    // The available space is computed a single time, before any chunk is streamed, instead of
-    // for every chunk. The space occupied by everything other than the resource being written
-    // does not change while a single write is streaming, so it can be captured once and reused.
-    // Re-walking the filesystem (getTotalSpaceUsed) for every chunk turned each write into an
-    // O(chunks * storage size) operation and was a denial-of-service lever when quota is enabled.
-    // The rejection point is unchanged: a write is refused as soon as its cumulative byte count
-    // exceeds the space that was available before the write started.
+    // The space used by everything except the resource being written does not change during the write,
+    // so the available space can be determined once for the entire stream.
     const availableSpace = await this.getAvailableSpace(identifier);
 
     return guardStream(new PassThrough({

--- a/test/unit/quota/QuotaStrategy.test.ts
+++ b/test/unit/quota/QuotaStrategy.test.ts
@@ -97,8 +97,6 @@ describe('A QuotaStrategy', (): void => {
       // Fully consume the stream so every chunk passes through the guard.
       await expect(readableToString(piped)).resolves.toBe(chunk.repeat(5));
 
-      // Regression guard for the per-chunk directory walk: the expensive available-space
-      // computation must happen exactly once per write, not once per chunk.
       expect(availableSpaceSpy).toHaveBeenCalledTimes(1);
       expect(mockReporter.calculateChunkSize).toHaveBeenCalledTimes(5);
     });

--- a/test/unit/quota/QuotaStrategy.test.ts
+++ b/test/unit/quota/QuotaStrategy.test.ts
@@ -3,7 +3,7 @@ import { QuotaStrategy } from '../../../src/storage/quota/QuotaStrategy';
 import { UNIT_BYTES } from '../../../src/storage/size-reporter/Size';
 import type { Size } from '../../../src/storage/size-reporter/Size';
 import type { SizeReporter } from '../../../src/storage/size-reporter/SizeReporter';
-import { guardedStreamFrom, pipeSafely } from '../../../src/util/StreamUtil';
+import { guardedStreamFrom, pipeSafely, readableToString } from '../../../src/util/StreamUtil';
 import { mockFileSystem } from '../../util/Util';
 
 jest.mock('node:fs');
@@ -84,6 +84,23 @@ describe('A QuotaStrategy', (): void => {
         piped.on('error', (): void => resolve());
       });
       await expect(destroy).resolves.toBeUndefined();
+    });
+
+    it('should only calculate the available space once instead of for every chunk.', async(): Promise<void> => {
+      const availableSpaceSpy = jest.spyOn(strategy, 'getAvailableSpace')
+        .mockResolvedValue({ amount: 10000, unit: mockSize.unit });
+      const chunk = 'A'.repeat(50);
+      const track = await strategy.createQuotaGuard({ path: `${base}nested/file2.txt` });
+      const source = guardedStreamFrom([ chunk, chunk, chunk, chunk, chunk ]);
+      const piped = pipeSafely(source, track);
+
+      // Fully consume the stream so every chunk passes through the guard.
+      await expect(readableToString(piped)).resolves.toBe(chunk.repeat(5));
+
+      // Regression guard for the per-chunk directory walk: the expensive available-space
+      // computation must happen exactly once per write, not once per chunk.
+      expect(availableSpaceSpy).toHaveBeenCalledTimes(1);
+      expect(mockReporter.calculateChunkSize).toHaveBeenCalledTimes(5);
     });
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — an issue needs to be created on CommunitySolidServer/CommunitySolidServer before this is submitted upstream (the template requires a linked issue).

#### ✍️ Description

When quota is enabled, `QuotaStrategy.createQuotaGuard` computed the available space inside the per-chunk `transform`, so every chunk of every write triggered `getAvailableSpace` → `getTotalSpaceUsed` → a full recursive `readdir`+`stat` walk of the whole storage root (global quota) or the entire pod (pod quota) via `FileSizeReporter`. A quota-enabled write was therefore O(chunks × storage size): a throughput sink, and a denial-of-service lever, since a large slow upload re-walks the filesystem thousands of times.

This PR computes the available space once, before returning the guard, and compares the running byte total against that value per chunk. The rejection rule is unchanged: a write is rejected as soon as its cumulative bytes exceed the space available before the write began.

Why this is semantically safe: the available space is `limit − (space used by everything except the resource being written)`, and `getTotalSpaceUsed` already adds back the resource's own current on-disk size. That quantity is invariant for the duration of one write, so recomputing it per chunk always returned the same number (concurrent writes are a pre-existing separate issue — see below). The `MAX_SAFE_INTEGER` "quota not applicable" short-circuit and `QuotaValidator`'s up-front and `afterWrite` checks are untouched.

One honest behavioural note: because `FileSizeReporter` is configured without `ignoreFolders`, the old per-chunk global walk incidentally counted the growing atomic temp file under `/.internal/tempFiles/`, which could reject a global-quota write earlier than the configured limit (timing-dependent, worst case at roughly half the quota). With this change the rejection point is deterministic at the intended limit; a genuinely over-quota write is still rejected. Pod quota was unaffected, as the temp file lives outside the pod.

Performance evidence is the deterministic operation count — no reproducible wall-clock benchmark command exists, since the walk cost depends entirely on storage contents:

| | Full storage walks per write |
| --- | --- |
| Before | 1 per chunk (a 1000-chunk upload walks the storage 1000 times) |
| After | 1 |

The regression test reproduces this: it streams 5 chunks through the guard and asserts `getAvailableSpace` runs exactly once while the per-chunk size calculation runs 5 times.

```
npm run jest -- test/unit/quota/QuotaStrategy.test.ts
```

The investigation surfaced two further quota defects that are deliberately kept out of this PR to keep it single-purpose — each needs its own upstream issue + PR: metadata writes bypass quota entirely (`ValidatingDataAccessor` does not override `writeMetadata`), and concurrent writes can jointly overshoot quota (check-then-write race; no reserve-then-commit).

This targets `main`: it is a backwards-compatible fix with no interface or configuration change, so the intended semver level is **semver.patch** (stated in prose — contributors cannot set labels).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
