### PR TITLE
fix: Bound the size of documents buffered for RDF validation

### DIFF
--- a/config/util/auxiliary/strategies/acl.json
+++ b/config/util/auxiliary/strategies/acl.json
@@ -7,8 +7,10 @@
       "@type": "ComposedAuxiliaryStrategy",
       "identifierStrategy": { "@id": "urn:solid-server:default:AclIdentifierStrategy" },
       "validator": {
+        "comment": "Rejects auxiliary documents larger than maxSize bytes before buffering them for RDF validation. Set to 0 to disable.",
         "@type": "RdfValidator",
-        "converter": { "@id": "urn:solid-server:default:RepresentationConverter" }
+        "converter": { "@id": "urn:solid-server:default:RepresentationConverter" },
+        "maxSize": 4194304
       },
       "ownAuthorization": true,
       "requiredInRoot": true

--- a/config/util/auxiliary/strategies/acr.json
+++ b/config/util/auxiliary/strategies/acr.json
@@ -7,8 +7,10 @@
       "@type": "ComposedAuxiliaryStrategy",
       "identifierStrategy": { "@id": "urn:solid-server:default:AcrIdentifierStrategy" },
       "validator": {
+        "comment": "Rejects auxiliary documents larger than maxSize bytes before buffering them for RDF validation. Set to 0 to disable.",
         "@type": "RdfValidator",
-        "converter": { "@id": "urn:solid-server:default:RepresentationConverter" }
+        "converter": { "@id": "urn:solid-server:default:RepresentationConverter" },
+        "maxSize": 4194304
       },
       "ownAuthorization": true,
       "requiredInRoot": true

--- a/src/http/auxiliary/RdfValidator.ts
+++ b/src/http/auxiliary/RdfValidator.ts
@@ -1,21 +1,45 @@
+import type { Readable, Transform } from 'node:stream';
 import arrayifyStream from 'arrayify-stream';
 import type { RepresentationConverter } from '../../storage/conversion/RepresentationConverter';
 import { INTERNAL_QUADS } from '../../util/ContentTypes';
+import { PayloadHttpError } from '../../util/errors/PayloadHttpError';
+import type { Guarded } from '../../util/GuardedStream';
 import { cloneRepresentation } from '../../util/ResourceUtil';
+import { transformSafely } from '../../util/StreamUtil';
 import type { Representation } from '../representation/Representation';
 import type { ValidatorInput } from './Validator';
 import { Validator } from './Validator';
 
 /**
+ * The default maximum number of bytes {@link RdfValidator} buffers while validating a document.
+ * Set very generously (several MiB) as ACL and shape documents are normally only a few KiB,
+ * so legitimate documents will never reach this value.
+ */
+export const DEFAULT_MAX_VALIDATION_SIZE = 4 * 1024 * 1024;
+
+/**
  * Validates a Representation by verifying if the data stream contains valid RDF data.
  * It does this by letting the stored RepresentationConverter convert the data.
+ *
+ * Validating RDF requires the entire graph, so the data stream is fully buffered in memory during validation.
+ * An oversized document is therefore an (authenticated) memory-based denial-of-service vector.
+ * To prevent this, the data stream is aborted with a 413 {@link PayloadHttpError}
+ * as soon as it exceeds `maxSize` bytes, before the whole document is buffered.
  */
 export class RdfValidator extends Validator {
   protected readonly converter: RepresentationConverter;
+  protected readonly maxSize: number;
 
-  public constructor(converter: RepresentationConverter) {
+  /**
+   * @param converter - Used to convert the data stream to RDF quads to verify it is valid.
+   * @param maxSize - The maximum number of bytes a document may contain before validation rejects it.
+   *                  Set to 0 (or a negative value) to disable the check and allow documents of unlimited size.
+   *                  Defaults to {@link DEFAULT_MAX_VALIDATION_SIZE}.
+   */
+  public constructor(converter: RepresentationConverter, maxSize = DEFAULT_MAX_VALIDATION_SIZE) {
     super();
     this.converter = converter;
+    this.maxSize = maxSize;
   }
 
   public async handle({ representation, identifier }: ValidatorInput): Promise<Representation> {
@@ -26,6 +50,12 @@ export class RdfValidator extends Validator {
     const preferences = { type: { [INTERNAL_QUADS]: 1 }};
     let result;
     try {
+      // Validating RDF needs the full graph, so `cloneRepresentation` below buffers the whole stream in memory.
+      // Guard against oversized documents by aborting the stream once it passes the configured limit,
+      // so a pathologically large document is rejected before it is fully buffered.
+      if (this.maxSize > 0) {
+        representation.data = this.guardSize(representation.data);
+      }
       // Creating new representation since converter might edit metadata
       const tempRepresentation = await cloneRepresentation(representation);
       result = await this.converter.handleSafe({
@@ -41,5 +71,28 @@ export class RdfValidator extends Validator {
     await arrayifyStream(result.data);
 
     return representation;
+  }
+
+  /**
+   * Wraps the given data stream so it errors with a 413 {@link PayloadHttpError}
+   * as soon as more than `maxSize` bytes have passed through it.
+   * The data itself is left unchanged, so documents that stay within the limit are unaffected.
+   *
+   * @param data - The data stream to guard.
+   *
+   * @returns A stream emitting the same data that aborts once the size limit is exceeded.
+   */
+  private guardSize(data: Guarded<Readable>): Guarded<Transform> {
+    const { maxSize } = this;
+    let size = 0;
+    return transformSafely<Buffer | string>(data, {
+      transform(this: Transform, chunk: Buffer | string): void {
+        size += Buffer.byteLength(chunk);
+        if (size > maxSize) {
+          throw new PayloadHttpError(`Data exceeds the maximum size of ${maxSize} bytes allowed for RDF validation.`);
+        }
+        this.push(chunk);
+      },
+    });
   }
 }

--- a/src/http/auxiliary/RdfValidator.ts
+++ b/src/http/auxiliary/RdfValidator.ts
@@ -12,8 +12,7 @@ import { Validator } from './Validator';
 
 /**
  * The default maximum number of bytes {@link RdfValidator} buffers while validating a document.
- * Set very generously (several MiB) as ACL and shape documents are normally only a few KiB,
- * so legitimate documents will never reach this value.
+ * ACL and shape documents are usually only a few KiB, so this leaves generous headroom.
  */
 export const DEFAULT_MAX_VALIDATION_SIZE = 4 * 1024 * 1024;
 
@@ -21,10 +20,8 @@ export const DEFAULT_MAX_VALIDATION_SIZE = 4 * 1024 * 1024;
  * Validates a Representation by verifying if the data stream contains valid RDF data.
  * It does this by letting the stored RepresentationConverter convert the data.
  *
- * Validating RDF requires the entire graph, so the data stream is fully buffered in memory during validation.
- * An oversized document is therefore an (authenticated) memory-based denial-of-service vector.
- * To prevent this, the data stream is aborted with a 413 {@link PayloadHttpError}
- * as soon as it exceeds `maxSize` bytes, before the whole document is buffered.
+ * Validation buffers the entire data stream in memory,
+ * so streams exceeding `maxSize` bytes are rejected with a 413 error before being fully buffered.
  */
 export class RdfValidator extends Validator {
   protected readonly converter: RepresentationConverter;
@@ -33,8 +30,7 @@ export class RdfValidator extends Validator {
   /**
    * @param converter - Used to convert the data stream to RDF quads to verify it is valid.
    * @param maxSize - The maximum number of bytes a document may contain before validation rejects it.
-   *                  Set to 0 (or a negative value) to disable the check and allow documents of unlimited size.
-   *                  Defaults to {@link DEFAULT_MAX_VALIDATION_SIZE}.
+   *                  0 or a negative value disables the check. Defaults to {@link DEFAULT_MAX_VALIDATION_SIZE}.
    */
   public constructor(converter: RepresentationConverter, maxSize = DEFAULT_MAX_VALIDATION_SIZE) {
     super();
@@ -50,9 +46,7 @@ export class RdfValidator extends Validator {
     const preferences = { type: { [INTERNAL_QUADS]: 1 }};
     let result;
     try {
-      // Validating RDF needs the full graph, so `cloneRepresentation` below buffers the whole stream in memory.
-      // Guard against oversized documents by aborting the stream once it passes the configured limit,
-      // so a pathologically large document is rejected before it is fully buffered.
+      // Reject oversized documents before cloneRepresentation buffers the entire stream in memory
       if (this.maxSize > 0) {
         representation.data = this.guardSize(representation.data);
       }
@@ -75,12 +69,9 @@ export class RdfValidator extends Validator {
 
   /**
    * Wraps the given data stream so it errors with a 413 {@link PayloadHttpError}
-   * as soon as more than `maxSize` bytes have passed through it.
-   * The data itself is left unchanged, so documents that stay within the limit are unaffected.
+   * once more than `maxSize` bytes have passed through it.
    *
    * @param data - The data stream to guard.
-   *
-   * @returns A stream emitting the same data that aborts once the size limit is exceeded.
    */
   private guardSize(data: Guarded<Readable>): Guarded<Transform> {
     const { maxSize } = this;

--- a/test/unit/http/auxiliary/RdfValidator.test.ts
+++ b/test/unit/http/auxiliary/RdfValidator.test.ts
@@ -54,7 +54,7 @@ describe('An RdfValidator', (): void => {
     validator = new RdfValidator(converter, 1024);
     const representation = new BasicRepresentation('a'.repeat(512), 'content/type');
     await expect(validator.handle({ representation, identifier })).resolves.toBeDefined();
-    // The under-cap document is still fully available afterwards.
+    // Make sure the data can still be streamed
     await expect(readableToString(representation.data)).resolves.toBe('a'.repeat(512));
     expect(handleSafe).toHaveBeenCalledTimes(1);
   });
@@ -65,16 +65,15 @@ describe('An RdfValidator', (): void => {
     const source = guardStream(new Readable({
       read(): void {
         emitted += 1;
-        // Would emit 1000 KiB in total if it were ever fully read.
+        // Would emit 1000 KiB in total if fully read
         this.push(emitted <= 1000 ? Buffer.alloc(1024, 0x61) : null);
       },
     }));
     const representation = new BasicRepresentation(source, 'content/type', true);
     validator = new RdfValidator(converter, 4096);
     await expect(validator.handle({ representation, identifier })).rejects.toThrow(PayloadHttpError);
-    // The converter is never invoked, proving the document was not buffered/converted in full.
     expect(handleSafe).not.toHaveBeenCalled();
-    // The stream was aborted long before all 1000 chunks were read.
+    // Make sure the stream was aborted before being fully read
     expect(emitted).toBeLessThan(1000);
     expect(representation.data.destroyed).toBe(true);
   });
@@ -83,7 +82,6 @@ describe('An RdfValidator', (): void => {
     const handleSafe = jest.spyOn(converter, 'handleSafe')
       .mockResolvedValue(new BasicRepresentation('transformedData', 'wrong/type'));
     validator = new RdfValidator(converter, 0);
-    // Far larger than the tests above reject, but accepted because the check is disabled.
     const representation = new BasicRepresentation('a'.repeat(100000), 'content/type');
     await expect(validator.handle({ representation, identifier })).resolves.toBeDefined();
     expect(handleSafe).toHaveBeenCalledTimes(1);

--- a/test/unit/http/auxiliary/RdfValidator.test.ts
+++ b/test/unit/http/auxiliary/RdfValidator.test.ts
@@ -1,7 +1,10 @@
+import { Readable } from 'node:stream';
 import { RdfValidator } from '../../../../src/http/auxiliary/RdfValidator';
 import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
 import type { ResourceIdentifier } from '../../../../src/http/representation/ResourceIdentifier';
 import type { RepresentationConverter } from '../../../../src/storage/conversion/RepresentationConverter';
+import { PayloadHttpError } from '../../../../src/util/errors/PayloadHttpError';
+import { guardStream } from '../../../../src/util/GuardedStream';
 import { readableToString } from '../../../../src/util/StreamUtil';
 import { StaticAsyncHandler } from '../../../util/StaticAsyncHandler';
 import 'jest-rdf';
@@ -43,5 +46,46 @@ describe('An RdfValidator', (): void => {
     await expect(validator.handle({ representation, identifier })).rejects.toThrow('bad data!');
     // Make sure the data on the readable has not been reset
     expect(representation.data.destroyed).toBe(true);
+  });
+
+  it('validates a document that stays within the maximum size.', async(): Promise<void> => {
+    const handleSafe = jest.spyOn(converter, 'handleSafe')
+      .mockResolvedValue(new BasicRepresentation('transformedData', 'wrong/type'));
+    validator = new RdfValidator(converter, 1024);
+    const representation = new BasicRepresentation('a'.repeat(512), 'content/type');
+    await expect(validator.handle({ representation, identifier })).resolves.toBeDefined();
+    // The under-cap document is still fully available afterwards.
+    await expect(readableToString(representation.data)).resolves.toBe('a'.repeat(512));
+    expect(handleSafe).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an oversized document before it is fully buffered.', async(): Promise<void> => {
+    const handleSafe = jest.spyOn(converter, 'handleSafe');
+    let emitted = 0;
+    const source = guardStream(new Readable({
+      read(): void {
+        emitted += 1;
+        // Would emit 1000 KiB in total if it were ever fully read.
+        this.push(emitted <= 1000 ? Buffer.alloc(1024, 0x61) : null);
+      },
+    }));
+    const representation = new BasicRepresentation(source, 'content/type', true);
+    validator = new RdfValidator(converter, 4096);
+    await expect(validator.handle({ representation, identifier })).rejects.toThrow(PayloadHttpError);
+    // The converter is never invoked, proving the document was not buffered/converted in full.
+    expect(handleSafe).not.toHaveBeenCalled();
+    // The stream was aborted long before all 1000 chunks were read.
+    expect(emitted).toBeLessThan(1000);
+    expect(representation.data.destroyed).toBe(true);
+  });
+
+  it('does not limit the size when maxSize is 0.', async(): Promise<void> => {
+    const handleSafe = jest.spyOn(converter, 'handleSafe')
+      .mockResolvedValue(new BasicRepresentation('transformedData', 'wrong/type'));
+    validator = new RdfValidator(converter, 0);
+    // Far larger than the tests above reject, but accepted because the check is disabled.
+    const representation = new BasicRepresentation('a'.repeat(100000), 'content/type');
+    await expect(validator.handle({ representation, identifier })).resolves.toBeDefined();
+    expect(handleSafe).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — an upstream issue still needs to be created before this is submitted to CommunitySolidServer (the PR template requires one).

#### ✍️ Description

`RdfValidator` buffers the entire document into memory with no bound: it calls `cloneRepresentation` (whose own documentation notes it loads the entire stream into memory), and it runs on write — before data is streamed to disk — for every `.acl`/`.acr`. Any client who can write an ACL to their own pod can therefore PUT an arbitrarily large `.acl`/`.acr` and force the server to buffer all of it. There is no upstream mitigation on this path: `RawBodyParser` does not limit body size, and quota is not applied to the ACL path (and defaults to unlimited anyway). Call chain: `DataAccessorBasedStore` (write) → `ComposedAuxiliaryStrategy.validate` → `RdfValidator.handle` → `cloneRepresentation` (`ResourceUtil.ts`).

RDF validation inherently needs the full graph, so streaming validation is not an option; a size cap is the right tool. `RdfValidator` gains a `maxSize` parameter (default 4 MiB via the exported `DEFAULT_MAX_VALIDATION_SIZE`): the data stream is piped through a byte-counting transform that errors with a 413 as soon as the count exceeds the cap — before `cloneRepresentation` collects the document and before the converter runs. The guard only counts and forwards chunks, so under-cap documents pass through byte-identically and still validate; the `internal/quads` fast path (which never buffers) is untouched. `maxSize: 0` (or a negative value) disables the check, restoring today's behaviour.

The 4 MiB default is deliberately generous — ACL and shape documents are normally a few KiB, so this is roughly 1000× headroom and no legitimate document is affected. The `.acl` and `.acr` strategy configs wire the value explicitly.

No wall-clock benchmark applies; the reproducible evidence is the unit test, which streams 1000 × 1 KiB chunks through a 4 KiB cap and asserts the 413 fires after only a few chunks, the converter is never invoked, and the source stream is destroyed.

Complements the fork's #54, which caps request bodies at parse time; this bounds the separate validation-buffering path for auxiliary resources.

Intended semver level, stated in prose since contributors cannot set labels: **semver.minor** (a new optional constructor parameter and exported constant; **semver.major** if the new default cap counts as a config-behaviour change — maintainer's call). As a non-patch change, the upstream submission should target the latest `versions/*` branch (currently `versions/next-major`) rather than `main`.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
