### PR TITLE
feat: Make the password hashing cost factor configurable

### DIFF
--- a/config/app/variables/cli/cli.json
+++ b/config/app/variables/cli/cli.json
@@ -129,6 +129,15 @@
             "type": "boolean",
             "describe": "Skips the confirmation prompts during migration from older versions."
           }
+        },
+        {
+          "@type": "YargsParameter",
+          "name": "saltRounds",
+          "options": {
+            "requiresArg": true,
+            "type": "number",
+            "describe": "The bcrypt cost factor (salt rounds) used when hashing passwords. Higher is more secure but slower."
+          }
         }
       ],
       "options": {

--- a/config/app/variables/resolver/resolver.json
+++ b/config/app/variables/resolver/resolver.json
@@ -89,6 +89,14 @@
             "key": "confirmMigration",
             "defaultValue": false
           }
+        },
+        {
+          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:saltRounds",
+          "CombinedShorthandResolver:_resolvers_value": {
+            "@type": "KeyExtractor",
+            "key": "saltRounds",
+            "defaultValue": 10
+          }
         }
       ]
     }

--- a/config/identity/handler/storage/password.json
+++ b/config/identity/handler/storage/password.json
@@ -4,7 +4,8 @@
     {
       "@id": "urn:solid-server:default:PasswordStore",
       "@type": "BasePasswordStore",
-      "storage": { "@id": "urn:solid-server:default:AccountStorage" }
+      "storage": { "@id": "urn:solid-server:default:AccountStorage" },
+      "saltRounds": { "@id": "urn:solid-server:default:variable:saltRounds" }
     },
     {
       "comment": "Initialize the password store. Also necessary on primary thread for pod seeding.",

--- a/config/util/variables/default.json
+++ b/config/util/variables/default.json
@@ -58,7 +58,7 @@
       "@type": "Variable"
     },
     {
-      "comment": "The bcrypt cost factor (salt rounds) used when hashing passwords. Higher is more secure but slower.",
+      "comment": "The bcrypt cost factor (salt rounds) used when hashing passwords.",
       "@id": "urn:solid-server:default:variable:saltRounds",
       "@type": "Variable"
     }

--- a/config/util/variables/default.json
+++ b/config/util/variables/default.json
@@ -56,6 +56,11 @@
       "comment": "If true, skips the confirmation prompts during migration.",
       "@id": "urn:solid-server:default:variable:confirmMigration",
       "@type": "Variable"
+    },
+    {
+      "comment": "The bcrypt cost factor (salt rounds) used when hashing passwords. Higher is more secure but slower.",
+      "@id": "urn:solid-server:default:variable:saltRounds",
+      "@type": "Variable"
     }
   ]
 }

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -64,7 +64,7 @@ to some commonly used settings:
 | `--seedConfig`          |                            | Path to the file that keeps track of seeded account configurations.                                                                           |
 | `--mainModulePath, -m`  |                            | Path from where Components.js will start its lookup when initializing configurations.                                                         |
 | `--workers, -w`         | `1`                        | Run in multithreaded mode using workers. Special values are `-1` (scale to `num_cores-1`), `0` (scale to `num_cores`) and 1 (singlethreaded). |
-| `--saltRounds`          | `10`                       | The bcrypt cost factor (salt rounds) used when hashing passwords. Also settable via `CSS_SALT_ROUNDS`.                                        |
+| `--saltRounds`          | `10`                       | The bcrypt cost factor (salt rounds) used when hashing passwords.                                                                             |
 
 Parameters can also be passed through environment variables.
 

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -64,6 +64,7 @@ to some commonly used settings:
 | `--seedConfig`          |                            | Path to the file that keeps track of seeded account configurations.                                                                           |
 | `--mainModulePath, -m`  |                            | Path from where Components.js will start its lookup when initializing configurations.                                                         |
 | `--workers, -w`         | `1`                        | Run in multithreaded mode using workers. Special values are `-1` (scale to `num_cores-1`), `0` (scale to `num_cores`) and 1 (singlethreaded). |
+| `--saltRounds`          | `10`                       | The bcrypt cost factor (salt rounds) used when hashing passwords. Also settable via `CSS_SALT_ROUNDS`.                                        |
 
 Parameters can also be passed through environment variables.
 

--- a/test/integration/Config.ts
+++ b/test/integration/Config.ts
@@ -60,5 +60,6 @@ export function getDefaultVariables(port: number, baseUrl?: string): Record<stri
     'urn:solid-server:default:variable:seedConfig': null,
     'urn:solid-server:default:variable:workers': 1,
     'urn:solid-server:default:variable:confirmMigration': false,
+    'urn:solid-server:default:variable:saltRounds': 10,
   };
 }


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the upstream template requires a related issue, so one must be created on CommunitySolidServer/CommunitySolidServer before this is submitted (proposal: "Make the password hashing cost factor configurable").

#### ✍️ Description

The bcrypt cost factor for password hashing is fixed at **10**: `BasePasswordStore` already accepts a `saltRounds` constructor parameter (default 10), but the shipped `password.json` never passes it, so operators have no way to raise it — and 10 is on the low side for current hardware (12+ is a common recommendation for interactive logins).

This exposes it as a standard CLI/env/config variable, **default 10, so out-of-the-box behaviour is unchanged**. No `src/` code is touched — this is pure config wiring, mirroring the existing `loggingLevel` pattern:

- New `saltRounds` Components.js variable (`config/util/variables/default.json`), with a `--saltRounds` CLI option / `CSS_SALT_ROUNDS` env var (`cli.json`) and a resolver default of 10 (`resolver.json`).
- `password.json` passes the variable to `BasePasswordStore`.
- `test/integration/Config.ts` binds the new variable, so programmatic instantiation of the default configs keeps working.
- Documented in the `starting-server.md` parameter table.

Operators can then run e.g. `--saltRounds 12` (or `CSS_SALT_ROUNDS=12`) to harden password hashing. Raising the cost only affects newly created or changed passwords: verification uses `compare`, which reads the cost from the stored hash, so existing hashes keep working unchanged.

Notes for reviewers:

- No `src/` change → no unit-coverage delta; the value flows through the existing constructor parameter.
- Smoke-tested: booted `-c config/file.json --saltRounds 12`; the server accepted the option and a full account + password-login creation succeeded (hashing at cost 12). A default boot (no flag) is unchanged.
- Existing CLI/resolver unit tests are fully mocked (own key maps) and unaffected; `test/integration/Config.ts` was the only shared variable enumeration and is updated. One nuance for the semver call: programmatic users who bind the default configs' variables themselves will need to bind the new variable, just as `Config.ts` does.
- Gates run green: full `npm run build` (components generation binds the new variable), the coverage-gated unit suite, and eslint at zero warnings.
- Intended as **semver.minor** (backwards-compatible feature addition). As a feature + config change, the upstream target should be the latest `versions/*` branch (currently `versions/next-major`), not `main` — this fork-internal draft is based on `main` only for staging and will be retargeted on submission. Contributors cannot set the semver label; leaving the checklist below for the maintainer.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
