### PR TITLE
perf: Allow disabling log colorization for plain, cheaper output

### DIFF
--- a/config/app/variables/cli/cli.json
+++ b/config/app/variables/cli/cli.json
@@ -38,6 +38,15 @@
         },
         {
           "@type": "YargsParameter",
+          "name": "loggingFormat",
+          "options": {
+            "requiresArg": true,
+            "type": "string",
+            "describe": "The format used to output log messages: 'pretty' or 'json'."
+          }
+        },
+        {
+          "@type": "YargsParameter",
           "name": "baseUrl",
           "options": {
             "alias": "b",

--- a/config/app/variables/cli/cli.json
+++ b/config/app/variables/cli/cli.json
@@ -47,6 +47,14 @@
         },
         {
           "@type": "YargsParameter",
+          "name": "loggingColorize",
+          "options": {
+            "type": "boolean",
+            "describe": "Whether the 'pretty' log format colorizes the level. Use --no-loggingColorize for plain output."
+          }
+        },
+        {
+          "@type": "YargsParameter",
           "name": "baseUrl",
           "options": {
             "alias": "b",

--- a/config/app/variables/resolver/resolver.json
+++ b/config/app/variables/resolver/resolver.json
@@ -29,6 +29,14 @@
           }
         },
         {
+          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:loggingColorize",
+          "CombinedShorthandResolver:_resolvers_value": {
+            "@type": "KeyExtractor",
+            "key": "loggingColorize",
+            "defaultValue": true
+          }
+        },
+        {
           "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:port",
           "CombinedShorthandResolver:_resolvers_value": {
             "@type": "KeyExtractor",

--- a/config/app/variables/resolver/resolver.json
+++ b/config/app/variables/resolver/resolver.json
@@ -21,6 +21,14 @@
           }
         },
         {
+          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:loggingFormat",
+          "CombinedShorthandResolver:_resolvers_value": {
+            "@type": "KeyExtractor",
+            "key": "loggingFormat",
+            "defaultValue": "pretty"
+          }
+        },
+        {
           "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:default:variable:port",
           "CombinedShorthandResolver:_resolvers_value": {
             "@type": "KeyExtractor",

--- a/config/util/logging/winston.json
+++ b/config/util/logging/winston.json
@@ -6,7 +6,8 @@
       "@id": "urn:solid-server:default:LoggerFactory",
       "@type": "WinstonLoggerFactory",
       "level": { "@id": "urn:solid-server:default:variable:loggingLevel" },
-      "logFormat": { "@id": "urn:solid-server:default:variable:loggingFormat" }
+      "logFormat": { "@id": "urn:solid-server:default:variable:loggingFormat" },
+      "colorize": { "@id": "urn:solid-server:default:variable:loggingColorize" }
     }
   ]
 }

--- a/config/util/logging/winston.json
+++ b/config/util/logging/winston.json
@@ -5,7 +5,8 @@
       "comment": "Uses the winston library for logging",
       "@id": "urn:solid-server:default:LoggerFactory",
       "@type": "WinstonLoggerFactory",
-      "level": { "@id": "urn:solid-server:default:variable:loggingLevel" }
+      "level": { "@id": "urn:solid-server:default:variable:loggingLevel" },
+      "logFormat": { "@id": "urn:solid-server:default:variable:loggingFormat" }
     }
   ]
 }

--- a/config/util/variables/default.json
+++ b/config/util/variables/default.json
@@ -33,6 +33,11 @@
       "@type": "Variable"
     },
     {
+      "comment": "The format used to output log messages: 'pretty' or 'json'.",
+      "@id": "urn:solid-server:default:variable:loggingFormat",
+      "@type": "Variable"
+    },
+    {
       "comment": "Whether error stack traces should be shown in the server responses.",
       "@id": "urn:solid-server:default:variable:showStackTrace",
       "@type": "Variable"

--- a/config/util/variables/default.json
+++ b/config/util/variables/default.json
@@ -38,6 +38,11 @@
       "@type": "Variable"
     },
     {
+      "comment": "Whether the 'pretty' log format colorizes the log level. Disable for plain, ANSI-free output.",
+      "@id": "urn:solid-server:default:variable:loggingColorize",
+      "@type": "Variable"
+    },
+    {
       "comment": "Whether error stack traces should be shown in the server responses.",
       "@id": "urn:solid-server:default:variable:showStackTrace",
       "@type": "Variable"

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -56,6 +56,7 @@ to some commonly used settings:
 | `--baseUrl, -b`         | `http://localhost:$PORT/`  | The base URL used internally to generate URLs. Change this if your server does not run on `http://localhost:$PORT/`.                          |
 | `--socket`              |                            | The Unix Domain Socket on which the server should listen. `--baseUrl` must be set if this option is provided                                  |
 | `--loggingLevel, -l`    | `info`                     | The detail level of logging; useful for debugging problems. Use `debug` for full information.                                                 |
+| `--loggingFormat`       | `pretty`                   | The format used to output log messages: `pretty` for human-readable colorized lines, or `json` for a line of JSON per message.                |
 | `--config, -c`          | `@css:config/default.json` | The configuration(s) for the server. The default only stores data in memory; to persist to your filesystem, use `@css:config/file.json`       |
 | `--rootFilePath, -f`    | `./`                       | Root folder where the server stores data, when using a file-based configuration.                                                              |
 | `--sparqlEndpoint, -s`  |                            | URL of the SPARQL endpoint, when using a quadstore-based configuration.                                                                       |

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -57,7 +57,7 @@ to some commonly used settings:
 | `--socket`              |                            | The Unix Domain Socket on which the server should listen. `--baseUrl` must be set if this option is provided                                  |
 | `--loggingLevel, -l`    | `info`                     | The detail level of logging; useful for debugging problems. Use `debug` for full information.                                                 |
 | `--loggingFormat`       | `pretty`                   | The format used to output log messages: `pretty` for human-readable colorized lines, or `json` for a line of JSON per message.                |
-| `--loggingColorize`     | `true`                     | Whether the `pretty` format colorizes the log level. Use `--no-loggingColorize` for plain, ANSI-free output (also slightly cheaper per line). |
+| `--loggingColorize`     | `true`                     | Whether the `pretty` format colorizes the log level. Use `--no-loggingColorize` for plain, ANSI-free output.                                  |
 | `--config, -c`          | `@css:config/default.json` | The configuration(s) for the server. The default only stores data in memory; to persist to your filesystem, use `@css:config/file.json`       |
 | `--rootFilePath, -f`    | `./`                       | Root folder where the server stores data, when using a file-based configuration.                                                              |
 | `--sparqlEndpoint, -s`  |                            | URL of the SPARQL endpoint, when using a quadstore-based configuration.                                                                       |

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -57,6 +57,7 @@ to some commonly used settings:
 | `--socket`              |                            | The Unix Domain Socket on which the server should listen. `--baseUrl` must be set if this option is provided                                  |
 | `--loggingLevel, -l`    | `info`                     | The detail level of logging; useful for debugging problems. Use `debug` for full information.                                                 |
 | `--loggingFormat`       | `pretty`                   | The format used to output log messages: `pretty` for human-readable colorized lines, or `json` for a line of JSON per message.                |
+| `--loggingColorize`     | `true`                     | Whether the `pretty` format colorizes the log level. Use `--no-loggingColorize` for plain, ANSI-free output (also slightly cheaper per line). |
 | `--config, -c`          | `@css:config/default.json` | The configuration(s) for the server. The default only stores data in memory; to persist to your filesystem, use `@css:config/file.json`       |
 | `--rootFilePath, -f`    | `./`                       | Root folder where the server stores data, when using a file-based configuration.                                                              |
 | `--sparqlEndpoint, -s`  |                            | URL of the SPARQL endpoint, when using a quadstore-based configuration.                                                                       |

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,6 +311,7 @@ export * from './init/ServerInitializer';
 
 // Logging
 export * from './logging/LazyLoggerFactory';
+export * from './logging/LogContext';
 export * from './logging/Logger';
 export * from './logging/LoggerFactory';
 export * from './logging/LogLevel';

--- a/src/logging/LogContext.ts
+++ b/src/logging/LogContext.ts
@@ -1,0 +1,48 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
+
+const requestIdStorage = new AsyncLocalStorage<string>();
+
+/**
+ * Runs the given function within a logging context that has a newly generated request identifier.
+ * Log messages emitted while the function, or any asynchronous work it starts, is running
+ * will include this identifier in their metadata.
+ *
+ * @param fn - The function to run.
+ *
+ * @returns The result of calling the given function.
+ */
+export function runWithRequestId<T>(fn: () => T): T {
+  return requestIdStorage.run(randomUUID(), fn);
+}
+
+/**
+ * Returns the request identifier of the current logging context,
+ * or `undefined` when called outside a {@link runWithRequestId} context.
+ */
+export function getRequestId(): string | undefined {
+  return requestIdStorage.getStore();
+}
+
+/**
+ * Binds the given function to the request identifier of the current logging context.
+ * This is needed when a function can be called from outside the current asynchronous context,
+ * such as an event listener that gets invoked by an external emitter,
+ * as the identifier would otherwise be lost.
+ * The `this` binding the function gets called with is preserved,
+ * matching the behavior of `AsyncLocalStorage.bind`.
+ *
+ * @param fn - The function to bind.
+ *
+ * @returns The bound function, or the original function when there is no request identifier.
+ */
+export function bindToCurrentRequestId<TArgs extends unknown[], TOut>(fn: (...args: TArgs) => TOut):
+(...args: TArgs) => TOut {
+  const requestId = requestIdStorage.getStore();
+  if (typeof requestId === 'undefined') {
+    return fn;
+  }
+  return function(this: unknown, ...args: TArgs): TOut {
+    return requestIdStorage.run(requestId, (): TOut => fn.call(this, ...args));
+  };
+}

--- a/src/logging/Logger.ts
+++ b/src/logging/Logger.ts
@@ -1,4 +1,5 @@
 import cluster from 'node:cluster';
+import { getRequestId } from './LogContext';
 import type { LogLevel } from './LogLevel';
 
 export interface LogMetadata {
@@ -6,6 +7,8 @@ export interface LogMetadata {
   isPrimary: boolean;
   /** The process id of the current process */
   pid: number;
+  /** The unique identifier of the request during whose handling this message was logged */
+  requestId?: string;
 }
 
 /**
@@ -97,10 +100,17 @@ export interface Logger extends SimpleLogger {
 export abstract class BaseLogger implements Logger {
   public abstract log(level: LogLevel, message: string, meta?: LogMetadata): Logger;
 
-  private readonly getMeta = (): LogMetadata => ({
-    pid: process.pid,
-    isPrimary: cluster.isPrimary,
-  });
+  private readonly getMeta = (): LogMetadata => {
+    const meta: LogMetadata = {
+      pid: process.pid,
+      isPrimary: cluster.isPrimary,
+    };
+    const requestId = getRequestId();
+    if (requestId) {
+      meta.requestId = requestId;
+    }
+    return meta;
+  };
 
   public error(message: string): Logger {
     return this.log('error', message, this.getMeta());

--- a/src/logging/WinstonLoggerFactory.ts
+++ b/src/logging/WinstonLoggerFactory.ts
@@ -39,9 +39,7 @@ export class WinstonLoggerFactory implements LoggerFactory {
    * @param logFormat - The format used to output log messages:
    *                    `pretty` for human-readable colorized lines, or `json` for a line of JSON per message.
    * @param colorize - Whether the level in the `pretty` output is colorized with ANSI escape codes.
-   *                   Defaults to `true` to preserve the historical output. Set to `false` for plain,
-   *                   ANSI-free lines (e.g. when piping the output to a file), which also removes the
-   *                   per-line colorization cost. Has no effect on the `json` format, which is never colorized.
+   *                   Has no effect on the `json` format.
    */
   public constructor(level: string, logFormat = 'pretty', colorize = true) {
     this.level = level;
@@ -109,9 +107,6 @@ export class WinstonLoggerFactory implements LoggerFactory {
         format.json(),
       );
     }
-    // Colorizing the level is purely cosmetic, so it is only added when enabled.
-    // This keeps the default output byte-compatible while letting operators drop the
-    // per-line colorization cost (and produce ANSI-free lines) by disabling it.
     const prettyFormats: Logform.Format[] = [ format.label({ label }) ];
     if (this.colorize) {
       prettyFormats.push(format.colorize());

--- a/src/logging/WinstonLoggerFactory.ts
+++ b/src/logging/WinstonLoggerFactory.ts
@@ -25,6 +25,13 @@ export class WinstonLoggerFactory implements LoggerFactory {
     return `W-${meta.pid ?? '???'}`;
   };
 
+  private readonly requestInfo = (meta: LogMetadata): string => {
+    if (meta.requestId) {
+      return ` [${meta.requestId}]`;
+    }
+    return '';
+  };
+
   public createLogger(label: string): Logger {
     return new WinstonLogger(createLogger({
       level: this.level,
@@ -35,7 +42,8 @@ export class WinstonLoggerFactory implements LoggerFactory {
         format.metadata({ fillExcept: [ 'level', 'timestamp', 'label', 'message' ]}),
         format.printf(
           ({ level: levelInner, message, label: labelInner, timestamp, metadata: meta }: TransformableInfo): string =>
-            `${timestamp} [${labelInner}] {${this.clusterInfo(meta as LogMetadata)}} ${levelInner}: ${message}`,
+            `${timestamp} [${labelInner}] {${this.clusterInfo(meta as LogMetadata)}}` +
+            `${this.requestInfo(meta as LogMetadata)} ${levelInner}: ${message}`,
         ),
       ),
       transports: this.createTransports(),

--- a/src/logging/WinstonLoggerFactory.ts
+++ b/src/logging/WinstonLoggerFactory.ts
@@ -13,6 +13,15 @@ export const LOG_FORMATS = [ 'pretty', 'json' ] as const;
 export type LogFormat = typeof LOG_FORMATS[number];
 
 /**
+ * Matches the characters that must be escaped before being written to the `pretty` log output:
+ * every C0 control character except tab (`\t`), the DEL character, and the C1 control range.
+ * These can otherwise be abused by attacker-influenced log fields (e.g. a WebID or request URL)
+ * to forge additional log lines or emit terminal escape (ANSI) sequences.
+ */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARACTERS = /[\u0000-\u0008\u000A-\u001F\u007F-\u009F]/gu;
+
+/**
  * Uses the winston library to create loggers for the given logging level.
  * By default, it will print to the console with colorized logging levels.
  * The `json` format can be used instead to output every log entry
@@ -51,6 +60,30 @@ export class WinstonLoggerFactory implements LoggerFactory {
     return '';
   };
 
+  /**
+   * Escapes control characters in an attacker-influenceable value so it cannot forge additional
+   * lines or emit terminal escape sequences in the `pretty` log output.
+   * Newlines and carriage returns become the literal two-character `\n`/`\r` sequences, tab is
+   * kept as-is, and every other control character becomes its `\uXXXX` escape.
+   * Legitimate printable Unicode (including backslashes) is left untouched.
+   *
+   * @param value - The value to escape.
+   *
+   * @returns The value with all dangerous control characters escaped.
+   */
+  private sanitize(value: string): string {
+    return value.replaceAll(CONTROL_CHARACTERS, (char: string): string => {
+      switch (char) {
+        case '\n':
+          return '\\n';
+        case '\r':
+          return '\\r';
+        default:
+          return `\\u${char.codePointAt(0)!.toString(16).padStart(4, '0')}`;
+      }
+    });
+  }
+
   public createLogger(label: string): Logger {
     return new WinstonLogger(createLogger({
       level: this.level,
@@ -78,8 +111,8 @@ export class WinstonLoggerFactory implements LoggerFactory {
       format.printf(
         ({ level: levelInner, message, label: labelInner, timestamp, metadata: meta }: Logform.TransformableInfo):
         string =>
-          `${timestamp} [${labelInner}] {${this.clusterInfo(meta as LogMetadata)}}` +
-          `${this.requestInfo(meta as LogMetadata)} ${levelInner}: ${message}`,
+          `${timestamp} [${this.sanitize(String(labelInner))}] {${this.clusterInfo(meta as LogMetadata)}}` +
+          `${this.requestInfo(meta as LogMetadata)} ${levelInner}: ${this.sanitize(String(message))}`,
       ),
     );
   }

--- a/src/logging/WinstonLoggerFactory.ts
+++ b/src/logging/WinstonLoggerFactory.ts
@@ -32,18 +32,24 @@ const CONTROL_CHARACTERS = /[\u0000-\u0008\u000A-\u001F\u007F-\u009F]/gu;
 export class WinstonLoggerFactory implements LoggerFactory {
   private readonly level: string;
   private readonly logFormat: LogFormat;
+  private readonly colorize: boolean;
 
   /**
    * @param level - The most detailed level of log messages that should be output.
    * @param logFormat - The format used to output log messages:
    *                    `pretty` for human-readable colorized lines, or `json` for a line of JSON per message.
+   * @param colorize - Whether the level in the `pretty` output is colorized with ANSI escape codes.
+   *                   Defaults to `true` to preserve the historical output. Set to `false` for plain,
+   *                   ANSI-free lines (e.g. when piping the output to a file), which also removes the
+   *                   per-line colorization cost. Has no effect on the `json` format, which is never colorized.
    */
-  public constructor(level: string, logFormat = 'pretty') {
+  public constructor(level: string, logFormat = 'pretty', colorize = true) {
     this.level = level;
     if (!(LOG_FORMATS as readonly string[]).includes(logFormat)) {
       throw new Error(`Unknown log format ${logFormat}, expected one of ${LOG_FORMATS.join('/')}`);
     }
     this.logFormat = logFormat as LogFormat;
+    this.colorize = colorize;
   }
 
   private readonly clusterInfo = (meta: LogMetadata): string => {
@@ -103,9 +109,14 @@ export class WinstonLoggerFactory implements LoggerFactory {
         format.json(),
       );
     }
-    return format.combine(
-      format.label({ label }),
-      format.colorize(),
+    // Colorizing the level is purely cosmetic, so it is only added when enabled.
+    // This keeps the default output byte-compatible while letting operators drop the
+    // per-line colorization cost (and produce ANSI-free lines) by disabling it.
+    const prettyFormats: Logform.Format[] = [ format.label({ label }) ];
+    if (this.colorize) {
+      prettyFormats.push(format.colorize());
+    }
+    prettyFormats.push(
       format.timestamp(),
       format.metadata({ fillExcept: [ 'level', 'timestamp', 'label', 'message' ]}),
       format.printf(
@@ -115,6 +126,7 @@ export class WinstonLoggerFactory implements LoggerFactory {
           `${this.requestInfo(meta as LogMetadata)} ${levelInner}: ${this.sanitize(String(message))}`,
       ),
     );
+    return format.combine(...prettyFormats);
   }
 
   protected createTransports(): Transport[] {

--- a/src/logging/WinstonLoggerFactory.ts
+++ b/src/logging/WinstonLoggerFactory.ts
@@ -1,21 +1,40 @@
-import type { TransformableInfo } from 'logform';
+import type { Logform } from 'winston';
 import { createLogger, format, transports } from 'winston';
 import type * as Transport from 'winston-transport';
 import type { Logger, LogMetadata } from './Logger';
 import type { LoggerFactory } from './LoggerFactory';
 import { WinstonLogger } from './WinstonLogger';
 
+export const LOG_FORMATS = [ 'pretty', 'json' ] as const;
+
+/**
+ * Different formats in which log messages can be output.
+ */
+export type LogFormat = typeof LOG_FORMATS[number];
+
 /**
  * Uses the winston library to create loggers for the given logging level.
  * By default, it will print to the console with colorized logging levels.
+ * The `json` format can be used instead to output every log entry
+ * as a single line of JSON, which is easier to parse for log aggregators.
  *
  * This creates instances of {@link WinstonLogger}.
  */
 export class WinstonLoggerFactory implements LoggerFactory {
   private readonly level: string;
+  private readonly logFormat: LogFormat;
 
-  public constructor(level: string) {
+  /**
+   * @param level - The most detailed level of log messages that should be output.
+   * @param logFormat - The format used to output log messages:
+   *                    `pretty` for human-readable colorized lines, or `json` for a line of JSON per message.
+   */
+  public constructor(level: string, logFormat = 'pretty') {
     this.level = level;
+    if (!(LOG_FORMATS as readonly string[]).includes(logFormat)) {
+      throw new Error(`Unknown log format ${logFormat}, expected one of ${LOG_FORMATS.join('/')}`);
+    }
+    this.logFormat = logFormat as LogFormat;
   }
 
   private readonly clusterInfo = (meta: LogMetadata): string => {
@@ -28,18 +47,33 @@ export class WinstonLoggerFactory implements LoggerFactory {
   public createLogger(label: string): Logger {
     return new WinstonLogger(createLogger({
       level: this.level,
-      format: format.combine(
-        format.label({ label }),
-        format.colorize(),
-        format.timestamp(),
-        format.metadata({ fillExcept: [ 'level', 'timestamp', 'label', 'message' ]}),
-        format.printf(
-          ({ level: levelInner, message, label: labelInner, timestamp, metadata: meta }: TransformableInfo): string =>
-            `${timestamp} [${labelInner}] {${this.clusterInfo(meta as LogMetadata)}} ${levelInner}: ${message}`,
-        ),
-      ),
+      format: this.createFormat(label),
       transports: this.createTransports(),
     }));
+  }
+
+  /**
+   * Creates the winston format corresponding to the `logFormat` this factory was created with.
+   */
+  protected createFormat(label: string): Logform.Format {
+    if (this.logFormat === 'json') {
+      return format.combine(
+        format.label({ label }),
+        format.timestamp(),
+        format.json(),
+      );
+    }
+    return format.combine(
+      format.label({ label }),
+      format.colorize(),
+      format.timestamp(),
+      format.metadata({ fillExcept: [ 'level', 'timestamp', 'label', 'message' ]}),
+      format.printf(
+        ({ level: levelInner, message, label: labelInner, timestamp, metadata: meta }: Logform.TransformableInfo):
+        string =>
+          `${timestamp} [${labelInner}] {${this.clusterInfo(meta as LogMetadata)}} ${levelInner}: ${message}`,
+      ),
+    );
   }
 
   protected createTransports(): Transport[] {

--- a/src/server/HandlerServerConfigurator.ts
+++ b/src/server/HandlerServerConfigurator.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
+import { bindToCurrentRequestId, runWithRequestId } from '../logging/LogContext';
 import { getLoggerFor } from '../logging/LogUtil';
 import { isError } from '../util/errors/ErrorUtil';
 import { guardStream } from '../util/GuardedStream';
@@ -32,27 +33,28 @@ export class HandlerServerConfigurator extends ServerConfigurator {
     server.on(
       'request',
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      async(request: IncomingMessage, response: ServerResponse): Promise<void> => {
-        try {
-          this.logger.info(`Received ${request.method} request for ${request.url}`);
-          const guardedRequest = guardStream(request);
-          guardedRequest.on('error', this.errorLogger);
-          await this.handler.handleSafe({ request: guardedRequest, response });
-        } catch (error: unknown) {
-          const errMsg = this.createErrorMessage(error);
-          this.logger.error(errMsg);
-          if (response.headersSent) {
-            response.end();
-          } else {
-            response.setHeader('Content-Type', 'text/plain; charset=utf-8');
-            response.writeHead(500).end(errMsg);
+      async(request: IncomingMessage, response: ServerResponse): Promise<void> =>
+        runWithRequestId(async(): Promise<void> => {
+          try {
+            this.logger.info(`Received ${request.method} request for ${request.url}`);
+            const guardedRequest = guardStream(request);
+            guardedRequest.on('error', bindToCurrentRequestId(this.errorLogger));
+            await this.handler.handleSafe({ request: guardedRequest, response });
+          } catch (error: unknown) {
+            const errMsg = this.createErrorMessage(error);
+            this.logger.error(errMsg);
+            if (response.headersSent) {
+              response.end();
+            } else {
+              response.setHeader('Content-Type', 'text/plain; charset=utf-8');
+              response.writeHead(500).end(errMsg);
+            }
+          } finally {
+            if (!response.headersSent) {
+              response.writeHead(404).end();
+            }
           }
-        } finally {
-          if (!response.headersSent) {
-            response.writeHead(404).end();
-          }
-        }
-      },
+        }),
     );
   }
 

--- a/test/integration/Config.ts
+++ b/test/integration/Config.ts
@@ -57,6 +57,7 @@ export function getDefaultVariables(port: number, baseUrl?: string): Record<stri
     'urn:solid-server:default:variable:socket': null,
     'urn:solid-server:default:variable:loggingLevel': 'off',
     'urn:solid-server:default:variable:loggingFormat': 'pretty',
+    'urn:solid-server:default:variable:loggingColorize': true,
     'urn:solid-server:default:variable:showStackTrace': true,
     'urn:solid-server:default:variable:seedConfig': null,
     'urn:solid-server:default:variable:workers': 1,

--- a/test/integration/Config.ts
+++ b/test/integration/Config.ts
@@ -56,6 +56,7 @@ export function getDefaultVariables(port: number, baseUrl?: string): Record<stri
     'urn:solid-server:default:variable:port': port,
     'urn:solid-server:default:variable:socket': null,
     'urn:solid-server:default:variable:loggingLevel': 'off',
+    'urn:solid-server:default:variable:loggingFormat': 'pretty',
     'urn:solid-server:default:variable:showStackTrace': true,
     'urn:solid-server:default:variable:seedConfig': null,
     'urn:solid-server:default:variable:workers': 1,

--- a/test/unit/logging/LogContext.test.ts
+++ b/test/unit/logging/LogContext.test.ts
@@ -1,0 +1,81 @@
+import { bindToCurrentRequestId, getRequestId, runWithRequestId } from '../../../src/logging/LogContext';
+
+const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
+
+describe('LogContext', (): void => {
+  describe('#getRequestId', (): void => {
+    it('returns undefined outside a request context.', async(): Promise<void> => {
+      expect(getRequestId()).toBeUndefined();
+    });
+
+    it('returns the generated identifier within a request context.', async(): Promise<void> => {
+      runWithRequestId((): void => {
+        expect(getRequestId()).toMatch(uuidRegex);
+      });
+    });
+  });
+
+  describe('#runWithRequestId', (): void => {
+    it('returns the result of the given function.', async(): Promise<void> => {
+      expect(runWithRequestId((): number => 5)).toBe(5);
+    });
+
+    it('generates a new identifier for every context.', async(): Promise<void> => {
+      const requestId = runWithRequestId((): string | undefined => getRequestId());
+      const requestId2 = runWithRequestId((): string | undefined => getRequestId());
+      expect(requestId).toMatch(uuidRegex);
+      expect(requestId2).toMatch(uuidRegex);
+      expect(requestId).not.toBe(requestId2);
+    });
+
+    it('retains the identifier across asynchronous calls.', async(): Promise<void> => {
+      await runWithRequestId(async(): Promise<void> => {
+        const requestId = getRequestId();
+        await new Promise<void>((resolve): void => {
+          setImmediate(resolve);
+        });
+        expect(getRequestId()).toBe(requestId);
+      });
+      expect(getRequestId()).toBeUndefined();
+    });
+  });
+
+  describe('#bindToCurrentRequestId', (): void => {
+    it('returns the input function when there is no request context.', async(): Promise<void> => {
+      const fn = jest.fn();
+      expect(bindToCurrentRequestId(fn)).toBe(fn);
+      expect(fn).toHaveBeenCalledTimes(0);
+    });
+
+    it('restores the request identifier when the function is called outside the context.', async(): Promise<void> => {
+      const fn = jest.fn((input: string): string => `${input}:${getRequestId()}`);
+      let bound: (input: string) => string;
+      const requestId = runWithRequestId((): string | undefined => {
+        bound = bindToCurrentRequestId(fn);
+        return getRequestId();
+      });
+      expect(getRequestId()).toBeUndefined();
+      expect(bound!('result')).toBe(`result:${requestId}`);
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(fn).toHaveBeenLastCalledWith('result');
+      expect(getRequestId()).toBeUndefined();
+    });
+
+    it('preserves the this binding of the bound function.', async(): Promise<void> => {
+      let captured: string | undefined;
+      const object = {
+        id: 'myId',
+        capture(this: { id: string }): void {
+          captured = `${this.id}:${getRequestId()}`;
+        },
+      };
+      const requestId = runWithRequestId((): string | undefined => {
+        // eslint-disable-next-line jest/unbound-method
+        object.capture = bindToCurrentRequestId(object.capture);
+        return getRequestId();
+      });
+      object.capture();
+      expect(captured).toBe(`myId:${requestId}`);
+    });
+  });
+});

--- a/test/unit/logging/Logger.test.ts
+++ b/test/unit/logging/Logger.test.ts
@@ -1,3 +1,4 @@
+import { getRequestId, runWithRequestId } from '../../../src/logging/LogContext';
 import { BaseLogger, WrappingLogger } from '../../../src/logging/Logger';
 import type { LogMetadata, SimpleLogger } from '../../../src/logging/Logger';
 
@@ -54,6 +55,15 @@ describe('Logger', (): void => {
       logger.silly('my message');
       expect(logger.log).toHaveBeenCalledTimes(1);
       expect(logger.log).toHaveBeenCalledWith('silly', 'my message', metadata);
+    });
+
+    it('includes the request identifier when logging within a request context.', async(): Promise<void> => {
+      const requestId = runWithRequestId((): string | undefined => {
+        logger.info('my message');
+        return getRequestId();
+      });
+      expect(logger.log).toHaveBeenCalledTimes(1);
+      expect(logger.log).toHaveBeenCalledWith('info', 'my message', { ...metadata, requestId });
     });
   });
 

--- a/test/unit/logging/WinstonLoggerFactory.test.ts
+++ b/test/unit/logging/WinstonLoggerFactory.test.ts
@@ -95,6 +95,37 @@ describe('WinstonLoggerFactory', (): void => {
       .toBe(`${now.toISOString()} [MyLabel] {W-???} ${level}: my message`);
   });
 
+  it('colorizes the level in the pretty output by default.', async(): Promise<void> => {
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'my message');
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    const line: string = transport.write.mock.calls[0][0][Symbol.for('message')];
+    // The default output wraps the level in ANSI color codes.
+    // eslint-disable-next-line no-control-regex
+    expect(line).toMatch(/\u001B\[\d+m/u);
+  });
+
+  it('omits ANSI colors from the pretty output when colorization is disabled.', async(): Promise<void> => {
+    factory = new WinstonLoggerFactory('debug', 'pretty', false);
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'my message');
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    const line: string = transport.write.mock.calls[0][0][Symbol.for('message')];
+    // No ANSI escape codes are present anywhere in the line.
+    // eslint-disable-next-line no-control-regex
+    expect(line).not.toMatch(/\u001B/u);
+    // The line is otherwise identical to the colorized output: same fields, plain level.
+    expect(line).toBe(`${now.toISOString()} [MyLabel] {W-???} debug: my message`);
+  });
+
   it('adds the request identifier to the output when there is one.', async(): Promise<void> => {
     (factory as any).createTransports = (): any => [ transport ];
 

--- a/test/unit/logging/WinstonLoggerFactory.test.ts
+++ b/test/unit/logging/WinstonLoggerFactory.test.ts
@@ -74,4 +74,65 @@ describe('WinstonLoggerFactory', (): void => {
       [Symbol.for('message')]: `${now.toISOString()} [MyLabel] {Primary} ${level}: my message`,
     }));
   });
+
+  it('errors on unknown log formats.', async(): Promise<void> => {
+    expect((): WinstonLoggerFactory => new WinstonLoggerFactory('debug', 'unknown'))
+      .toThrow('Unknown log format unknown, expected one of pretty/json');
+  });
+
+  it('can be created with an explicit pretty format.', async(): Promise<void> => {
+    factory = new WinstonLoggerFactory('debug', 'pretty');
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'my message');
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    // Need to check level like this as it has color tags
+    const { level } = transport.write.mock.calls[0][0];
+    expect(transport.write.mock.calls[0][0][Symbol.for('message')])
+      .toBe(`${now.toISOString()} [MyLabel] {W-???} ${level}: my message`);
+  });
+
+  it('outputs a line of JSON per message when using the json format.', async(): Promise<void> => {
+    factory = new WinstonLoggerFactory('debug', 'json');
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'my message');
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    const line: string = transport.write.mock.calls[0][0][Symbol.for('message')];
+    // The JSON format does not apply any color tags
+    // eslint-disable-next-line no-control-regex
+    expect(line).not.toMatch(/\u001B/u);
+    expect(JSON.parse(line)).toEqual({
+      label: 'MyLabel',
+      level: 'debug',
+      message: 'my message',
+      timestamp: now.toISOString(),
+    });
+  });
+
+  it('includes the extra metadata in the JSON output.', async(): Promise<void> => {
+    factory = new WinstonLoggerFactory('debug', 'json');
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'my message', { isPrimary: true, pid: 0 });
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    const line: string = transport.write.mock.calls[0][0][Symbol.for('message')];
+    expect(JSON.parse(line)).toEqual({
+      label: 'MyLabel',
+      level: 'debug',
+      message: 'my message',
+      timestamp: now.toISOString(),
+      isPrimary: true,
+      pid: 0,
+    });
+  });
 });

--- a/test/unit/logging/WinstonLoggerFactory.test.ts
+++ b/test/unit/logging/WinstonLoggerFactory.test.ts
@@ -74,4 +74,18 @@ describe('WinstonLoggerFactory', (): void => {
       [Symbol.for('message')]: `${now.toISOString()} [MyLabel] {Primary} ${level}: my message`,
     }));
   });
+
+  it('adds the request identifier to the output when there is one.', async(): Promise<void> => {
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'my message', { isPrimary: true, pid: 0, requestId: '4c079dca' });
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    // Need to check level like this as it has color tags
+    const { level } = transport.write.mock.calls[0][0];
+    expect(transport.write.mock.calls[0][0][Symbol.for('message')])
+      .toBe(`${now.toISOString()} [MyLabel] {Primary} [4c079dca] ${level}: my message`);
+  });
 });

--- a/test/unit/logging/WinstonLoggerFactory.test.ts
+++ b/test/unit/logging/WinstonLoggerFactory.test.ts
@@ -150,4 +150,56 @@ describe('WinstonLoggerFactory', (): void => {
       requestId: '4c079dca',
     });
   });
+
+  it('escapes control characters in the pretty message so extra lines cannot be forged.', async(): Promise<void> => {
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log a message with newline, carriage return, ESC, NUL and a C1 control
+    // character: all of these are attacker-influenceable (e.g. via a WebID or request URL).
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'a\nb\rc\u001Bd\u0000e\u0085f');
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    const line: string = transport.write.mock.calls[0][0][Symbol.for('message')];
+    // No raw newline/CR/NUL survive in the output to forge a new line.
+    expect(line).not.toContain('\n');
+    expect(line).not.toContain('\r');
+    expect(line).not.toContain('\u0000');
+    // The message renders on a single line with every control character escaped.
+    expect(line).toContain('a\\nb\\rc\\u001bd\\u0000e\\u0085f');
+    // The message's own ESC is neutralised (the raw injected sequence no longer appears)...
+    expect(line).not.toContain('c\u001Bd');
+    // ...yet the level's legitimate ANSI color codes (also ESC-based) are still present.
+    // eslint-disable-next-line no-control-regex
+    expect(line).toMatch(/\u001B\[\d+m/u);
+  });
+
+  it('leaves printable Unicode, backslashes and tabs in the pretty message unchanged.', async(): Promise<void> => {
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log a message with backslashes, a tab and multi-byte printable Unicode.
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'C:\\Users\trésumé 你好');
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    // Need to check level like this as it has color tags
+    const { level } = transport.write.mock.calls[0][0];
+    expect(transport.write.mock.calls[0][0][Symbol.for('message')])
+      .toBe(`${now.toISOString()} [MyLabel] {W-???} ${level}: C:\\Users\trésumé 你好`);
+  });
+
+  it('does not double-escape control characters in the json format.', async(): Promise<void> => {
+    factory = new WinstonLoggerFactory('debug', 'json');
+    (factory as any).createTransports = (): any => [ transport ];
+
+    // Create logger, and log a message containing a newline and an ESC character
+    const logger = factory.createLogger('MyLabel');
+    logger.log('debug', 'a\nb\u001Bc');
+
+    expect(transport.write).toHaveBeenCalledTimes(1);
+    const line: string = transport.write.mock.calls[0][0][Symbol.for('message')];
+    // JSON.stringify already escapes these safely, so the message round-trips to the raw input:
+    // this proves the json branch was left untouched and no extra backslash-escaping was applied.
+    expect(JSON.parse(line).message).toBe('a\nb\u001Bc');
+  });
 });

--- a/test/unit/logging/WinstonLoggerFactory.test.ts
+++ b/test/unit/logging/WinstonLoggerFactory.test.ts
@@ -119,10 +119,8 @@ describe('WinstonLoggerFactory', (): void => {
 
     expect(transport.write).toHaveBeenCalledTimes(1);
     const line: string = transport.write.mock.calls[0][0][Symbol.for('message')];
-    // No ANSI escape codes are present anywhere in the line.
     // eslint-disable-next-line no-control-regex
     expect(line).not.toMatch(/\u001B/u);
-    // The line is otherwise identical to the colorized output: same fields, plain level.
     expect(line).toBe(`${now.toISOString()} [MyLabel] {W-???} debug: my message`);
   });
 

--- a/test/unit/server/HandlerServerConfigurator.test.ts
+++ b/test/unit/server/HandlerServerConfigurator.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events';
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
+import { getRequestId } from '../../../src/logging/LogContext';
 import type { Logger } from '../../../src/logging/Logger';
 import { getLoggerFor } from '../../../src/logging/LogUtil';
 import { HandlerServerConfigurator } from '../../../src/server/HandlerServerConfigurator';
@@ -122,6 +123,49 @@ describe('A HandlerServerConfigurator', (): void => {
 
     expect(logger.error).toHaveBeenCalledTimes(1);
     expect(logger.error).toHaveBeenLastCalledWith('Request error: bad request');
+  });
+
+  it('handles every request within a context that has a unique request identifier.', async(): Promise<void> => {
+    let infoRequestId: string | undefined;
+    let handlerRequestId: string | undefined;
+    logger.info.mockImplementationOnce((): any => {
+      infoRequestId = getRequestId();
+    });
+    handler.handleSafe.mockImplementationOnce(async(): Promise<void> => {
+      handlerRequestId = getRequestId();
+      (response as any).headersSent = true;
+    });
+    server.emit('request', request, response);
+    await flushPromises();
+
+    expect(handler.handleSafe).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(handlerRequestId).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(infoRequestId).toBe(handlerRequestId);
+    expect(getRequestId()).toBeUndefined();
+  });
+
+  it('keeps the request identifier for request errors emitted outside the request context.', async(): Promise<void> => {
+    let handlerRequestId: string | undefined;
+    let errorRequestId: string | undefined;
+    logger.error.mockImplementationOnce((): any => {
+      errorRequestId = getRequestId();
+    });
+    handler.handleSafe.mockImplementationOnce(async(): Promise<void> => {
+      handlerRequestId = getRequestId();
+      (response as any).headersSent = true;
+    });
+    server.emit('request', request, response);
+    await flushPromises();
+
+    // This emit happens outside the request context created by the configurator
+    expect(getRequestId()).toBeUndefined();
+    request.emit('error', new Error('late error'));
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith('Request error: late error');
+    expect(errorRequestId).toBe(handlerRequestId);
+    expect(errorRequestId).toMatch(/^[0-9a-f-]{36}$/u);
   });
 
   it('prints the stack trace if that option is enabled.', async(): Promise<void> => {


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming. **Stacks on #65** (`feat/logging-combined`) — review that first; this branch adds its commits on top.

#### 📁 Related issues

None yet — the upstream template requires a linked issue, so one proposing the colorize opt-out must be created on CommunitySolidServer/CommunitySolidServer before this is submitted upstream.

#### ✍️ Description

The `pretty` log format always colorizes the level with ANSI escape codes. That is what you want on a terminal, but when the output is piped to a file or a log aggregator the escapes are noise. This adds a colorize opt-out:

- `WinstonLoggerFactory` gains an optional `colorize` constructor parameter, default `true`, so the default output stays byte-identical.
- Exposed as `--loggingColorize` / `--no-loggingColorize` and the `loggingColorize` config variable, mirroring the `--loggingFormat` wiring (variable declaration, CLI parameter, resolver default, factory binding, `starting-server.md` row).
- Only the `format.colorize()` step is made conditional; the `json` branch (never colorized), timestamp, metadata, request id, and control-character sanitization are untouched.

**Perf note:** the motivation came from a one-off local CPU profile of hot LDP `GET`s at `info` level, which attributed roughly 6% of request CPU to the log-format pipeline, with about 0.9% in `format.colorize()`. There is no reproducible benchmark command behind those numbers, so treat the plain, ANSI-free output as the main win and the saved colorize cost as a small side benefit. The two larger format costs the profile showed (timestamp formatting, `metadata()`/`fillExcept`) are deliberately left alone: reducing either changes the default output, so any such toggle would need to be a separate opt-in.

**Verification:** unit tests cover both branches (default: ANSI present; disabled: no ANSI, line otherwise identical), keeping 100% coverage on `WinstonLoggerFactory`. Smoke-tested by booting `config/file.json --no-loggingColorize`: pretty lines contain no ANSI escapes and retain all fields (label, worker, request id); a default boot is unchanged.

**Branch target and semver:** this is a backwards-compatible feature addition (a new optional CLI/config option and constructor parameter), so the intended semver level is **minor** and the upstream submission should target the latest `versions/*` branch (currently `versions/next-major`), not `main`. It targets the fork's `main` only because it stacks on #65 for fork-side review.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
