### PR TITLE
feat: Add an optional Prometheus metrics endpoint

### DIFF
--- a/config/util/metrics/default.json
+++ b/config/util/metrics/default.json
@@ -3,8 +3,8 @@
   "@graph": [
     {
       "comment": [
-        "OPT-IN Prometheus metrics. This file is NOT imported by any shipped config: add it next to your main config, e.g. `community-solid-server -c config/file.json -c config/util/metrics/default.json`.",
-        "SECURITY: the /metrics endpoint is UNAUTHENTICATED and exposes internal counters (request rates, latencies, process cpu/memory). Restrict it at your reverse proxy or firewall; never expose it to the public internet.",
+        "Opt-in Prometheus metrics. This file is not imported by any shipped config: add it next to your main config, e.g. `community-solid-server -c config/file.json -c config/util/metrics/default.json`.",
+        "The /metrics endpoint is unauthenticated and exposes internal counters (request rates, latencies, process CPU/memory), so restrict it at your reverse proxy or firewall.",
         "This recipe assumes the default handler waterfall (config/http/handler/default.json). If you use a different handler configuration, adjust the Override list below to match its handlers."
       ]
     },

--- a/config/util/metrics/default.json
+++ b/config/util/metrics/default.json
@@ -1,0 +1,56 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": [
+        "OPT-IN Prometheus metrics. This file is NOT imported by any shipped config: add it next to your main config, e.g. `community-solid-server -c config/file.json -c config/util/metrics/default.json`.",
+        "SECURITY: the /metrics endpoint is UNAUTHENTICATED and exposes internal counters (request rates, latencies, process cpu/memory). Restrict it at your reverse proxy or firewall; never expose it to the public internet.",
+        "This recipe assumes the default handler waterfall (config/http/handler/default.json). If you use a different handler configuration, adjust the Override list below to match its handlers."
+      ]
+    },
+    {
+      "comment": "Prometheus registry holding the default process metrics and the HTTP request instruments.",
+      "@id": "urn:solid-server:metrics:PrometheusMetrics",
+      "@type": "PrometheusMetrics"
+    },
+    {
+      "comment": "Observe-only configurator: records request rate/latency without ever writing to the response.",
+      "@id": "urn:solid-server:metrics:MetricsServerConfigurator",
+      "@type": "MetricsServerConfigurator",
+      "metrics": { "@id": "urn:solid-server:metrics:PrometheusMetrics" }
+    },
+    {
+      "comment": "Adds the observe-only metrics configurator to the existing (parallel) set of server configurators.",
+      "@id": "urn:solid-server:default:ServerConfigurator",
+      "@type": "ParallelHandler",
+      "handlers": [
+        { "@id": "urn:solid-server:metrics:MetricsServerConfigurator" }
+      ]
+    },
+    {
+      "comment": "Serves the Prometheus registry on GET /metrics.",
+      "@id": "urn:solid-server:metrics:MetricsHandler",
+      "@type": "MetricsHandler",
+      "metrics": { "@id": "urn:solid-server:metrics:PrometheusMetrics" },
+      "path": "/metrics"
+    },
+    {
+      "comment": "Places the metrics handler first in the waterfall so a scrape is answered immediately and never traverses the LDP stack.",
+      "@type": "Override",
+      "overrideInstance": { "@id": "urn:solid-server:default:BaseHttpHandler" },
+      "overrideParameters": {
+        "@type": "WaterfallHandler",
+        "handlers": [
+          { "@id": "urn:solid-server:metrics:MetricsHandler" },
+          { "@id": "urn:solid-server:default:StaticAssetHandler" },
+          { "@id": "urn:solid-server:default:OidcHandler" },
+          { "@id": "urn:solid-server:default:NotificationHttpHandler" },
+          { "@id": "urn:solid-server:default:StorageDescriptionHandler" },
+          { "@id": "urn:solid-server:default:AuthResourceHttpHandler" },
+          { "@id": "urn:solid-server:default:IdentityProviderHandler" },
+          { "@id": "urn:solid-server:default:LdpHandler" }
+        ]
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "n3": "^1.17.1",
         "nodemailer": "^9.0.1",
         "oidc-provider": "^8.4.0",
+        "prom-client": "^15.1.3",
         "proper-lockfile": "^4.1.2",
         "pump": "^3.0.0",
         "punycode": "^2.3.0",
@@ -5446,6 +5447,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -7605,6 +7615,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -14501,6 +14517,19 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-polyfill": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
@@ -16098,6 +16127,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {
@@ -21579,6 +21617,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
+    },
     "@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -23160,6 +23203,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "brace-expansion": {
       "version": "1.1.14",
@@ -28163,6 +28211,15 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "requires": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise-polyfill": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
@@ -29412,6 +29469,14 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
       "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
       "dev": true
+    },
+    "tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "requires": {
+        "bintrees": "1.0.2"
+      }
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "n3": "^1.17.1",
     "nodemailer": "^9.0.1",
     "oidc-provider": "^8.4.0",
+    "prom-client": "^15.1.3",
     "proper-lockfile": "^4.1.2",
     "pump": "^3.0.0",
     "punycode": "^2.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -380,6 +380,11 @@ export * from './server/middleware/HeaderHandler';
 export * from './server/middleware/StaticAssetHandler';
 export * from './server/middleware/WebSocketAdvertiser';
 
+// Server/Metrics
+export * from './server/metrics/MetricsHandler';
+export * from './server/metrics/MetricsServerConfigurator';
+export * from './server/metrics/PrometheusMetrics';
+
 // Server/Notifications/Generate
 export * from './server/notifications/generate/ActivityNotificationGenerator';
 export * from './server/notifications/generate/AddRemoveNotificationGenerator';

--- a/src/server/metrics/MetricsHandler.ts
+++ b/src/server/metrics/MetricsHandler.ts
@@ -4,13 +4,10 @@ import { HttpHandler } from '../HttpHandler';
 import type { PrometheusMetrics } from './PrometheusMetrics';
 
 /**
- * An {@link HttpHandler} that exposes the collected Prometheus metrics on a fixed path (default `/metrics`).
- *
- * Only `GET` requests on the configured path are handled;
- * any other request is rejected with a {@link NotImplementedHttpError} so it continues down the waterfall.
- *
- * The response is UNAUTHENTICATED and exposes internal counters:
- * make sure this endpoint is restricted at the reverse proxy or firewall when the server is publicly reachable.
+ * An {@link HttpHandler} that serves the collected Prometheus metrics on a fixed path (default `/metrics`).
+ * Only `GET` requests on that path are handled.
+ * The response is unauthenticated and exposes internal counters:
+ * restrict access to this endpoint at the reverse proxy or firewall.
  */
 export class MetricsHandler extends HttpHandler {
   private readonly metrics: PrometheusMetrics;
@@ -30,7 +27,6 @@ export class MetricsHandler extends HttpHandler {
     if (request.method !== 'GET') {
       throw new NotImplementedHttpError('Only GET requests are supported');
     }
-    // Strip a potential query string before comparing to the configured path.
     if (request.url?.split('?')[0] !== this.path) {
       throw new NotImplementedHttpError(`Only ${this.path} is supported`);
     }

--- a/src/server/metrics/MetricsHandler.ts
+++ b/src/server/metrics/MetricsHandler.ts
@@ -1,0 +1,48 @@
+import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import type { HttpHandlerInput } from '../HttpHandler';
+import { HttpHandler } from '../HttpHandler';
+import type { PrometheusMetrics } from './PrometheusMetrics';
+
+/**
+ * An {@link HttpHandler} that exposes the collected Prometheus metrics on a fixed path (default `/metrics`).
+ *
+ * Only `GET` requests on the configured path are handled;
+ * any other request is rejected with a {@link NotImplementedHttpError} so it continues down the waterfall.
+ *
+ * The response is UNAUTHENTICATED and exposes internal counters:
+ * make sure this endpoint is restricted at the reverse proxy or firewall when the server is publicly reachable.
+ */
+export class MetricsHandler extends HttpHandler {
+  private readonly metrics: PrometheusMetrics;
+  private readonly path: string;
+
+  /**
+   * @param metrics - The {@link PrometheusMetrics} exposing the registry to serialize.
+   * @param path - The path on which the metrics are exposed. Defaults to `/metrics`.
+   */
+  public constructor(metrics: PrometheusMetrics, path = '/metrics') {
+    super();
+    this.metrics = metrics;
+    this.path = path;
+  }
+
+  public async canHandle({ request }: HttpHandlerInput): Promise<void> {
+    if (request.method !== 'GET') {
+      throw new NotImplementedHttpError('Only GET requests are supported');
+    }
+    // Strip a potential query string before comparing to the configured path.
+    if (request.url?.split('?')[0] !== this.path) {
+      throw new NotImplementedHttpError(`Only ${this.path} is supported`);
+    }
+  }
+
+  public async handle({ response }: HttpHandlerInput): Promise<void> {
+    const { registry } = this.metrics;
+    const body = await registry.metrics();
+    response.writeHead(200, {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'content-type': registry.contentType,
+    });
+    response.end(body);
+  }
+}

--- a/src/server/metrics/MetricsServerConfigurator.ts
+++ b/src/server/metrics/MetricsServerConfigurator.ts
@@ -1,0 +1,52 @@
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
+import { getLoggerFor } from '../../logging/LogUtil';
+import { createErrorMessage } from '../../util/errors/ErrorUtil';
+import { ServerConfigurator } from '../ServerConfigurator';
+import type { PrometheusMetrics } from './PrometheusMetrics';
+
+/**
+ * A {@link ServerConfigurator} that attaches an observe-only listener to the `request` event of a
+ * {@link Server} to record Prometheus metrics.
+ *
+ * The listener runs alongside the main request listener without interfering with it:
+ * it never writes to the response, never consumes the request body,
+ * and never throws into the request flow.
+ * Any error while instrumenting or recording is caught and logged so that a metrics failure
+ * can never break request handling.
+ *
+ * On every request a timer is started; when the response emits `finish` the duration is observed and
+ * the request counter is incremented with the request method and the response status code.
+ */
+export class MetricsServerConfigurator extends ServerConfigurator {
+  protected readonly logger = getLoggerFor(this);
+
+  private readonly metrics: PrometheusMetrics;
+
+  /**
+   * @param metrics - The {@link PrometheusMetrics} holding the registry and request instruments.
+   */
+  public constructor(metrics: PrometheusMetrics) {
+    super();
+    this.metrics = metrics;
+  }
+
+  public async handle(server: Server): Promise<void> {
+    server.on('request', (request: IncomingMessage, response: ServerResponse): void => {
+      try {
+        // Start timing before the request is handled; the returned function observes the duration.
+        const stopTimer = this.metrics.requestDuration.startTimer();
+        response.on('finish', (): void => {
+          try {
+            const labels = { method: request.method ?? 'UNKNOWN', code: response.statusCode };
+            this.metrics.requestsTotal.inc(labels);
+            stopTimer(labels);
+          } catch (error: unknown) {
+            this.logger.error(`Unable to record request metrics: ${createErrorMessage(error)}`);
+          }
+        });
+      } catch (error: unknown) {
+        this.logger.error(`Unable to instrument request for metrics: ${createErrorMessage(error)}`);
+      }
+    });
+  }
+}

--- a/src/server/metrics/MetricsServerConfigurator.ts
+++ b/src/server/metrics/MetricsServerConfigurator.ts
@@ -6,16 +6,9 @@ import type { PrometheusMetrics } from './PrometheusMetrics';
 
 /**
  * A {@link ServerConfigurator} that attaches an observe-only listener to the `request` event of a
- * {@link Server} to record Prometheus metrics.
- *
- * The listener runs alongside the main request listener without interfering with it:
- * it never writes to the response, never consumes the request body,
- * and never throws into the request flow.
- * Any error while instrumenting or recording is caught and logged so that a metrics failure
- * can never break request handling.
- *
- * On every request a timer is started; when the response emits `finish` the duration is observed and
- * the request counter is incremented with the request method and the response status code.
+ * {@link Server}, recording the request count and duration, labelled by method and status code,
+ * once the response finishes. The listener never writes to the response,
+ * and errors are caught and logged, so a metrics failure can never break request handling.
  */
 export class MetricsServerConfigurator extends ServerConfigurator {
   protected readonly logger = getLoggerFor(this);
@@ -33,7 +26,6 @@ export class MetricsServerConfigurator extends ServerConfigurator {
   public async handle(server: Server): Promise<void> {
     server.on('request', (request: IncomingMessage, response: ServerResponse): void => {
       try {
-        // Start timing before the request is handled; the returned function observes the duration.
         const stopTimer = this.metrics.requestDuration.startTimer();
         response.on('finish', (): void => {
           try {

--- a/src/server/metrics/PrometheusMetrics.ts
+++ b/src/server/metrics/PrometheusMetrics.ts
@@ -1,16 +1,10 @@
 import { collectDefaultMetrics, Counter, Histogram, Registry } from 'prom-client';
 
 /**
- * Creates and owns a Prometheus {@link Registry} together with the instruments used to observe
- * incoming HTTP requests.
- *
- * Default process metrics (CPU, memory, event loop lag, garbage collection, ...) are collected on the
- * same registry through `collectDefaultMetrics`.
- *
- * The request instruments are intentionally kept low-cardinality: they are only labelled by the
- * request `method` and the response status `code`.
- * The request target/path is deliberately *not* used as a label:
- * the unbounded number of resource URLs would cause a cardinality explosion in the time-series database.
+ * Creates a Prometheus {@link Registry} collecting the default process metrics,
+ * together with the instruments used to observe incoming HTTP requests.
+ * These are only labelled by request `method` and response status `code`:
+ * a label on the request path would cause a cardinality explosion, since every resource URL is distinct.
  */
 export class PrometheusMetrics {
   public readonly registry: Registry;
@@ -19,7 +13,6 @@ export class PrometheusMetrics {
 
   public constructor() {
     this.registry = new Registry();
-    // Collect the default Node.js/process metrics (cpu, memory, event loop lag, gc, ...) on this registry.
     collectDefaultMetrics({ register: this.registry });
 
     this.requestsTotal = new Counter({

--- a/src/server/metrics/PrometheusMetrics.ts
+++ b/src/server/metrics/PrometheusMetrics.ts
@@ -1,0 +1,39 @@
+import { collectDefaultMetrics, Counter, Histogram, Registry } from 'prom-client';
+
+/**
+ * Creates and owns a Prometheus {@link Registry} together with the instruments used to observe
+ * incoming HTTP requests.
+ *
+ * Default process metrics (CPU, memory, event loop lag, garbage collection, ...) are collected on the
+ * same registry through `collectDefaultMetrics`.
+ *
+ * The request instruments are intentionally kept low-cardinality: they are only labelled by the
+ * request `method` and the response status `code`.
+ * The request target/path is deliberately *not* used as a label:
+ * the unbounded number of resource URLs would cause a cardinality explosion in the time-series database.
+ */
+export class PrometheusMetrics {
+  public readonly registry: Registry;
+  public readonly requestsTotal: Counter<'code' | 'method'>;
+  public readonly requestDuration: Histogram<'code' | 'method'>;
+
+  public constructor() {
+    this.registry = new Registry();
+    // Collect the default Node.js/process metrics (cpu, memory, event loop lag, gc, ...) on this registry.
+    collectDefaultMetrics({ register: this.registry });
+
+    this.requestsTotal = new Counter({
+      name: 'http_requests_total',
+      help: 'Total number of HTTP requests, labelled by request method and response status code.',
+      labelNames: [ 'method', 'code' ],
+      registers: [ this.registry ],
+    });
+
+    this.requestDuration = new Histogram({
+      name: 'http_request_duration_seconds',
+      help: 'Duration of HTTP requests in seconds, labelled by request method and response status code.',
+      labelNames: [ 'method', 'code' ],
+      registers: [ this.registry ],
+    });
+  }
+}

--- a/test/unit/server/metrics/MetricsHandler.test.ts
+++ b/test/unit/server/metrics/MetricsHandler.test.ts
@@ -1,0 +1,63 @@
+import { MetricsHandler } from '../../../../src/server/metrics/MetricsHandler';
+import type { PrometheusMetrics } from '../../../../src/server/metrics/PrometheusMetrics';
+
+describe('A MetricsHandler', (): void => {
+  const contentType = 'text/plain; version=0.0.4; charset=utf-8';
+  let registry: { metrics: jest.Mock; contentType: string };
+  let metrics: jest.Mocked<PrometheusMetrics>;
+  let response: { writeHead: jest.Mock; end: jest.Mock };
+  let handler: MetricsHandler;
+
+  beforeEach((): void => {
+    registry = {
+      metrics: jest.fn().mockResolvedValue('# metrics body'),
+      contentType,
+    };
+    metrics = { registry } as any;
+
+    response = {
+      writeHead: jest.fn(),
+      end: jest.fn(),
+    };
+
+    handler = new MetricsHandler(metrics);
+  });
+
+  it('rejects non-GET requests.', async(): Promise<void> => {
+    const request = { method: 'POST', url: '/metrics' };
+    await expect(handler.canHandle({ request } as any)).rejects.toThrow('Only GET requests are supported');
+  });
+
+  it('rejects GET requests on a different path.', async(): Promise<void> => {
+    const request = { method: 'GET', url: '/other' };
+    await expect(handler.canHandle({ request } as any)).rejects.toThrow('Only /metrics is supported');
+  });
+
+  it('rejects GET requests without a URL.', async(): Promise<void> => {
+    const request = { method: 'GET' };
+    await expect(handler.canHandle({ request } as any)).rejects.toThrow('Only /metrics is supported');
+  });
+
+  it('accepts GET requests on the metrics path, ignoring the query string.', async(): Promise<void> => {
+    const request = { method: 'GET', url: '/metrics?foo=bar' };
+    await expect(handler.canHandle({ request } as any)).resolves.toBeUndefined();
+  });
+
+  it('serves the registry contents with the registry content type.', async(): Promise<void> => {
+    await handler.handle({ response } as any);
+
+    expect(registry.metrics).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenLastCalledWith(200, { 'content-type': contentType });
+    expect(response.end).toHaveBeenCalledTimes(1);
+    expect(response.end).toHaveBeenLastCalledWith('# metrics body');
+  });
+
+  it('exposes the metrics on a configurable path.', async(): Promise<void> => {
+    handler = new MetricsHandler(metrics, '/internal/metrics');
+    await expect(handler.canHandle({ request: { method: 'GET', url: '/metrics' }} as any)).rejects
+      .toThrow('Only /internal/metrics is supported');
+    await expect(handler.canHandle({ request: { method: 'GET', url: '/internal/metrics' }} as any)).resolves
+      .toBeUndefined();
+  });
+});

--- a/test/unit/server/metrics/MetricsServerConfigurator.test.ts
+++ b/test/unit/server/metrics/MetricsServerConfigurator.test.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from 'node:events';
+import type { Server } from 'node:http';
+import type { Logger } from '../../../../src/logging/Logger';
+import { getLoggerFor } from '../../../../src/logging/LogUtil';
+import { MetricsServerConfigurator } from '../../../../src/server/metrics/MetricsServerConfigurator';
+import type { PrometheusMetrics } from '../../../../src/server/metrics/PrometheusMetrics';
+
+jest.mock('../../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { error: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+
+describe('A MetricsServerConfigurator', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
+  let server: Server;
+  let request: any;
+  let response: any;
+  let stopTimer: jest.Mock;
+  let metrics: jest.Mocked<PrometheusMetrics>;
+  let configurator: MetricsServerConfigurator;
+
+  beforeEach(async(): Promise<void> => {
+    jest.clearAllMocks();
+
+    server = new EventEmitter() as any;
+
+    request = { method: 'GET', url: '/foo' };
+
+    response = Object.assign(new EventEmitter(), {
+      statusCode: 200,
+      write: jest.fn(),
+      writeHead: jest.fn(),
+      end: jest.fn(),
+      setHeader: jest.fn(),
+    });
+
+    stopTimer = jest.fn();
+    metrics = {
+      requestDuration: { startTimer: jest.fn().mockReturnValue(stopTimer) },
+      requestsTotal: { inc: jest.fn() },
+    } as any;
+
+    configurator = new MetricsServerConfigurator(metrics);
+    await configurator.handle(server);
+  });
+
+  it('starts a timer per request but only records once the response finishes.', (): void => {
+    server.emit('request', request, response);
+    expect(metrics.requestDuration.startTimer).toHaveBeenCalledTimes(1);
+    expect(metrics.requestsTotal.inc).toHaveBeenCalledTimes(0);
+
+    response.emit('finish');
+    expect(metrics.requestsTotal.inc).toHaveBeenCalledTimes(1);
+    expect(metrics.requestsTotal.inc).toHaveBeenLastCalledWith({ method: 'GET', code: 200 });
+    expect(stopTimer).toHaveBeenCalledTimes(1);
+    expect(stopTimer).toHaveBeenLastCalledWith({ method: 'GET', code: 200 });
+  });
+
+  it('never writes to the response.', (): void => {
+    server.emit('request', request, response);
+    response.emit('finish');
+    expect(response.write).toHaveBeenCalledTimes(0);
+    expect(response.writeHead).toHaveBeenCalledTimes(0);
+    expect(response.end).toHaveBeenCalledTimes(0);
+    expect(response.setHeader).toHaveBeenCalledTimes(0);
+  });
+
+  it('uses a placeholder label when the request method is undefined.', (): void => {
+    request.method = undefined;
+    server.emit('request', request, response);
+    response.emit('finish');
+    expect(metrics.requestsTotal.inc).toHaveBeenLastCalledWith({ method: 'UNKNOWN', code: 200 });
+  });
+
+  it('does not throw or break the request flow when recording fails.', (): void => {
+    metrics.requestsTotal.inc.mockImplementation((): never => {
+      throw new Error('boom');
+    });
+    server.emit('request', request, response);
+    expect((): boolean => response.emit('finish')).not.toThrow();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith(expect.stringContaining('Unable to record request metrics'));
+  });
+
+  it('does not throw when the timer cannot be started.', (): void => {
+    metrics.requestDuration.startTimer.mockImplementation((): never => {
+      throw new Error('no timer');
+    });
+    expect((): void => {
+      server.emit('request', request, response);
+    }).not.toThrow();
+    expect(metrics.requestsTotal.inc).toHaveBeenCalledTimes(0);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith(expect.stringContaining('Unable to instrument request for metrics'));
+  });
+});

--- a/test/unit/server/metrics/PrometheusMetrics.test.ts
+++ b/test/unit/server/metrics/PrometheusMetrics.test.ts
@@ -1,0 +1,48 @@
+import { PrometheusMetrics } from '../../../../src/server/metrics/PrometheusMetrics';
+
+describe('A PrometheusMetrics', (): void => {
+  let metrics: PrometheusMetrics;
+
+  beforeEach((): void => {
+    metrics = new PrometheusMetrics();
+  });
+
+  afterEach((): void => {
+    metrics.registry.clear();
+  });
+
+  it('creates a registry using the Prometheus content type.', (): void => {
+    expect(metrics.registry.contentType).toContain('text/plain');
+  });
+
+  it('collects the default process metrics on its registry.', async(): Promise<void> => {
+    // `process_start_time_seconds` is one of the metrics registered by `collectDefaultMetrics`.
+    expect(metrics.registry.getSingleMetric('process_start_time_seconds')).toBeDefined();
+    await expect(metrics.registry.metrics()).resolves.toContain('process_cpu_user_seconds_total');
+  });
+
+  it('creates an http_requests_total counter labelled by method and code.', async(): Promise<void> => {
+    expect(metrics.registry.getSingleMetric('http_requests_total')).toBeDefined();
+
+    metrics.requestsTotal.inc({ method: 'GET', code: 200 });
+
+    const json = await metrics.registry.getMetricsAsJSON();
+    const counter = json.find((metric): boolean => metric.name === 'http_requests_total');
+    expect(counter?.type).toBe('counter');
+    expect(counter?.values).toContainEqual(
+      expect.objectContaining({ value: 1, labels: { method: 'GET', code: 200 }}),
+    );
+  });
+
+  it('creates an http_request_duration_seconds histogram labelled by method and code.', async(): Promise<void> => {
+    expect(metrics.registry.getSingleMetric('http_request_duration_seconds')).toBeDefined();
+
+    metrics.requestDuration.observe({ method: 'POST', code: 500 }, 0.25);
+
+    const json = await metrics.registry.getMetricsAsJSON();
+    const histogram = json.find((metric): boolean => metric.name === 'http_request_duration_seconds');
+    expect(histogram?.type).toBe('histogram');
+    expect(histogram?.values.some((value): boolean =>
+      value.labels.method === 'POST' && value.labels.code === 500)).toBe(true);
+  });
+});


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet. An upstream issue describing the need for operational metrics must be created before this is submitted to CommunitySolidServer — the PR template requires one.

#### ✍️ Description

CSS has no runtime instrumentation: an operator gets no request-rate, latency, or error visibility, and no process (CPU / memory / event loop / GC) metrics. This adds an opt-in Prometheus metrics surface built on `prom-client`:

- `PrometheusMetrics` owns a dedicated registry with `collectDefaultMetrics` (process CPU, memory, event loop lag, GC) and two request instruments: an `http_requests_total{method, code}` counter and an `http_request_duration_seconds{method, code}` histogram (default buckets).
- `MetricsServerConfigurator` attaches a second, observe-only listener to the server's `request` event (Node invokes all listeners) and records both instruments when the response emits `finish`. It never writes to the response or consumes the request body, and both the instrumenting and the recording paths are `try`/`catch`-wrapped, so a metrics failure cannot break request handling. The unit tests include an observe-only proof: a full request/finish cycle asserts zero calls to `write`/`writeHead`/`end`/`setHeader`.
- `MetricsHandler` serves `GET /metrics` in the Prometheus exposition format, placed first in the handler waterfall so a scrape never traverses the LDP stack.

Design decisions:

- The request instruments are labelled only by method and status code. A path/URL label would explode time-series cardinality, since every resource URL is distinct; method × code is bounded.
- Nothing is wired into the shipped root configs: operators opt in by adding `-c @css:config/util/metrics/default.json` as a second config. `/metrics` is unauthenticated, so the config warns to restrict it at the reverse proxy or firewall.
- Config wiring (the non-obvious part): the shipped `ServerConfigurator` is already a `ParallelHandler`, so the metrics collector merges into that set. The `/metrics` handler however has to sit before the `LdpHandler` catch-all, and Components.js merges same-`@id` array parameters in document load order — a plain merge would append it last, and LDP would answer `/metrics` with a 404. The config therefore uses a Components.js `Override` to replace the `BaseHttpHandler` waterfall with `[MetricsHandler, ...the default seven]`. That is deterministic but assumes the default handler waterfall; the config comment says so.

Intended semver level: **minor** (backwards-compatible opt-in feature; adds `prom-client` — a widely used, zero-dependency library — to `dependencies`).

Verified on this branch: `npm run build` (including components generation for the three new classes), lint at zero warnings, and the unit suite under the 100% `./src` coverage gate; 15 unit tests cover the three classes, including the `UNKNOWN`-method and metric-failure branches. Smoke-tested by booting `-c config/file.json -c config/util/metrics/default.json`: `GET /` still serves the LDP stack, and `GET /metrics` returns the exposition format with the request metrics incrementing across requests.

Before upstream submission: create the related issue (above); retarget to the latest `versions/*` branch (`versions/next-major`) — as a feature this should not target `main`; and consider a short page under `documentation/markdown` for the new config option.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
