### PR TITLE
feat: Support restricting OIDC dynamic client registration (opt-in)

### DIFF
--- a/config/identity/handler/base/provider-factory-restricted-registration.json
+++ b/config/identity/handler/base/provider-factory-restricted-registration.json
@@ -1,11 +1,9 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
-  "import": [
-    "css:config/identity/handler/base/provider-factory.json"
-  ],
   "@graph": [
     {
       "comment": [
+        "USAGE: import this ADDITIONALLY, after a config that already provides the identity handler (e.g. @css:config/file.json) \u2014 do NOT also rely on this file to declare the base provider factory. It only contributes the Override; the base IdentityProviderFactory must be declared by your main config (importing it twice causes a Components.js 'multiple values' error).",
         "OPT-IN HARDENING. Importing this file does NOT change any default: it overrides the OIDC provider config of the already-declared IdentityProviderFactory so that dynamic client registration (RFC 7591, POST /.oidc/reg) requires a valid initial access token as a bearer token.",
         "WHY: with the default (open) registration anyone can POST /.oidc/reg and persist a client unauthenticated, which is a storage-growth spam vector.",
         "TRADE-OFF: many Solid apps register dynamically, so requiring a token (or disabling registration) can break clients that rely on open dynamic registration. Only import this if you understand your client population and have a way to hand out initial access tokens. This is why the server keeps open registration as the default and this restriction is opt-in.",
@@ -13,18 +11,29 @@
         "MAINTENANCE: an Override replaces the whole `config` object, so this block is a copy of provider-factory.json's `config` with ONLY `features.registration.initialAccessToken` added. Keep every other value in sync with provider-factory.json."
       ],
       "@type": "Override",
-      "overrideInstance": { "@id": "urn:solid-server:default:IdentityProviderFactory" },
+      "overrideInstance": {
+        "@id": "urn:solid-server:default:IdentityProviderFactory"
+      },
       "overrideParameters": {
         "@type": "IdentityProviderFactory",
         "config": {
           "claims": {
-            "openid": [ "azp" ],
-            "webid": [ "webid" ]
+            "openid": [
+              "azp"
+            ],
+            "webid": [
+              "webid"
+            ]
           },
           "clockTolerance": 120,
           "cookies": {
-            "long": { "signed": true, "maxAge": 86400000 },
-            "short": { "signed": true }
+            "long": {
+              "signed": true,
+              "maxAge": 86400000
+            },
+            "short": {
+              "signed": true
+            }
           },
           "enabledJWA": {
             "dPoPSigningAlgValues": [
@@ -42,17 +51,41 @@
             ]
           },
           "features": {
-            "claimsParameter": { "enabled": true },
-            "clientCredentials": { "enabled": true },
-            "devInteractions": { "enabled": false },
-            "dPoP": { "enabled": true },
-            "introspection": { "enabled": true },
-            "registration": { "enabled": true, "initialAccessToken": true },
-            "revocation": { "enabled": true },
-            "userinfo": { "enabled": false }
+            "claimsParameter": {
+              "enabled": true
+            },
+            "clientCredentials": {
+              "enabled": true
+            },
+            "devInteractions": {
+              "enabled": false
+            },
+            "dPoP": {
+              "enabled": true
+            },
+            "introspection": {
+              "enabled": true
+            },
+            "registration": {
+              "enabled": true,
+              "initialAccessToken": true
+            },
+            "revocation": {
+              "enabled": true
+            },
+            "userinfo": {
+              "enabled": false
+            }
           },
-          "scopes": [ "openid", "profile", "offline_access", "webid" ],
-          "subjectTypes": [ "public" ],
+          "scopes": [
+            "openid",
+            "profile",
+            "offline_access",
+            "webid"
+          ],
+          "subjectTypes": [
+            "public"
+          ],
           "ttl": {
             "AccessToken": 3600,
             "AuthorizationCode": 600,

--- a/config/identity/handler/base/provider-factory-restricted-registration.json
+++ b/config/identity/handler/base/provider-factory-restricted-registration.json
@@ -3,12 +3,10 @@
   "@graph": [
     {
       "comment": [
-        "USAGE: import this ADDITIONALLY, after a config that already provides the identity handler (e.g. @css:config/file.json) \u2014 do NOT also rely on this file to declare the base provider factory. It only contributes the Override; the base IdentityProviderFactory must be declared by your main config (importing it twice causes a Components.js 'multiple values' error).",
-        "OPT-IN HARDENING. Importing this file does NOT change any default: it overrides the OIDC provider config of the already-declared IdentityProviderFactory so that dynamic client registration (RFC 7591, POST /.oidc/reg) requires a valid initial access token as a bearer token.",
-        "WHY: with the default (open) registration anyone can POST /.oidc/reg and persist a client unauthenticated, which is a storage-growth spam vector.",
-        "TRADE-OFF: many Solid apps register dynamically, so requiring a token (or disabling registration) can break clients that rely on open dynamic registration. Only import this if you understand your client population and have a way to hand out initial access tokens. This is why the server keeps open registration as the default and this restriction is opt-in.",
-        "TO FULLY DISABLE INSTEAD: in the copied `config` below, replace `\"registration\": { \"enabled\": true, \"initialAccessToken\": true }` with `\"registration\": { \"enabled\": false }` (more disruptive; the endpoint returns 404).",
-        "MAINTENANCE: an Override replaces the whole `config` object, so this block is a copy of provider-factory.json's `config` with ONLY `features.registration.initialAccessToken` added. Keep every other value in sync with provider-factory.json."
+        "Overrides the OIDC provider configuration so that dynamic client registration (POST /.oidc/reg) requires a valid initial access token.",
+        "Import this in addition to a configuration that already declares the IdentityProviderFactory, such as one of the default server configurations.",
+        "Many Solid apps rely on open dynamic registration, so see the identity-provider documentation for the trade-offs and alternatives.",
+        "The config below is a copy of the one in provider-factory.json with only the registration feature changed; keep the other values in sync with that file."
       ],
       "@type": "Override",
       "overrideInstance": {

--- a/config/identity/handler/base/provider-factory-restricted-registration.json
+++ b/config/identity/handler/base/provider-factory-restricted-registration.json
@@ -1,0 +1,72 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "import": [
+    "css:config/identity/handler/base/provider-factory.json"
+  ],
+  "@graph": [
+    {
+      "comment": [
+        "OPT-IN HARDENING. Importing this file does NOT change any default: it overrides the OIDC provider config of the already-declared IdentityProviderFactory so that dynamic client registration (RFC 7591, POST /.oidc/reg) requires a valid initial access token as a bearer token.",
+        "WHY: with the default (open) registration anyone can POST /.oidc/reg and persist a client unauthenticated, which is a storage-growth spam vector.",
+        "TRADE-OFF: many Solid apps register dynamically, so requiring a token (or disabling registration) can break clients that rely on open dynamic registration. Only import this if you understand your client population and have a way to hand out initial access tokens. This is why the server keeps open registration as the default and this restriction is opt-in.",
+        "TO FULLY DISABLE INSTEAD: in the copied `config` below, replace `\"registration\": { \"enabled\": true, \"initialAccessToken\": true }` with `\"registration\": { \"enabled\": false }` (more disruptive; the endpoint returns 404).",
+        "MAINTENANCE: an Override replaces the whole `config` object, so this block is a copy of provider-factory.json's `config` with ONLY `features.registration.initialAccessToken` added. Keep every other value in sync with provider-factory.json."
+      ],
+      "@type": "Override",
+      "overrideInstance": { "@id": "urn:solid-server:default:IdentityProviderFactory" },
+      "overrideParameters": {
+        "@type": "IdentityProviderFactory",
+        "config": {
+          "claims": {
+            "openid": [ "azp" ],
+            "webid": [ "webid" ]
+          },
+          "clockTolerance": 120,
+          "cookies": {
+            "long": { "signed": true, "maxAge": 86400000 },
+            "short": { "signed": true }
+          },
+          "enabledJWA": {
+            "dPoPSigningAlgValues": [
+              "RS256",
+              "RS384",
+              "RS512",
+              "PS256",
+              "PS384",
+              "PS512",
+              "ES256",
+              "ES256K",
+              "ES384",
+              "ES512",
+              "EdDSA"
+            ]
+          },
+          "features": {
+            "claimsParameter": { "enabled": true },
+            "clientCredentials": { "enabled": true },
+            "devInteractions": { "enabled": false },
+            "dPoP": { "enabled": true },
+            "introspection": { "enabled": true },
+            "registration": { "enabled": true, "initialAccessToken": true },
+            "revocation": { "enabled": true },
+            "userinfo": { "enabled": false }
+          },
+          "scopes": [ "openid", "profile", "offline_access", "webid" ],
+          "subjectTypes": [ "public" ],
+          "ttl": {
+            "AccessToken": 3600,
+            "AuthorizationCode": 600,
+            "BackchannelAuthenticationRequest": 600,
+            "ClientCredentials": 600,
+            "DeviceCode": 600,
+            "Grant": 1209600,
+            "IdToken": 3600,
+            "Interaction": 3600,
+            "RefreshToken": 86400,
+            "Session": 1209600
+          }
+        }
+      }
+    }
+  ]
+}

--- a/documentation/markdown/usage/identity-provider.md
+++ b/documentation/markdown/usage/identity-provider.md
@@ -140,6 +140,47 @@ to have a custom Components.js configuration for their own pod.
 When using such a configuration, a JSON file will be written containing all the information of the user pods,
 so they can be recreated when the server restarts.
 
+### Restricting dynamic client registration
+
+Solid-OIDC clients authenticate primarily through
+[Client ID Documents](https://solid.github.io/solid-oidc/#clientids-document),
+but the server also enables
+[OpenID Dynamic Client Registration](https://openid.net/specs/openid-connect-registration-1_0.html)
+([RFC 7591](https://www.rfc-editor.org/rfc/rfc7591.html)) on `POST /.oidc/reg`,
+which many Solid apps rely on to register on the fly.
+For that reason registration is **open by default and stays that way**:
+changing the default could break those clients.
+
+Open registration does have a downside: anyone can `POST /.oidc/reg` and persist a client without authenticating,
+which is a storage-growth spam vector.
+If you understand your client population and want to harden the server against this,
+you can *opt in* to requiring an
+[initial access token](https://openid.net/specs/openid-connect-registration-1_0.html#Terminology)
+by adding the following import to your configuration:
+
+```json
+"css:config/identity/handler/base/provider-factory-restricted-registration.json"
+```
+
+This overrides only the OIDC provider configuration so that `POST /.oidc/reg`
+requires a valid initial access token as a bearer token; every other default is left untouched.
+It sets `features.registration.initialAccessToken` to `true`, meaning the server accepts
+adapter-backed initial access tokens that you mint yourself, for example:
+
+```js
+new (provider.InitialAccessToken)({}).save().then(console.log);
+```
+
+Alternatively, you can edit the imported file to use a single fixed secret instead of minting tokens
+by replacing `"initialAccessToken": true` with `"initialAccessToken": "<your-secret-token>"`,
+or fully disable dynamic registration by replacing the registration entry with `{ "enabled": false }`
+(which makes the endpoint return a 404).
+
+**Trade-off:** requiring a token or disabling registration can break Solid clients
+that depend on open dynamic registration, so only enable this if you can hand out tokens to
+(or otherwise pre-register) the clients that need them.
+When in doubt, keep the default open registration.
+
 ## Adding a new login method to the server
 
 Due to its modular nature,

--- a/test/unit/identity/configuration/ProviderFactoryRestrictedRegistration.test.ts
+++ b/test/unit/identity/configuration/ProviderFactoryRestrictedRegistration.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { getPresetConfigPath } from '../../../integration/Config';
+
+/**
+ * These tests guard the opt-in registration-hardening config against drift.
+ * The default provider factory config MUST keep dynamic client registration open,
+ * and the opt-in overlay MUST differ from it in exactly one way: requiring an initial access token.
+ */
+
+interface ProviderConfig {
+  features: { registration: Record<string, unknown> };
+  [key: string]: unknown;
+}
+
+function readConfig(configFile: string): Record<string, any> {
+  return JSON.parse(readFileSync(getPresetConfigPath(configFile), 'utf8')) as Record<string, any>;
+}
+
+describe('The restricted registration provider factory config', (): void => {
+  const defaultConfig = readConfig('identity/handler/base/provider-factory.json');
+  const restrictedConfig = readConfig('identity/handler/base/provider-factory-restricted-registration.json');
+
+  const defaultProviderConfig = defaultConfig['@graph'][0].config as ProviderConfig;
+  const override = restrictedConfig['@graph'][0];
+  const restrictedProviderConfig = override.overrideParameters.config as ProviderConfig;
+
+  it('is an Override targeting the default IdentityProviderFactory instance.', (): void => {
+    expect(override['@type']).toBe('Override');
+    expect(override.overrideInstance['@id']).toBe('urn:solid-server:default:IdentityProviderFactory');
+    expect(override.overrideParameters['@type']).toBe('IdentityProviderFactory');
+  });
+
+  it('keeps registration open by default.', (): void => {
+    // This is the Solid client contract that must never change: registration enabled and unrestricted.
+    expect(defaultProviderConfig.features.registration).toEqual({ enabled: true });
+  });
+
+  it('only adds an initial access token requirement when opted in.', (): void => {
+    expect(restrictedProviderConfig.features.registration).toEqual({ enabled: true, initialAccessToken: true });
+  });
+
+  it('changes nothing else about the provider configuration.', (): void => {
+    // Everything apart from the registration feature must stay identical to the shipped default,
+    // so enabling the hardening never silently diverges from the other default OIDC settings.
+    const restrictedWithoutRegistration = structuredClone(restrictedProviderConfig);
+    restrictedWithoutRegistration.features.registration = defaultProviderConfig.features.registration;
+    expect(restrictedWithoutRegistration).toEqual(defaultProviderConfig);
+  });
+});

--- a/test/unit/identity/configuration/ProviderFactoryRestrictedRegistration.test.ts
+++ b/test/unit/identity/configuration/ProviderFactoryRestrictedRegistration.test.ts
@@ -1,12 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { getPresetConfigPath } from '../../../integration/Config';
 
-/**
- * These tests guard the opt-in registration-hardening config against drift.
- * The default provider factory config MUST keep dynamic client registration open,
- * and the opt-in overlay MUST differ from it in exactly one way: requiring an initial access token.
- */
-
 interface ProviderConfig {
   features: { registration: Record<string, unknown> };
   [key: string]: unknown;
@@ -31,7 +25,6 @@ describe('The restricted registration provider factory config', (): void => {
   });
 
   it('keeps registration open by default.', (): void => {
-    // This is the Solid client contract that must never change: registration enabled and unrestricted.
     expect(defaultProviderConfig.features.registration).toEqual({ enabled: true });
   });
 
@@ -40,8 +33,7 @@ describe('The restricted registration provider factory config', (): void => {
   });
 
   it('changes nothing else about the provider configuration.', (): void => {
-    // Everything apart from the registration feature must stay identical to the shipped default,
-    // so enabling the hardening never silently diverges from the other default OIDC settings.
+    // Neutralize the one intended difference, then require deep equality with the default.
     const restrictedWithoutRegistration = structuredClone(restrictedProviderConfig);
     restrictedWithoutRegistration.features.registration = defaultProviderConfig.features.registration;
     expect(restrictedWithoutRegistration).toEqual(defaultProviderConfig);


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the upstream template requires a related issue, so one needs to be created on CommunitySolidServer/CommunitySolidServer before this is submitted there.

#### ✍️ Description

OIDC dynamic client registration (`POST /.oidc/reg`) is enabled and open by default, so anyone can register and persist a client unauthenticated — a storage-growth spam vector. Since many Solid apps rely on dynamic registration to authenticate, the default must not change; this adds a strictly opt-in way to restrict it.

A new config, `config/identity/handler/base/provider-factory-restricted-registration.json`, contributes a Components.js `Override` that replaces the OIDC provider `config` of the already-declared `IdentityProviderFactory`, setting `features.registration` to `{ enabled: true, initialAccessToken: true }` — registration then requires a valid initial access token. Operators import it in addition to a base config; editing the copied block instead disables registration entirely (`{ "enabled": false }`). The trade-off (a token requirement can break clients that rely on open registration) is documented in a new `identity-provider.md` section.

Why a config-only `Override`: the `IdentityProviderFactory` `config` parameter is `range: rdf:JSON` (an opaque JSON literal), so overriding just the registration key is not expressible — an `Override` of the whole `config` is the intended tool, and it is CSS's own documented operator pattern (the `EmailSender` example in `identity-provider.md`; the `quota-*.json` test configs). `OverrideParameters` copies only the named property, so the factory's other constructor arguments are preserved from the base config. A TypeScript/constructor-argument route was rejected: it would need regenerated Components.js metadata, while the overlay keeps the change purely additive (no `src/` touched). The cost is that the overlay duplicates the default `config` block; a drift-guard test fails if the copy ever diverges from `provider-factory.json` in anything but the registration feature.

The default is provably unchanged: `provider-factory.json` is byte-for-byte untouched, and the drift-guard tests assert that the default keeps `registration: { enabled: true }` and that the overlay differs from it only in the token requirement. An earlier revision of the overlay also imported `provider-factory.json` itself; when a main config already imported the base (the intended usage), the double declaration caused a Components.js "multiple values" boot error, so the overlay now contributes only the `Override` and must be imported alongside a base config.

Verification: boot smoke with the default `config/file.json` → unauthenticated `POST /.oidc/reg` → `201` (registration stays open); with the overlay imported alongside it → the same request → `400 "no access token provided"`. `npm run build`, lint, and the full unit suite are green; there is no `src/` change, so no coverage delta.

Intended semver level: **semver.minor** (a backwards-compatible feature addition — a new supported config; the default is unchanged). Per the checklist below, a minor change should target the latest `versions/*` branch when submitted upstream (currently `versions/next-major`); this fork draft targets the fork's `main` for review only.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
