### PR TITLE
feat: Add an offline configuration validation command

### DIFF
--- a/bin/validate.js
+++ b/bin/validate.js
@@ -8,6 +8,5 @@ process.on('uncaughtExceptionMonitor', (err, origin) => {
   console.error(`Process is halting due to an ${origin} with error ${err.message}`);
 });
 
-// Validates the configuration without starting the server; exits 0 if valid, non-zero otherwise.
 // eslint-disable-next-line no-sync
 new AppRunner().validateCliSync(process);

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const { AppRunner } = require('..');
+
+// Attaching a logger to the uncaughtExceptionMonitor event,
+// such that the default uncaughtException behavior still occurs.
+process.on('uncaughtExceptionMonitor', (err, origin) => {
+  // eslint-disable-next-line no-console
+  console.error(`Process is halting due to an ${origin} with error ${err.message}`);
+});
+
+// Validates the configuration without starting the server; exits 0 if valid, non-zero otherwise.
+// eslint-disable-next-line no-sync
+new AppRunner().validateCliSync(process);

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -73,6 +73,39 @@ They are prefixed with `CSS_` and converted from `camelCase` to `CAMEL_CASE`
 
 Command-line arguments will always override environment variables.
 
+## Validating a configuration
+
+Before deploying a custom configuration it can be validated offline,
+without starting the server or binding a port.
+This builds the configuration, resolves all variable bindings,
+and instantiates the entire application graph exactly as a normal start would,
+but stops right before the server is started.
+It exits with code `0` when the configuration is valid,
+and with a non-zero code (printing the error) when it is not,
+which makes it convenient to run in CI or a deployment pipeline.
+
+It accepts the same parameters and environment variables as the start command
+(such as `-c` for the configuration and any variable flags):
+
+```shell
+node ./bin/validate.js -c config/default.json
+```
+
+When installed as a package the `validate:config` npm script exposes the same entry point:
+
+```shell
+npm run validate:config -- -c @css:config/file.json -f data/
+```
+
+Because the entry point is shipped in `bin/` and only relies on the built `dist/`,
+it also works inside the Docker image, so a mounted configuration can be checked before going live:
+
+```shell
+docker run --rm -v ~/solid-config:/config -it \
+  --entrypoint node solidproject/community-server \
+  bin/validate.js -c /config/my-config.json
+```
+
 ## Alternative ways to run the server
 
 ### From source

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:unit": "jest --config=./jest.coverage.config.js test/unit",
     "test:watch": "jest --coverageReporters none --watch test/unit",
     "validate": "componentsjs-compile-config urn:solid-server:default:Initializer -c config/default.json -f > /dev/null",
+    "validate:config": "node ./bin/validate.js",
     "watch": "nodemon --watch \"dist/**/*.js\" --exec npm start"
   },
   "dependencies": {

--- a/src/init/AppRunner.ts
+++ b/src/init/AppRunner.ts
@@ -201,6 +201,50 @@ export class AppRunner {
   }
 
   /**
+   * Validates a server configuration as a command-line application, without starting the server.
+   * Will exit the process with a non-zero code on failure.
+   *
+   * Made non-async to lower the risk of unhandled promise rejections,
+   * mirroring {@link runCliSync}.
+   * This is only relevant when this is used to validate as a Node.js application on its own,
+   * if you use this as part of your code you probably want to use the async {@link validateCli} version.
+   *
+   * @param argv - Input parameters.
+   * @param argv.argv - Command line arguments.
+   * @param argv.stderr - Stream that should be used to output errors before the logger is enabled.
+   */
+  public validateCliSync({ argv, stderr = process.stderr }: { argv?: CliArgv; stderr?: WriteStream }): void {
+    this.validateCli(argv).then((): void => {
+      // eslint-disable-next-line unicorn/no-process-exit
+      process.exit(0);
+    }, (error: unknown): never => {
+      stderr.write(createErrorMessage(error));
+      // eslint-disable-next-line unicorn/no-process-exit
+      process.exit(1);
+    });
+  }
+
+  /**
+   * Validates a server configuration by fully building and instantiating it, without starting the server.
+   *
+   * This reuses the exact same configuration-loading and instantiation path as {@link createCli}
+   * (building the Components.js manager, registering the configuration(s), resolving the variable bindings,
+   * and instantiating the entire application graph), but it deliberately never calls {@link App.start}.
+   * As a result no port is bound and no HTTP server is started, making this safe to run offline
+   * (e.g. inside a Docker image) to verify a custom configuration before deploying it.
+   *
+   * Any Components.js build, wiring, type, or variable error causes the returned promise to reject.
+   *
+   * @param argv - Command line arguments.
+   */
+  public async validateCli(argv?: CliArgv): Promise<void> {
+    // Building the CLI app instantiates the full config graph but does not start it,
+    // so this both type-checks and instantiates the configuration without binding a port.
+    await this.createCli(argv);
+    this.logger.info('The configuration is valid: the server can be instantiated with these settings.');
+  }
+
+  /**
    * Retrieves settings from package.json or configuration file when
    * part of an npm project.
    *

--- a/src/init/AppRunner.ts
+++ b/src/init/AppRunner.ts
@@ -202,12 +202,11 @@ export class AppRunner {
 
   /**
    * Validates a server configuration as a command-line application, without starting the server.
-   * Will exit the process with a non-zero code on failure.
+   * Will exit the process when done, with a non-zero code on failure.
    *
-   * Made non-async to lower the risk of unhandled promise rejections,
-   * mirroring {@link runCliSync}.
+   * Made non-async to lower the risk of unhandled promise rejections.
    * This is only relevant when this is used to validate as a Node.js application on its own,
-   * if you use this as part of your code you probably want to use the async {@link validateCli} version.
+   * if you use this as part of your code you probably want to use the async version.
    *
    * @param argv - Input parameters.
    * @param argv.argv - Command line arguments.
@@ -225,21 +224,12 @@ export class AppRunner {
   }
 
   /**
-   * Validates a server configuration by fully building and instantiating it, without starting the server.
-   *
-   * This reuses the exact same configuration-loading and instantiation path as {@link createCli}
-   * (building the Components.js manager, registering the configuration(s), resolving the variable bindings,
-   * and instantiating the entire application graph), but it deliberately never calls {@link App.start}.
-   * As a result no port is bound and no HTTP server is started, making this safe to run offline
-   * (e.g. inside a Docker image) to verify a custom configuration before deploying it.
-   *
-   * Any Components.js build, wiring, type, or variable error causes the returned promise to reject.
+   * Validates a server configuration by fully building and instantiating it,
+   * without starting the server, so no port is bound.
    *
    * @param argv - Command line arguments.
    */
   public async validateCli(argv?: CliArgv): Promise<void> {
-    // Building the CLI app instantiates the full config graph but does not start it,
-    // so this both type-checks and instantiates the configuration without binding a port.
     await this.createCli(argv);
     this.logger.info('The configuration is valid: the server can be instantiated with these settings.');
   }

--- a/test/unit/init/AppRunner.test.ts
+++ b/test/unit/init/AppRunner.test.ts
@@ -587,6 +587,87 @@ describe('AppRunner', (): void => {
     });
   });
 
+  describe('validateCli', (): void => {
+    it('instantiates the configuration without starting the server.', async(): Promise<void> => {
+      await expect(new AppRunner().validateCli([ 'node', 'script' ])).resolves.toBeUndefined();
+
+      // The full instantiation path is used, exactly like when starting the server.
+      expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
+      expect(ComponentsManager.build).toHaveBeenCalledWith({
+        logLevel: 'info',
+        mainModulePath: joinFilePath(__dirname, '../../../'),
+        typeChecking: false,
+        dumpErrorState: false,
+      });
+      expect(manager.configRegistry.register).toHaveBeenCalledTimes(1);
+      expect(manager.configRegistry.register)
+        .toHaveBeenCalledWith(joinFilePath(__dirname, '/../../../config/default.json'));
+      expect(manager.instantiate).toHaveBeenCalledTimes(2);
+      expect(manager.instantiate).toHaveBeenNthCalledWith(1, 'urn:solid-server-app-setup:default:CliResolver', {});
+      expect(manager.instantiate)
+        .toHaveBeenNthCalledWith(2, 'urn:solid-server:default:App', { variables: defaultVariables });
+      expect(cliExtractor.handleSafe).toHaveBeenCalledTimes(1);
+      expect(shorthandResolver.handleSafe).toHaveBeenCalledTimes(1);
+
+      // The crucial difference with the run path: the server is never started.
+      expect(app.start).toHaveBeenCalledTimes(0);
+    });
+
+    it('rejects if the configuration is invalid.', async(): Promise<void> => {
+      jest.mocked(manager.configRegistry.register).mockRejectedValueOnce(new Error('Fatal'));
+
+      let caughtError: Error = new Error('should disappear');
+      try {
+        await new AppRunner().validateCli([ 'node', 'script' ]);
+      } catch (error: unknown) {
+        caughtError = error as Error;
+      }
+      expect(caughtError.message).toMatch(/^Could not build the config files from .*default\.json/mu);
+      expect(caughtError.message).toMatch(/^Error: Fatal/mu);
+
+      expect(app.start).toHaveBeenCalledTimes(0);
+      expect(write).toHaveBeenCalledTimes(0);
+      expect(exit).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('validateCliSync', (): void => {
+    it('exits with code 0 if the configuration is valid.', async(): Promise<void> => {
+      // eslint-disable-next-line no-sync
+      new AppRunner().validateCliSync({ argv: [ 'node', 'script' ]});
+
+      // Wait until validateCli has resolved, because we can't await validateCliSync.
+      await flushPromises();
+
+      expect(manager.instantiate).toHaveBeenCalledTimes(2);
+      expect(manager.instantiate)
+        .toHaveBeenNthCalledWith(2, 'urn:solid-server:default:App', { variables: defaultVariables });
+      expect(app.start).toHaveBeenCalledTimes(0);
+
+      expect(write).toHaveBeenCalledTimes(0);
+      expect(exit).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenLastCalledWith(0);
+    });
+
+    it('exits with a non-zero code and writes to stderr if the configuration is invalid.', async(): Promise<void> => {
+      manager.instantiate.mockRejectedValueOnce(new Error('Fatal'));
+
+      // eslint-disable-next-line no-sync
+      new AppRunner().validateCliSync({ argv: [ 'node', 'script' ]});
+
+      // Wait until validateCli has rejected, because we can't await validateCliSync.
+      await flushPromises();
+
+      expect(app.start).toHaveBeenCalledTimes(0);
+
+      expect(write).toHaveBeenCalledTimes(1);
+      expect(write).toHaveBeenLastCalledWith(expect.stringMatching(/Error: Fatal/u));
+
+      expect(exit).toHaveBeenCalledTimes(1);
+      expect(exit).toHaveBeenLastCalledWith(1);
+    });
+  });
+
   describe('runCli', (): void => {
     it('runs the server.', async(): Promise<void> => {
       await expect(new AppRunner().runCli([ 'node', 'script' ])).resolves.toBeUndefined();

--- a/test/unit/init/AppRunner.test.ts
+++ b/test/unit/init/AppRunner.test.ts
@@ -591,7 +591,6 @@ describe('AppRunner', (): void => {
     it('instantiates the configuration without starting the server.', async(): Promise<void> => {
       await expect(new AppRunner().validateCli([ 'node', 'script' ])).resolves.toBeUndefined();
 
-      // The full instantiation path is used, exactly like when starting the server.
       expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
       expect(ComponentsManager.build).toHaveBeenCalledWith({
         logLevel: 'info',
@@ -609,7 +608,6 @@ describe('AppRunner', (): void => {
       expect(cliExtractor.handleSafe).toHaveBeenCalledTimes(1);
       expect(shorthandResolver.handleSafe).toHaveBeenCalledTimes(1);
 
-      // The crucial difference with the run path: the server is never started.
       expect(app.start).toHaveBeenCalledTimes(0);
     });
 


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue describing the need for offline configuration validation must be created before this is submitted to CommunitySolidServer (the upstream template requires one).

#### ✍️ Description

Adds an offline configuration validation command: `bin/validate.js` (also exposed as the `validate:config` npm script) builds and fully instantiates a configuration exactly as a server start would, but never calls `App.start`, so no port is bound and no server runs. It exits `0` on a valid configuration and non-zero (printing the error) on an invalid one, making it suitable for CI and pre-deploy checks.

Why: the existing `npm run validate` script only compiles `config/default.json` and needs a source checkout, so a broken *custom* configuration currently surfaces only as a failed server start, sometimes after a partial boot. Validating by full instantiation through the existing `createCli` path is the strongest offline check — it exercises the same ComponentsManager build, config registration, variable resolution, and full App-graph instantiation as a real boot, and any Components.js build, wiring, type, or variable error rejects with the same error context a failed start would give. Because `bin/validate.js` only relies on the built `dist/` (mirroring `bin/server.js`), it also works inside the Docker image against a mounted configuration.

Why not a lighter check: compiling the config without instantiating (what `npm run validate` does) misses variable-resolution and instantiation errors. `typeChecking` is left `false` exactly as `create()` sets it (the components error under it); full instantiation is the stronger check regardless.

The change is purely additive: `bin/server.js` and the existing `run`/`runCli`/`create`/`createCli` methods are untouched, and the two new `AppRunner` methods (`validateCli`/`validateCliSync`) follow the `runCli`/`runCliSync` pattern. User-facing documentation is in `documentation/markdown/usage/starting-server.md` ("Validating a configuration").

Usage:

```shell
node ./bin/validate.js -c config/file.json -f data/
# Docker:
docker run --rm -v ~/solid-config:/config --entrypoint node solidproject/community-server bin/validate.js -c /config/my-config.json
```

Notes for reviewers:

- Live-verified: a valid config exits `0` with the full graph instantiated and no port bound; a deliberately broken config exits `1` with `Could not build the config files from … Error while parsing file …`. No server was started in either case.
- Unit tests cover instantiate-without-start (`app.start` called 0 times), invalid-config rejection, and the sync wrapper's exit codes and stderr output; `bin/validate.js` is excluded from coverage the same way `bin/server.js` is.
- Branch target: as a feature this should target the latest `versions/*` branch (currently `versions/next-major`) when submitted upstream, per the contribution guide — this fork draft sits on `main` only for review. Intended semver level: **minor** (backwards-compatible feature addition; contributors cannot set the label).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
