### PR TITLE
feat: Make the Redis locker connection configurable

### DIFF
--- a/config/app/variables/cli/cli.json
+++ b/config/app/variables/cli/cli.json
@@ -129,6 +129,23 @@
             "type": "boolean",
             "describe": "Skips the confirmation prompts during migration from older versions."
           }
+        },
+        {
+          "@type": "YargsParameter",
+          "name": "redisUrl",
+          "options": {
+            "requiresArg": true,
+            "type": "string",
+            "describe": "Redis connection (host:port or redis:// URL). Only applies when using a Redis-based locker config."
+          }
+        },
+        {
+          "@type": "YargsParameter",
+          "name": "redisNamespace",
+          "options": {
+            "type": "string",
+            "describe": "Key namespace prefix for this deployment's locks. Only applies when using a Redis-based locker config."
+          }
         }
       ],
       "options": {

--- a/config/app/variables/resolver/resolver.json
+++ b/config/app/variables/resolver/resolver.json
@@ -89,6 +89,22 @@
             "key": "confirmMigration",
             "defaultValue": false
           }
+        },
+        {
+          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:redisUrl",
+          "CombinedShorthandResolver:_resolvers_value": {
+            "@type": "KeyExtractor",
+            "key": "redisUrl",
+            "defaultValue": "127.0.0.1:6379"
+          }
+        },
+        {
+          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:redisNamespace",
+          "CombinedShorthandResolver:_resolvers_value": {
+            "@type": "KeyExtractor",
+            "key": "redisNamespace",
+            "defaultValue": ""
+          }
         }
       ]
     }

--- a/config/util/resource-locker/redis.json
+++ b/config/util/resource-locker/redis.json
@@ -2,12 +2,19 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
   "@graph": [
     {
-      "comment": "Allows multiple simultaneous read operations. All locks are threadsafe.",
+      "comment": [
+        "Allows multiple simultaneous read operations. All locks are threadsafe.",
+        "HA / multi-instance deployment shape: use a file (or database) storage backend, a single shared Redis",
+        "reachable by every server instance, and a distinct `redisNamespace` per logical deployment so different",
+        "deployments never share lock keys. All instances of the SAME deployment must share one namespace to coordinate."
+      ],
       "@id": "urn:solid-server:default:ResourceLocker",
       "@type": "WrappedExpiringReadWriteLocker",
       "locker": {
         "@id": "urn:solid-server:default:RedisLocker",
-        "@type": "RedisLocker"
+        "@type": "RedisLocker",
+        "redisClient": { "@id": "urn:solid-server:default:variable:redisUrl" },
+        "redisSettings_namespacePrefix": { "@id": "urn:solid-server:default:variable:redisNamespace" }
       },
       "expiration": 6000
     },

--- a/config/util/resource-locker/redis.json
+++ b/config/util/resource-locker/redis.json
@@ -2,12 +2,7 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
   "@graph": [
     {
-      "comment": [
-        "Allows multiple simultaneous read operations. All locks are threadsafe.",
-        "HA / multi-instance deployment shape: use a file (or database) storage backend, a single shared Redis",
-        "reachable by every server instance, and a distinct `redisNamespace` per logical deployment so different",
-        "deployments never share lock keys. All instances of the SAME deployment must share one namespace to coordinate."
-      ],
+      "comment": "Allows multiple simultaneous read operations. All locks are threadsafe.",
       "@id": "urn:solid-server:default:ResourceLocker",
       "@type": "WrappedExpiringReadWriteLocker",
       "locker": {

--- a/config/util/resource-locker/redis.json
+++ b/config/util/resource-locker/redis.json
@@ -6,6 +6,7 @@
       "@id": "urn:solid-server:default:ResourceLocker",
       "@type": "WrappedExpiringReadWriteLocker",
       "locker": {
+        "comment": "All server instances sharing a lock domain must point at the same Redis service and namespace.",
         "@id": "urn:solid-server:default:RedisLocker",
         "@type": "RedisLocker",
         "redisClient": { "@id": "urn:solid-server:default:variable:redisUrl" },

--- a/config/util/variables/default.json
+++ b/config/util/variables/default.json
@@ -56,6 +56,16 @@
       "comment": "If true, skips the confirmation prompts during migration.",
       "@id": "urn:solid-server:default:variable:confirmMigration",
       "@type": "Variable"
+    },
+    {
+      "comment": "Redis connection for the Redis-based resource locker, e.g. host:port or a redis:// URL.",
+      "@id": "urn:solid-server:default:variable:redisUrl",
+      "@type": "Variable"
+    },
+    {
+      "comment": "Key namespace prefix to isolate this deployment's locks in a shared Redis.",
+      "@id": "urn:solid-server:default:variable:redisNamespace",
+      "@type": "Variable"
     }
   ]
 }

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -64,6 +64,8 @@ to some commonly used settings:
 | `--seedConfig`          |                            | Path to the file that keeps track of seeded account configurations.                                                                           |
 | `--mainModulePath, -m`  |                            | Path from where Components.js will start its lookup when initializing configurations.                                                         |
 | `--workers, -w`         | `1`                        | Run in multithreaded mode using workers. Special values are `-1` (scale to `num_cores-1`), `0` (scale to `num_cores`) and 1 (singlethreaded). |
+| `--redisUrl`            | `127.0.0.1:6379`           | Redis connection (`host:port` or `redis://` URL) for the Redis-based locker. Also settable via `CSS_REDIS_URL`.                               |
+| `--redisNamespace`      |                            | Key namespace prefix isolating this deployment's locks in a shared Redis. Also settable via `CSS_REDIS_NAMESPACE`.                            |
 
 Parameters can also be passed through environment variables.
 

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -64,8 +64,8 @@ to some commonly used settings:
 | `--seedConfig`          |                            | Path to the file that keeps track of seeded account configurations.                                                                           |
 | `--mainModulePath, -m`  |                            | Path from where Components.js will start its lookup when initializing configurations.                                                         |
 | `--workers, -w`         | `1`                        | Run in multithreaded mode using workers. Special values are `-1` (scale to `num_cores-1`), `0` (scale to `num_cores`) and 1 (singlethreaded). |
-| `--redisUrl`            | `127.0.0.1:6379`           | Redis connection (`host:port` or `redis://` URL) for the Redis-based locker. Also settable via `CSS_REDIS_URL`.                               |
-| `--redisNamespace`      |                            | Key namespace prefix isolating this deployment's locks in a shared Redis. Also settable via `CSS_REDIS_NAMESPACE`.                            |
+| `--redisUrl`            | `127.0.0.1:6379`           | Redis connection (`host:port` or `redis://` URL) for the Redis-based locker.                                                                  |
+| `--redisNamespace`      |                            | Key namespace prefix isolating this deployment's locks in a shared Redis.                                                                     |
 
 Parameters can also be passed through environment variables.
 

--- a/test/integration/Config.ts
+++ b/test/integration/Config.ts
@@ -60,5 +60,7 @@ export function getDefaultVariables(port: number, baseUrl?: string): Record<stri
     'urn:solid-server:default:variable:seedConfig': null,
     'urn:solid-server:default:variable:workers': 1,
     'urn:solid-server:default:variable:confirmMigration': false,
+    'urn:solid-server:default:variable:redisUrl': '127.0.0.1:6379',
+    'urn:solid-server:default:variable:redisNamespace': '',
   };
 }


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the upstream PR template requires a related issue, so one must be created on CommunitySolidServer/CommunitySolidServer before this is submitted there.

#### ✍️ Description

`config/util/resource-locker/redis.json` instantiates `RedisLocker` with no arguments, hardcoding `127.0.0.1:6379` and an empty key namespace — so the only cross-machine (multi-instance) locking path is not configurable at startup. `RedisLocker`'s constructor already accepts what is needed, so this is pure config wiring (`RedisLocker.ts` is unchanged), mirroring the existing `sparqlEndpoint` variable pattern:

- `--redisUrl` / `CSS_REDIS_URL` (default `127.0.0.1:6379`): the connection, as `host:port` or a `redis://` URL.
- `--redisNamespace` / `CSS_REDIS_NAMESPACE` (default empty): a key prefix isolating one deployment's locks in a shared Redis.

Defaults preserve current behaviour exactly. The namespace is wired through the flattened Components.js parameter `redisSettings_namespacePrefix` — the generator produces flat `a_b_c` keys for nested argument objects, not nested JSON (verified against the generated `RedisLocker.jsonld` and the `sparql.json` precedent).

Intended deployment shape (the reason the namespace flag exists): all instances of one deployment share a single Redis and a single namespace so they coordinate on the same lock keys, while distinct deployments on the same Redis use distinct namespaces so they never contend. No shipped config imports `resource-locker/redis.json`; operators compose it in place of the default file/memory locker (the instantiated `@id` is `urn:solid-server:default:ResourceLocker`).

Verified against a live Redis by booting a `file.json` variant with this locker: with no flags, lock keys appear un-prefixed (`__RW__http://localhost:3482/...`); with `--redisNamespace test-deploy`, they appear as `test-deploy__RW__...`. That exercises both the connection variable and the flattened namespace field end-to-end. (Not a performance change, so there are no benchmarks to report.)

Two pre-existing hazards in `RedisLuaScripts.ts` surfaced while verifying the multi-instance path. Both predate this PR and are out of scope here; each needs its own upstream issue and separate PR:

1. Locks are `SET` without a TTL, so the Redis key of a crashed lock-holder persists and deadlocks peers on that resource — `WrappedExpiringReadWriteLocker` (6 s) only expires the in-process usage, not the Redis key of a dead process.
2. The startup cleanup initializer clears all locks in the namespace, so a rolling restart of one instance wipes locks held by live peers. Until fixed, operators should quiesce an instance before restarting it.

Notes for review: `test/integration/Config.ts` binds the two new variables (harmless for configs that do not use them). As a backwards-compatible feature addition the intended semver level is **semver.minor**, and since it changes configuration behaviour the upstream submission should target the latest `versions/*` branch (`versions/next-major`), not `main` — this fork PR targets `main` only for pre-review. `npm run build`, lint (zero warnings), and the full unit suite with the 100% coverage gate are green.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
