### PR TITLE
fix: Count metadata writes against quota

### DIFF
--- a/src/storage/accessors/ValidatingDataAccessor.ts
+++ b/src/storage/accessors/ValidatingDataAccessor.ts
@@ -40,23 +40,12 @@ export class ValidatingDataAccessor extends PassthroughDataAccessor {
     return this.accessor.writeContainer(identifier, metadata);
   }
 
-  /**
-   * Metadata (`.meta` sidecars) is persisted as a serialized stream of quads.
-   * Without this override the write would bypass the validator entirely, letting a large metadata
-   * document exceed the configured quota. The serialized metadata is therefore run through the same
-   * validator used for documents so its size counts against the quota. Because the wrapped accessor
-   * re-serializes the metadata itself, the validated stream is fully consumed here purely to drive the
-   * quota guard, which rejects (413) when the write would exceed the available space.
-   *
-   * When quota is not configured this accessor is not instantiated, so this method is never invoked
-   * and metadata writes keep their original behavior.
-   */
   public async writeMetadata(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
     const pipedRep = await this.validator.handleSafe({
       representation: new BasicRepresentation(serializeQuads(metadata.quads()), metadata),
       identifier,
     });
-    // Draining the validated stream triggers the quota guard, which errors when quota would be exceeded.
+    // Validation only happens while the stream is being consumed, so it has to be drained fully.
     await readableToString(pipedRep.data);
     return this.accessor.writeMetadata(identifier, metadata);
   }

--- a/src/storage/accessors/ValidatingDataAccessor.ts
+++ b/src/storage/accessors/ValidatingDataAccessor.ts
@@ -4,6 +4,8 @@ import { BasicRepresentation } from '../../http/representation/BasicRepresentati
 import type { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import type { Guarded } from '../../util/GuardedStream';
+import { serializeQuads } from '../../util/QuadUtil';
+import { readableToString } from '../../util/StreamUtil';
 import type { DataAccessor } from './DataAccessor';
 import { PassthroughDataAccessor } from './PassthroughDataAccessor';
 
@@ -36,5 +38,26 @@ export class ValidatingDataAccessor extends PassthroughDataAccessor {
     // of which we can't calculate the disk size of at this point in the code.
     // Extra info can be found here: https://github.com/CommunitySolidServer/CommunitySolidServer/pull/973#discussion_r723376888
     return this.accessor.writeContainer(identifier, metadata);
+  }
+
+  /**
+   * Metadata (`.meta` sidecars) is persisted as a serialized stream of quads.
+   * Without this override the write would bypass the validator entirely, letting a large metadata
+   * document exceed the configured quota. The serialized metadata is therefore run through the same
+   * validator used for documents so its size counts against the quota. Because the wrapped accessor
+   * re-serializes the metadata itself, the validated stream is fully consumed here purely to drive the
+   * quota guard, which rejects (413) when the write would exceed the available space.
+   *
+   * When quota is not configured this accessor is not instantiated, so this method is never invoked
+   * and metadata writes keep their original behavior.
+   */
+  public async writeMetadata(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
+    const pipedRep = await this.validator.handleSafe({
+      representation: new BasicRepresentation(serializeQuads(metadata.quads()), metadata),
+      identifier,
+    });
+    // Draining the validated stream triggers the quota guard, which errors when quota would be exceeded.
+    await readableToString(pipedRep.data);
+    return this.accessor.writeMetadata(identifier, metadata);
   }
 }

--- a/test/unit/storage/accessors/ValidatingDataAccessor.test.ts
+++ b/test/unit/storage/accessors/ValidatingDataAccessor.test.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import type { Validator, ValidatorInput } from '../../../../src/http/auxiliary/Validator';
 import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
 import type { Representation } from '../../../../src/http/representation/Representation';
@@ -22,6 +23,7 @@ describe('ValidatingDataAccessor', (): void => {
       getChildren: jest.fn(),
       writeDocument: jest.fn(),
       writeContainer: jest.fn(),
+      writeMetadata: jest.fn(),
     } as any;
     validator = {
       handleSafe: jest.fn(async(input: ValidatorInput): Promise<Representation> => input.representation),
@@ -51,6 +53,34 @@ describe('ValidatingDataAccessor', (): void => {
       await validatingAccessor.writeContainer(mockIdentifier, mockMetadata);
       expect(childAccessor.writeContainer).toHaveBeenCalledTimes(1);
       expect(childAccessor.writeContainer).toHaveBeenCalledWith(mockIdentifier, mockMetadata);
+    });
+  });
+
+  describe('writeMetadata()', (): void => {
+    it('should validate the serialized metadata against the quota.', async(): Promise<void> => {
+      await validatingAccessor.writeMetadata(mockIdentifier, mockMetadata);
+      expect(validator.handleSafe).toHaveBeenCalledTimes(1);
+      // The data stream is a freshly serialized copy of the metadata quads, so only assert the parts we control.
+      expect(validator.handleSafe).toHaveBeenCalledWith(expect.objectContaining({
+        identifier: mockIdentifier,
+        representation: expect.objectContaining({ metadata: mockMetadata }),
+      }));
+    });
+
+    it('should call the accessors writeMetadata() function when validation passes.', async(): Promise<void> => {
+      await validatingAccessor.writeMetadata(mockIdentifier, mockMetadata);
+      expect(childAccessor.writeMetadata).toHaveBeenCalledTimes(1);
+      expect(childAccessor.writeMetadata).toHaveBeenCalledWith(mockIdentifier, mockMetadata);
+    });
+
+    it('should reject and not write the metadata when the quota is exceeded.', async(): Promise<void> => {
+      validator.handleSafe.mockResolvedValueOnce(new BasicRepresentation(new Readable({
+        read(this): void {
+          this.destroy(new Error('Quota exceeded'));
+        },
+      }), mockMetadata));
+      await expect(validatingAccessor.writeMetadata(mockIdentifier, mockMetadata)).rejects.toThrow('Quota exceeded');
+      expect(childAccessor.writeMetadata).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — an upstream issue still needs to be created before this is submitted to CommunitySolidServer (the upstream PR template requires one).

#### ✍️ Description

Metadata writes were not counted against storage quota: `ValidatingDataAccessor` validates `writeDocument`, but inherited `writeMetadata` unchanged from `PassthroughDataAccessor`, so a pod could exceed its quota by writing large metadata resources.

`ValidatingDataAccessor.writeMetadata` now serializes the metadata quads and runs them through the same validator that guards document writes, rejecting with a 413 when the write would exceed the available space. The wrapped accessor persists the metadata object itself, so the validated stream is drained purely to drive the size check. Quota is opt-in — this class is only instantiated by `config/storage/backend/quota/quota-file.json` — so servers without quota configured are unaffected.

Notes for reviewers:

- Sizing is conservative: metadata is measured as serialized N-Quads, a slight over-estimate of the trimmed `.meta` file the backend actually writes. It can therefore never under-count; making it exact would couple this class to backend internals, which seems not worth it for byte-scale differences on tiny documents.
- The pre-existing check-then-write race (two concurrent writes measured against the same pre-write snapshot can jointly exceed quota) is confirmed but deliberately not addressed here. A correct reserve-then-commit needs a quota-scope key (global vs. per-pod) that `QuotaStrategy` does not currently expose; reserving per resource path would miss same-pod writes, and a single global counter would wrongly couple separate pods. That fix is a focused follow-up (issue to be opened alongside the upstream submission).
- `QuotaStrategy.ts` is deliberately untouched to avoid conflicting with the already-open per-chunk-walk fix (#61).
- Regression tests extend the existing `ValidatingDataAccessor` unit test file: quota validated, written when under, rejected and not written when over. Full unit suite (with the 100% coverage gate) and `test/integration/Quota.test.ts` are green.

This is a backwards-compatible bug fix: **semver.patch**, targeting `main` (no interface, signature, or config-behaviour change).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
