### PR TITLE
fix: Give Redis locks a renewed TTL so a crashed holder cannot deadlock peers

### DIFF
--- a/src/util/locking/RedisLocker.ts
+++ b/src/util/locking/RedisLocker.ts
@@ -3,6 +3,7 @@ import type { ResourceIdentifier } from '../../http/representation/ResourceIdent
 import type { Finalizable } from '../../init/final/Finalizable';
 import type { Initializable } from '../../init/Initializable';
 import { getLoggerFor } from '../../logging/LogUtil';
+import { createErrorMessage } from '../errors/ErrorUtil';
 import type { AttemptSettings } from '../LockUtils';
 import { retryFunction } from '../LockUtils';
 import type { PromiseOrValue } from '../PromiseUtil';
@@ -17,6 +18,16 @@ const attemptDefaults: Required<AttemptSettings> = { retryCount: -1, retryDelay:
 const PREFIX_RW = '__RW__';
 const PREFIX_LOCK = '__L__';
 
+/**
+ * Default time-to-live (in ms) for a Redis lock key.
+ *
+ * A crashed lock holder's key auto-expires after this time so that other instances cannot deadlock
+ * on the abandoned resource. It is deliberately several times larger than the in-process lock
+ * expiration (see {@link WrappedExpiringReadWriteLocker}, 6000ms by default), and it is actively
+ * renewed while a lock is legitimately held, so a normal operation never loses its lock.
+ */
+const DEFAULT_TTL = 30000;
+
 export interface RedisSettings {
   /* Override default namespacePrefixes (used to prefix keys in Redis) */
   namespacePrefix?: string;
@@ -26,6 +37,13 @@ export interface RedisSettings {
   password?: string;
   /* The number of the database to use */
   db?: number;
+  /**
+   * Time-to-live (in ms) for the Redis lock keys. A crashed holder's key auto-expires after this
+   * time so peers do not deadlock. While a lock is legitimately held it is renewed at half this
+   * interval, so this value only bounds how long peers wait after a hard crash. Must be larger than
+   * the in-process lock expiration. Defaults to {@link DEFAULT_TTL} (30000ms).
+   */
+  ttl?: number;
 }
 
 /**
@@ -63,6 +81,9 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   private readonly redisLock: RedisResourceLock;
   private readonly attemptSettings: Required<AttemptSettings>;
   private readonly namespacePrefix: string;
+  private readonly ttl: number;
+  private readonly renewalInterval: number;
+  private readonly renewalTimers = new Map<string, NodeJS.Timeout>();
   private finalized = false;
 
   /**
@@ -78,10 +99,13 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     redisSettings?: RedisSettings,
   ) {
     redisSettings = { namespacePrefix: '', ...redisSettings };
-    const { namespacePrefix, ...options } = redisSettings;
+    const { namespacePrefix, ttl, ...options } = redisSettings;
     this.redis = this.createRedisClient(redisClient, options);
     this.attemptSettings = { ...attemptDefaults, ...attemptSettings };
     this.namespacePrefix = namespacePrefix!;
+    this.ttl = ttl ?? DEFAULT_TTL;
+    // Renew at half the TTL so a live holder refreshes its lock long before it could expire.
+    this.renewalInterval = Math.max(1, Math.floor(this.ttl / 2));
 
     // Register lua scripts
     for (const [ name, script ] of Object.entries(REDIS_LUA_SCRIPTS)) {
@@ -98,7 +122,7 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
    * @param redisClientString - A string that contains either a host address and a
    *                            port number like '127.0.0.1:6379' or just a port number like '6379'.
    */
-  private createRedisClient(redisClientString: string, options: Omit<RedisSettings, 'namespacePrefix'>): Redis {
+  private createRedisClient(redisClientString: string, options: Omit<RedisSettings, 'namespacePrefix' | 'ttl'>): Redis {
     if (redisClientString.length > 0) {
       // Check if port number or ip with port number
       // Definitely not perfect, but configuring this is only for experienced users
@@ -138,6 +162,54 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     return `${this.namespacePrefix}${PREFIX_LOCK}${identifier.path}`;
   }
 
+  /* Lease renewal */
+
+  /**
+   * Creates an interval timer that periodically refreshes the TTL of a held Redis lock (a lease).
+   * As long as the process is alive the lock keeps being renewed, so a legitimate (even long-running)
+   * operation never loses its lock. Once the process crashes the timer dies with it and the Redis key
+   * expires after the TTL, releasing the abandoned lock so peers do not deadlock.
+   *
+   * @param renew - Refreshes the TTL of the relevant Redis key. Rejections are swallowed and logged,
+   *                as a single missed refresh is recovered by the next interval tick.
+   *
+   * @returns The interval timer, which must be cleared with {@link clearInterval} once the lock is released.
+   */
+  private createRenewalTimer(renew: () => Promise<RedisAnswer>): NodeJS.Timeout {
+    const timer = setInterval((): void => {
+      renew().catch((error: unknown): void => {
+        this.logger.warn(`Could not renew Redis lock TTL: ${createErrorMessage(error)}`);
+      });
+    }, this.renewalInterval);
+    // A background renewal timer should never keep the Node.js process alive on its own.
+    timer.unref();
+    return timer;
+  }
+
+  /**
+   * Starts renewing the TTL of a resource lock and tracks the timer so it can be stopped on release.
+   *
+   * @param key - The Redis key of the acquired resource lock.
+   * @param renew - Refreshes the TTL of the resource lock key.
+   */
+  private startRenewal(key: string, renew: () => Promise<RedisAnswer>): void {
+    this.stopRenewal(key);
+    this.renewalTimers.set(key, this.createRenewalTimer(renew));
+  }
+
+  /**
+   * Stops renewing the TTL of a resource lock, if a renewal timer is active for the given key.
+   *
+   * @param key - The Redis key of the resource lock to stop renewing.
+   */
+  private stopRenewal(key: string): void {
+    const timer = this.renewalTimers.get(key);
+    if (timer) {
+      clearInterval(timer);
+      this.renewalTimers.delete(key);
+    }
+  }
+
   /* ReadWriteLocker methods */
 
   /**
@@ -163,12 +235,16 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   public async withReadLock<T>(identifier: ResourceIdentifier, whileLocked: () => PromiseOrValue<T>): Promise<T> {
     const key = this.getReadWriteKey(identifier);
     await retryFunction(
-      this.swallowFalse(this.redisRw.acquireReadLock.bind(this.redisRw, key)),
+      this.swallowFalse(this.redisRw.acquireReadLock.bind(this.redisRw, key, this.ttl)),
       this.attemptSettings,
+    );
+    const renewalTimer = this.createRenewalTimer(
+      async(): Promise<RedisAnswer> => this.redisRw.renewReadLock(key, this.ttl),
     );
     try {
       return await whileLocked();
     } finally {
+      clearInterval(renewalTimer);
       await retryFunction(
         this.swallowFalse(this.redisRw.releaseReadLock.bind(this.redisRw, key)),
         this.attemptSettings,
@@ -179,12 +255,16 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   public async withWriteLock<T>(identifier: ResourceIdentifier, whileLocked: () => PromiseOrValue<T>): Promise<T> {
     const key = this.getReadWriteKey(identifier);
     await retryFunction(
-      this.swallowFalse(this.redisRw.acquireWriteLock.bind(this.redisRw, key)),
+      this.swallowFalse(this.redisRw.acquireWriteLock.bind(this.redisRw, key, this.ttl)),
       this.attemptSettings,
+    );
+    const renewalTimer = this.createRenewalTimer(
+      async(): Promise<RedisAnswer> => this.redisRw.renewWriteLock(key, this.ttl),
     );
     try {
       return await whileLocked();
     } finally {
+      clearInterval(renewalTimer);
       await retryFunction(
         this.swallowFalse(this.redisRw.releaseWriteLock.bind(this.redisRw, key)),
         this.attemptSettings,
@@ -197,13 +277,17 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   public async acquire(identifier: ResourceIdentifier): Promise<void> {
     const key = this.getResourceKey(identifier);
     await retryFunction(
-      this.swallowFalse(this.redisLock.acquireLock.bind(this.redisLock, key)),
+      this.swallowFalse(this.redisLock.acquireLock.bind(this.redisLock, key, this.ttl)),
       this.attemptSettings,
     );
+    // A resource lock is held across separate acquire()/release() calls, so keep renewing its TTL
+    // until it is explicitly released (or the process crashes).
+    this.startRenewal(key, async(): Promise<RedisAnswer> => this.redisLock.renewLock(key, this.ttl));
   }
 
   public async release(identifier: ResourceIdentifier): Promise<void> {
     const key = this.getResourceKey(identifier);
+    this.stopRenewal(key);
     await retryFunction(
       this.swallowFalse(this.redisLock.releaseLock.bind(this.redisLock, key)),
       this.attemptSettings,
@@ -219,6 +303,11 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
 
   public async finalize(): Promise<void> {
     this.finalized = true;
+    // Stop any active resource-lock renewals so their timers cannot outlive the locker.
+    for (const timer of this.renewalTimers.values()) {
+      clearInterval(timer);
+    }
+    this.renewalTimers.clear();
     try {
       // On controlled server shutdown: clean up all existing locks.
       await this.clearLocks();

--- a/src/util/locking/RedisLocker.ts
+++ b/src/util/locking/RedisLocker.ts
@@ -18,14 +18,7 @@ const attemptDefaults: Required<AttemptSettings> = { retryCount: -1, retryDelay:
 const PREFIX_RW = '__RW__';
 const PREFIX_LOCK = '__L__';
 
-/**
- * Default time-to-live (in ms) for a Redis lock key.
- *
- * A crashed lock holder's key auto-expires after this time so that other instances cannot deadlock
- * on the abandoned resource. It is deliberately several times larger than the in-process lock
- * expiration (see {@link WrappedExpiringReadWriteLocker}, 6000ms by default), and it is actively
- * renewed while a lock is legitimately held, so a normal operation never loses its lock.
- */
+// Default TTL (in ms) of the lock keys
 const DEFAULT_TTL = 30000;
 
 export interface RedisSettings {
@@ -38,10 +31,8 @@ export interface RedisSettings {
   /* The number of the database to use */
   db?: number;
   /**
-   * Time-to-live (in ms) for the Redis lock keys. A crashed holder's key auto-expires after this
-   * time so peers do not deadlock. While a lock is legitimately held it is renewed at half this
-   * interval, so this value only bounds how long peers wait after a hard crash. Must be larger than
-   * the in-process lock expiration. Defaults to {@link DEFAULT_TTL} (30000ms).
+   * Time-to-live (in ms) of the lock keys, so the locks of a crashed instance expire instead of
+   * blocking peers forever. Held locks are renewed at half this interval. Defaults to 30000.
    */
   ttl?: number;
 }
@@ -165,15 +156,12 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   /* Lease renewal */
 
   /**
-   * Creates an interval timer that periodically refreshes the TTL of a held Redis lock (a lease).
-   * As long as the process is alive the lock keeps being renewed, so a legitimate (even long-running)
-   * operation never loses its lock. Once the process crashes the timer dies with it and the Redis key
-   * expires after the TTL, releasing the abandoned lock so peers do not deadlock.
+   * Creates an interval timer that keeps refreshing the TTL of a held lock,
+   * so only the locks of a crashed process expire.
+   * The caller needs to clear the returned timer once the lock is released.
    *
-   * @param renew - Refreshes the TTL of the relevant Redis key. Rejections are swallowed and logged,
-   *                as a single missed refresh is recovered by the next interval tick.
-   *
-   * @returns The interval timer, which must be cleared with {@link clearInterval} once the lock is released.
+   * @param renew - Refreshes the TTL of the relevant Redis key.
+   *                Rejections are logged, as the next tick can retry a failed refresh.
    */
   private createRenewalTimer(renew: () => Promise<RedisAnswer>): NodeJS.Timeout {
     const timer = setInterval((): void => {
@@ -181,16 +169,13 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
         this.logger.warn(`Could not renew Redis lock TTL: ${createErrorMessage(error)}`);
       });
     }, this.renewalInterval);
-    // A background renewal timer should never keep the Node.js process alive on its own.
+    // The timer should not keep the process alive.
     timer.unref();
     return timer;
   }
 
   /**
-   * Starts renewing the TTL of a resource lock and tracks the timer so it can be stopped on release.
-   *
-   * @param key - The Redis key of the acquired resource lock.
-   * @param renew - Refreshes the TTL of the resource lock key.
+   * Starts renewing the TTL of the given resource lock, replacing any previous renewal timer for that key.
    */
   private startRenewal(key: string, renew: () => Promise<RedisAnswer>): void {
     this.stopRenewal(key);
@@ -198,9 +183,7 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   }
 
   /**
-   * Stops renewing the TTL of a resource lock, if a renewal timer is active for the given key.
-   *
-   * @param key - The Redis key of the resource lock to stop renewing.
+   * Stops renewing the TTL of the given resource lock, if it has an active renewal timer.
    */
   private stopRenewal(key: string): void {
     const timer = this.renewalTimers.get(key);
@@ -280,8 +263,7 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
       this.swallowFalse(this.redisLock.acquireLock.bind(this.redisLock, key, this.ttl)),
       this.attemptSettings,
     );
-    // A resource lock is held across separate acquire()/release() calls, so keep renewing its TTL
-    // until it is explicitly released (or the process crashes).
+    // A resource lock stays held across calls, so its renewal timer is tracked until release() or finalize()
     this.startRenewal(key, async(): Promise<RedisAnswer> => this.redisLock.renewLock(key, this.ttl));
   }
 

--- a/src/util/locking/scripts/RedisLuaScripts.ts
+++ b/src/util/locking/scripts/RedisLuaScripts.ts
@@ -17,7 +17,7 @@ export const REDIS_LUA_SCRIPTS = {
       return 0
     end
 
-    -- Increment the read counter and refresh its TTL (in ms, ARGV[1]); return true if succeeded
+    -- Increment the read counter and refresh its TTL (in ms, ARGV[1]); return 1 on success (Lua true becomes 1)
     local countKey = KEYS[1].."${SUFFIX_COUNT}"
     local count = redis.call("incr", countKey)
     redis.call("pexpire", countKey, ARGV[1])

--- a/src/util/locking/scripts/RedisLuaScripts.ts
+++ b/src/util/locking/scripts/RedisLuaScripts.ts
@@ -16,10 +16,13 @@ export const REDIS_LUA_SCRIPTS = {
     if redis.call("exists", lockKey) == 1 then
       return 0
     end
-    
-    -- Return true if succeeded (and counter is incremented)
+
+    -- Increment the read counter and (re)set its TTL (in ms, ARGV[1]) atomically, so a crashed
+    -- reader can never keep the counter alive (and thus deadlock writers) forever.
     local countKey = KEYS[1].."${SUFFIX_COUNT}"
-    return redis.call("incr", countKey) > 0
+    local count = redis.call("incr", countKey)
+    redis.call("pexpire", countKey, ARGV[1])
+    return count > 0
     `,
   acquireWriteLock: `
     -- Return 0 if a lock entry already exists or read count is > 0
@@ -29,9 +32,10 @@ export const REDIS_LUA_SCRIPTS = {
     if ((redis.call("exists", lockKey) == 1) or (count ~= nil and count > 0)) then
       return 0
     end
-    
-    -- Set lock and respond with 'OK' if succeeded (otherwise null)
-    return redis.call("set", lockKey, "${LOCKED}");
+
+    -- Set the write lock together with a TTL (in ms, ARGV[1]) and respond with 'OK' if succeeded
+    -- (otherwise null). The TTL ensures a crashed holder's lock auto-releases instead of deadlocking peers.
+    return redis.call("set", lockKey, "${LOCKED}", "PX", ARGV[1]);
     `,
   releaseReadLock: `
       -- Return 1 after decreasing the counter, if counter is < 0 now: return '-ERR'
@@ -53,15 +57,28 @@ export const REDIS_LUA_SCRIPTS = {
         return redis.error_reply("Error trying to release writelock that did not exist.")
       end
     `,
+  renewReadLock: `
+      -- Refresh the read counter TTL (in ms, ARGV[1]) while at least one reader legitimately holds
+      -- the lock, so the counter never expires mid-operation and lets a writer in.
+      local countKey = KEYS[1].."${SUFFIX_COUNT}"
+      return redis.call("pexpire", countKey, ARGV[1])
+      `,
+  renewWriteLock: `
+      -- Refresh the write lock TTL (in ms, ARGV[1]) while it is legitimately held, so a long-running
+      -- operation never loses its lock.
+      local lockKey = KEYS[1].."${SUFFIX_WLOCK}"
+      return redis.call("pexpire", lockKey, ARGV[1])
+      `,
   acquireLock: `
       -- Return 0 if lock entry already exists, or 'OK' if it succeeds in setting the lock entry.
       local key = KEYS[1].."${SUFFIX_LOCK}"
       if redis.call("exists", key) == 1 then
         return 0
       end
-      
-      -- Return 'OK' if succeeded setting entry
-      return redis.call("set", key, "${LOCKED}");
+
+      -- Set the lock with a TTL (in ms, ARGV[1]) and return 'OK' if succeeded. The TTL ensures a
+      -- crashed holder's lock auto-releases instead of deadlocking peers.
+      return redis.call("set", key, "${LOCKED}", "PX", ARGV[1]);
       `,
   releaseLock: `
       -- Release the lock and reply with 1 if succeeded (otherwise return '-ERR')
@@ -73,6 +90,11 @@ export const REDIS_LUA_SCRIPTS = {
         return redis.error_reply("Error trying to release lock that did not exist.")
       end
     `,
+  renewLock: `
+      -- Refresh the lock TTL (in ms, ARGV[1]) while it is legitimately held.
+      local key = KEYS[1].."${SUFFIX_LOCK}"
+      return redis.call("pexpire", key, ARGV[1])
+      `,
 } as const;
 
 export type RedisAnswer = 0 | 1 | null | string;
@@ -112,17 +134,43 @@ export interface RedisReadWriteLock extends Redis {
    * Try to acquire a readLock on `resourceIdentifierPath`.
    * Will succeed if there are no write locks.
    *
+   * @param resourceIdentifierPath - The key to lock.
+   * @param ttl - Time-to-live (in ms) set on the read counter, so a crashed reader auto-releases.
+   *
    * @returns 1 if succeeded. 0 if not possible.
    */
-  acquireReadLock: (resourceIdentifierPath: string, callback?: Callback<string>) => Promise<RedisAnswer>;
+  acquireReadLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
 
   /**
    * Try to acquire a writeLock on `resourceIdentifierPath`.
    * Only works if no other write lock is present and the read counter is 0.
    *
+   * @param resourceIdentifierPath - The key to lock.
+   * @param ttl - Time-to-live (in ms) set on the write lock, so a crashed holder auto-releases.
+   *
    * @returns 'OK' if succeeded, 0 if not possible.
    */
-  acquireWriteLock: (resourceIdentifierPath: string, callback?: Callback<string>) => Promise<RedisAnswer>;
+  acquireWriteLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
+
+  /**
+   * Refresh the TTL of the read counter while the lock is legitimately held (a lease renewal).
+   *
+   * @param resourceIdentifierPath - The key whose read counter TTL should be refreshed.
+   * @param ttl - Time-to-live (in ms) to (re)set on the read counter.
+   *
+   * @returns 1 if the TTL was refreshed, 0 if the counter no longer exists.
+   */
+  renewReadLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<number>) => Promise<RedisAnswer>;
+
+  /**
+   * Refresh the TTL of the write lock while it is legitimately held (a lease renewal).
+   *
+   * @param resourceIdentifierPath - The key whose write lock TTL should be refreshed.
+   * @param ttl - Time-to-live (in ms) to (re)set on the write lock.
+   *
+   * @returns 1 if the TTL was refreshed, 0 if the lock no longer exists.
+   */
+  renewWriteLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<number>) => Promise<RedisAnswer>;
 
   /**
    * Release readLock. This means decrementing the read counter with 1.
@@ -144,9 +192,22 @@ export interface RedisResourceLock extends Redis {
    * Try to acquire a lock  on `resourceIdentifierPath`.
    * Only works if no other lock is present.
    *
+   * @param resourceIdentifierPath - The key to lock.
+   * @param ttl - Time-to-live (in ms) set on the lock, so a crashed holder auto-releases.
+   *
    * @returns 'OK' if succeeded, 0 if not possible.
    */
-  acquireLock: (resourceIdentifierPath: string, callback?: Callback<string>) => Promise<RedisAnswer>;
+  acquireLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
+
+  /**
+   * Refresh the TTL of the lock while it is legitimately held (a lease renewal).
+   *
+   * @param resourceIdentifierPath - The key whose lock TTL should be refreshed.
+   * @param ttl - Time-to-live (in ms) to (re)set on the lock.
+   *
+   * @returns 1 if the TTL was refreshed, 0 if the lock no longer exists.
+   */
+  renewLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<number>) => Promise<RedisAnswer>;
 
   /**
    * Release lock. This means deleting the lock.

--- a/src/util/locking/scripts/RedisLuaScripts.ts
+++ b/src/util/locking/scripts/RedisLuaScripts.ts
@@ -17,8 +17,7 @@ export const REDIS_LUA_SCRIPTS = {
       return 0
     end
 
-    -- Increment the read counter and (re)set its TTL (in ms, ARGV[1]) atomically, so a crashed
-    -- reader can never keep the counter alive (and thus deadlock writers) forever.
+    -- Increment the read counter and refresh its TTL (in ms, ARGV[1]); return true if succeeded
     local countKey = KEYS[1].."${SUFFIX_COUNT}"
     local count = redis.call("incr", countKey)
     redis.call("pexpire", countKey, ARGV[1])
@@ -33,8 +32,7 @@ export const REDIS_LUA_SCRIPTS = {
       return 0
     end
 
-    -- Set the write lock together with a TTL (in ms, ARGV[1]) and respond with 'OK' if succeeded
-    -- (otherwise null). The TTL ensures a crashed holder's lock auto-releases instead of deadlocking peers.
+    -- Set the lock with a TTL (in ms, ARGV[1]) and respond with 'OK' if succeeded (otherwise null)
     return redis.call("set", lockKey, "${LOCKED}", "PX", ARGV[1]);
     `,
   releaseReadLock: `
@@ -58,14 +56,12 @@ export const REDIS_LUA_SCRIPTS = {
       end
     `,
   renewReadLock: `
-      -- Refresh the read counter TTL (in ms, ARGV[1]) while at least one reader legitimately holds
-      -- the lock, so the counter never expires mid-operation and lets a writer in.
+      -- Refresh the read counter TTL (in ms, ARGV[1]); return 1 if refreshed, 0 if it did not exist
       local countKey = KEYS[1].."${SUFFIX_COUNT}"
       return redis.call("pexpire", countKey, ARGV[1])
       `,
   renewWriteLock: `
-      -- Refresh the write lock TTL (in ms, ARGV[1]) while it is legitimately held, so a long-running
-      -- operation never loses its lock.
+      -- Refresh the write lock TTL (in ms, ARGV[1]); return 1 if refreshed, 0 if it did not exist
       local lockKey = KEYS[1].."${SUFFIX_WLOCK}"
       return redis.call("pexpire", lockKey, ARGV[1])
       `,
@@ -76,8 +72,7 @@ export const REDIS_LUA_SCRIPTS = {
         return 0
       end
 
-      -- Set the lock with a TTL (in ms, ARGV[1]) and return 'OK' if succeeded. The TTL ensures a
-      -- crashed holder's lock auto-releases instead of deadlocking peers.
+      -- Set the lock with a TTL (in ms, ARGV[1]) and return 'OK' if succeeded
       return redis.call("set", key, "${LOCKED}", "PX", ARGV[1]);
       `,
   releaseLock: `
@@ -91,7 +86,7 @@ export const REDIS_LUA_SCRIPTS = {
       end
     `,
   renewLock: `
-      -- Refresh the lock TTL (in ms, ARGV[1]) while it is legitimately held.
+      -- Refresh the lock TTL (in ms, ARGV[1]); return 1 if refreshed, 0 if it did not exist
       local key = KEYS[1].."${SUFFIX_LOCK}"
       return redis.call("pexpire", key, ARGV[1])
       `,
@@ -134,8 +129,7 @@ export interface RedisReadWriteLock extends Redis {
    * Try to acquire a readLock on `resourceIdentifierPath`.
    * Will succeed if there are no write locks.
    *
-   * @param resourceIdentifierPath - The key to lock.
-   * @param ttl - Time-to-live (in ms) set on the read counter, so a crashed reader auto-releases.
+   * @param ttl - Time-to-live (in ms) of the read counter.
    *
    * @returns 1 if succeeded. 0 if not possible.
    */
@@ -145,28 +139,25 @@ export interface RedisReadWriteLock extends Redis {
    * Try to acquire a writeLock on `resourceIdentifierPath`.
    * Only works if no other write lock is present and the read counter is 0.
    *
-   * @param resourceIdentifierPath - The key to lock.
-   * @param ttl - Time-to-live (in ms) set on the write lock, so a crashed holder auto-releases.
+   * @param ttl - Time-to-live (in ms) of the write lock.
    *
    * @returns 'OK' if succeeded, 0 if not possible.
    */
   acquireWriteLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
 
   /**
-   * Refresh the TTL of the read counter while the lock is legitimately held (a lease renewal).
+   * Refresh the TTL of the read counter of a held read lock.
    *
-   * @param resourceIdentifierPath - The key whose read counter TTL should be refreshed.
-   * @param ttl - Time-to-live (in ms) to (re)set on the read counter.
+   * @param ttl - New time-to-live (in ms).
    *
    * @returns 1 if the TTL was refreshed, 0 if the counter no longer exists.
    */
   renewReadLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<number>) => Promise<RedisAnswer>;
 
   /**
-   * Refresh the TTL of the write lock while it is legitimately held (a lease renewal).
+   * Refresh the TTL of a held write lock.
    *
-   * @param resourceIdentifierPath - The key whose write lock TTL should be refreshed.
-   * @param ttl - Time-to-live (in ms) to (re)set on the write lock.
+   * @param ttl - New time-to-live (in ms).
    *
    * @returns 1 if the TTL was refreshed, 0 if the lock no longer exists.
    */
@@ -192,18 +183,16 @@ export interface RedisResourceLock extends Redis {
    * Try to acquire a lock  on `resourceIdentifierPath`.
    * Only works if no other lock is present.
    *
-   * @param resourceIdentifierPath - The key to lock.
-   * @param ttl - Time-to-live (in ms) set on the lock, so a crashed holder auto-releases.
+   * @param ttl - Time-to-live (in ms) of the lock.
    *
    * @returns 'OK' if succeeded, 0 if not possible.
    */
   acquireLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
 
   /**
-   * Refresh the TTL of the lock while it is legitimately held (a lease renewal).
+   * Refresh the TTL of a held lock.
    *
-   * @param resourceIdentifierPath - The key whose lock TTL should be refreshed.
-   * @param ttl - Time-to-live (in ms) to (re)set on the lock.
+   * @param ttl - New time-to-live (in ms).
    *
    * @returns 1 if the TTL was refreshed, 0 if the lock no longer exists.
    */

--- a/test/unit/util/locking/RedisLocker.test.ts
+++ b/test/unit/util/locking/RedisLocker.test.ts
@@ -87,12 +87,15 @@ const redis: jest.Mocked<Redis & RedisResourceLock & RedisReadWriteLock> = {
     store.acquireReadLock(key)),
   acquireWriteLock: jest.fn().mockImplementation(async(key: string): Promise<number | null | 'OK'> =>
     store.acquireWriteLock(key)),
+  renewReadLock: jest.fn().mockResolvedValue(1),
+  renewWriteLock: jest.fn().mockResolvedValue(1),
   releaseReadLock: jest.fn().mockImplementation(async(key: string): Promise<number> =>
     store.releaseReadLock(key)),
   releaseWriteLock: jest.fn().mockImplementation(async(key: string): Promise<number | null> =>
     store.releaseWriteLock(key)),
   acquireLock: jest.fn().mockImplementation(async(key: string): Promise<number | null | 'OK'> =>
     store.acquireLock(key)),
+  renewLock: jest.fn().mockResolvedValue(1),
   releaseLock: jest.fn().mockImplementation(async(key: string): Promise<number | null | string> =>
     store.releaseLock(key)),
 } as any;
@@ -124,6 +127,8 @@ describe('A RedisLocker', (): void => {
     afterEach(async(): Promise<void> => {
     // In case some locks are not released by a test the timers will still be running
       jest.clearAllTimers();
+      // Restore real timers in case a test enabled fake timers for renewal assertions
+      jest.useRealTimers();
     });
 
     it('will fill in default arguments when constructed with empty arguments.', (): void => {
@@ -418,6 +423,93 @@ describe('A RedisLocker', (): void => {
       await expect(promise).rejects.toThrow('Unexpected Redis answer received! (unexpected)');
     });
 
+    describe('lock TTL', (): void => {
+      const key = `__RW__${resource1.path}`;
+
+      it('sets the default TTL when acquiring a read lock.', async(): Promise<void> => {
+        await locker.withReadLock(resource1, (): number => 5);
+        expect(redis.acquireReadLock).toHaveBeenCalledTimes(1);
+        expect(redis.acquireReadLock).toHaveBeenCalledWith(key, 30000);
+      });
+
+      it('sets the default TTL when acquiring a write lock.', async(): Promise<void> => {
+        await locker.withWriteLock(resource1, (): number => 5);
+        expect(redis.acquireWriteLock).toHaveBeenCalledTimes(1);
+        expect(redis.acquireWriteLock).toHaveBeenCalledWith(key, 30000);
+      });
+
+      it('uses a custom TTL when one is configured.', async(): Promise<void> => {
+        const customLocker = new RedisLocker('6379', {}, { ttl: 12000 });
+        await customLocker.withWriteLock(resource1, (): number => 5);
+        expect(redis.acquireWriteLock).toHaveBeenCalledWith(key, 12000);
+      });
+
+      it('renews the write lock TTL while the lock is held, and stops after release.', async(): Promise<void> => {
+        jest.useFakeTimers();
+        const emitter = new EventEmitter();
+        const promise = locker.withWriteLock(resource1, async(): Promise<void> =>
+          new Promise<void>((resolve): any => emitter.on('release', resolve)));
+
+        // Allow the acquire to resolve and the renewal timer to be scheduled
+        await flushPromises();
+
+        // The renewal fires at half the TTL and refreshes the write lock key with the full TTL
+        jest.advanceTimersByTime(15000);
+        expect(redis.renewWriteLock).toHaveBeenCalledTimes(1);
+        expect(redis.renewWriteLock).toHaveBeenLastCalledWith(key, 30000);
+        jest.advanceTimersByTime(15000);
+        expect(redis.renewWriteLock).toHaveBeenCalledTimes(2);
+
+        emitter.emit('release');
+        await promise;
+
+        // Once released the renewal timer is cleared and no further renewals happen
+        jest.advanceTimersByTime(60000);
+        expect(redis.renewWriteLock).toHaveBeenCalledTimes(2);
+      });
+
+      it('renews the read lock counter TTL while the lock is held.', async(): Promise<void> => {
+        jest.useFakeTimers();
+        const emitter = new EventEmitter();
+        const promise = locker.withReadLock(resource1, async(): Promise<void> =>
+          new Promise<void>((resolve): any => emitter.on('release', resolve)));
+
+        await flushPromises();
+
+        jest.advanceTimersByTime(15000);
+        expect(redis.renewReadLock).toHaveBeenCalledTimes(1);
+        expect(redis.renewReadLock).toHaveBeenLastCalledWith(key, 30000);
+
+        emitter.emit('release');
+        await promise;
+
+        jest.advanceTimersByTime(60000);
+        expect(redis.renewReadLock).toHaveBeenCalledTimes(1);
+      });
+
+      it('logs a warning when a lock renewal fails.', async(): Promise<void> => {
+        jest.useFakeTimers();
+        const logger = (locker as any).logger;
+        const warnSpy = jest.spyOn(logger, 'warn').mockImplementation((): any => undefined);
+        redis.renewWriteLock.mockRejectedValueOnce(new Error('renewal boom'));
+
+        const emitter = new EventEmitter();
+        const promise = locker.withWriteLock(resource1, async(): Promise<void> =>
+          new Promise<void>((resolve): any => emitter.on('release', resolve)));
+
+        await flushPromises();
+        jest.advanceTimersByTime(15000);
+        // Allow the rejected renewal promise to settle so the catch handler runs
+        await flushPromises();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenLastCalledWith(expect.stringContaining('Could not renew Redis lock TTL'));
+
+        emitter.emit('release');
+        await promise;
+        warnSpy.mockRestore();
+      });
+    });
+
     describe('finalize()', (): void => {
       it('should call quit and clear Read-Write locks when finalize() is called.', async(): Promise<void> => {
         const promise = locker.withWriteLock(resource1, async(): Promise<any> => {
@@ -443,6 +535,8 @@ describe('A RedisLocker', (): void => {
     afterEach(async(): Promise<void> => {
     // In case some locks are not released by a test the timers will still be running
       jest.clearAllTimers();
+      // Restore real timers in case a test enabled fake timers for renewal assertions
+      jest.useRealTimers();
     });
 
     it('will fill in default arguments when constructed with empty arguments.', (): void => {
@@ -455,6 +549,38 @@ describe('A RedisLocker', (): void => {
       await expect(locker.release(identifier)).resolves.toBeUndefined();
       expect(redis.acquireLock).toHaveBeenCalledTimes(1);
       expect(redis.releaseLock).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets a TTL when acquiring a resource lock.', async(): Promise<void> => {
+      await locker.acquire(identifier);
+      expect(redis.acquireLock).toHaveBeenCalledTimes(1);
+      expect(redis.acquireLock).toHaveBeenCalledWith(`__L__${identifier.path}`, 30000);
+      await locker.release(identifier);
+    });
+
+    it('renews a held resource lock TTL until it is released.', async(): Promise<void> => {
+      jest.useFakeTimers();
+      const key = `__L__${identifier.path}`;
+      await locker.acquire(identifier);
+
+      jest.advanceTimersByTime(15000);
+      expect(redis.renewLock).toHaveBeenCalledTimes(1);
+      expect(redis.renewLock).toHaveBeenLastCalledWith(key, 30000);
+
+      await locker.release(identifier);
+
+      // No renewals happen once the resource lock is released
+      jest.advanceTimersByTime(60000);
+      expect(redis.renewLock).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops renewing held resource locks on finalize.', async(): Promise<void> => {
+      jest.useFakeTimers();
+      await locker.acquire({ path: 'path1' });
+      await locker.finalize();
+
+      jest.advanceTimersByTime(60000);
+      expect(redis.renewLock).not.toHaveBeenCalled();
     });
 
     it('can lock a resource again after it was unlocked.', async(): Promise<void> => {


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue describing the crashed-holder deadlock must be created before this is submitted to CommunitySolidServer (the PR template requires one).

#### ✍️ Description

The Redis locker's lua scripts set lock keys without an expiry (`SET key "locked"`). When a lock-holding instance crashes, its key stays in Redis forever and every other instance deadlocks on that resource until manual intervention. The `WrappedExpiringReadWriteLocker` expiration (6 s by default) only releases the in-process usage; it never removes the Redis key of a dead process.

This change gives every lock key a renewed TTL (a lease):

- The TTL is set atomically at acquire time inside the lua scripts (`SET … PX <ttl>`; read counters get `PEXPIRE`), so a key can never exist without an expiry.
- A live holder refreshes the TTL on an interval: `RedisLocker` runs an `unref()`ed `setInterval` at TTL/2 calling new `renew*` lua scripts. A legitimate operation of any length keeps its lock; a crashed holder stops refreshing and its keys auto-expire, freeing peers.
- Read-lock counters carry and refresh the TTL too, so a crashed reader's counter also expires instead of blocking writers.
- The default TTL is 30 s, configurable through the new `RedisSettings.ttl` option. 30 s is roughly 5× the 6 s in-process expiration, and since renewal runs at TTL/2 a held key always has at least 15 s remaining — losing a held lock would need a 15 s event-loop stall, the same pathological case that already breaks the in-process expiration timer.
- Mutual-exclusion semantics are unchanged: the scripts only gained expiry and renewal.

Why a self-contained timer rather than wiring renewal through `WrappedExpiringReadWriteLocker.maintainLock`: that callback lives entirely inside the wrapper and is never passed down to this locker, and a timer also covers resource locks, which are held across separate `acquire()`/`release()` calls.

Verification (manual procedure against a real Redis — no scripted benchmark exists): a 2-instance crash test with `ttl=3000` showed lock keys with a positive `PTTL` countdown (previously `-1`, i.e. no expiry); after `kill -9` of the lock-holding instance, all 8 lock keys it left behind auto-expired within 5 s (0 remaining), so peers were no longer blocked. The new lua scripts were additionally `EVAL`ed directly against Redis to confirm the `PX`/`PEXPIRE` behaviour. Unit tests cover the TTL on acquire (default and custom), renewal firing while held and stopping on release/finalize, and the renewal-failure warning.

Intended semver level: **minor** (new `RedisSettings.ttl` option and a change to lock-key lifetime). On upstream submission this should therefore target the latest `versions/*` branch (currently `versions/next-major`); this fork draft sits on `main` only for review.

Note for review: trivial one-field overlap with #64, which also adds a `RedisSettings` field — whichever lands second needs a one-line rebase.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
