### PR TITLE
feat: Harden the account session cookie with HttpOnly and Secure flags

### DIFF
--- a/config/ldp/metadata-writer/writers/cookie.json
+++ b/config/ldp/metadata-writer/writers/cookie.json
@@ -5,6 +5,7 @@
       "comment": "Converts all triples with the given predicates to cookies.",
       "@id": "urn:solid-server:default:MetadataWriter_Cookie",
       "@type": "CookieMetadataWriter",
+      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
       "cookieMap": [
         {
           "CookieMetadataWriter:_cookieMap_key": "urn:npm:solid:community-server:http:accountCookie",

--- a/src/http/output/metadata/CookieMetadataWriter.ts
+++ b/src/http/output/metadata/CookieMetadataWriter.ts
@@ -17,8 +17,22 @@ import { MetadataWriter } from './MetadataWriter';
  */
 export class CookieMetadataWriter extends MetadataWriter {
   private readonly cookieMap: Map<NamedNode, { name: string; expirationUri?: NamedNode }>;
+  private readonly secure: boolean;
+  private readonly httpOnly: boolean;
 
-  public constructor(cookieMap: Record<string, { name: string; expirationUri?: string }>) {
+  /**
+   * @param cookieMap - A map linking metadata predicate URIs to cookie definitions.
+   * @param baseUrl - Base URL of the server. Used to enable the `Secure` flag when the server runs over `https`.
+   * @param secure - Explicitly enable/disable the `Secure` cookie flag.
+   *                 When undefined, the flag is derived from `baseUrl` (enabled for `https` deployments).
+   * @param httpOnly - Enable/disable the `HttpOnly` cookie flag. Defaults to `true`.
+   */
+  public constructor(
+    cookieMap: Record<string, { name: string; expirationUri?: string }>,
+    baseUrl?: string,
+    secure?: boolean,
+    httpOnly = true,
+  ) {
     super();
     this.cookieMap = new Map<NamedNode, { name: string; expirationUri?: NamedNode }>(Object.entries(cookieMap)
       .map(([ uri, { name, expirationUri }]): [ NamedNode, { name: string; expirationUri?: NamedNode } ] =>
@@ -29,6 +43,10 @@ export class CookieMetadataWriter extends MetadataWriter {
             expirationUri: expirationUri ? DataFactory.namedNode(expirationUri) : undefined,
           },
         ]));
+    // Only enable the `Secure` flag when the server is behind `https`,
+    // as an `https`-only cookie would never be sent to an `http` deployment.
+    this.secure = secure ?? Boolean(baseUrl?.startsWith('https:'));
+    this.httpOnly = httpOnly;
   }
 
   public async handle(input: { response: HttpResponse; metadata: RepresentationMetadata }): Promise<void> {
@@ -38,12 +56,22 @@ export class CookieMetadataWriter extends MetadataWriter {
       if (value) {
         const expiration = expirationUri && metadata.get(expirationUri)?.value;
         const expires = typeof expiration === 'string' ? new Date(expiration) : undefined;
-        // Not setting secure flag since not all tools realize those cookies are also valid for http://localhost.
-        // Not setting the httpOnly flag as that would prevent JS API access.
+        // `HttpOnly` prevents client-side JavaScript from reading the cookie, mitigating session theft via XSS.
+        // This is safe because the account UI never reads the cookie through `document.cookie`;
+        // the browser attaches it automatically, and the JSON API also returns the value in an `authorization`
+        // field for use as a `CSS-Account-Token` header.
+        // `Secure` restricts the cookie to `https`; it is only enabled when the server runs over `https`,
+        // since an `https`-only cookie would never be sent to an `http` deployment (breaking login there).
         // SameSite: Lax makes it so the cookie gets sent if the origin is the server,
         // or if the browser navigates there from another site.
         // Setting the path to `/` so it applies to the entire server.
-        addHeader(response, 'Set-Cookie', serialize(name, value, { path: '/', sameSite: 'lax', expires }));
+        addHeader(response, 'Set-Cookie', serialize(name, value, {
+          path: '/',
+          sameSite: 'lax',
+          expires,
+          httpOnly: this.httpOnly,
+          secure: this.secure,
+        }));
       }
     }
   }

--- a/src/http/output/metadata/CookieMetadataWriter.ts
+++ b/src/http/output/metadata/CookieMetadataWriter.ts
@@ -22,9 +22,9 @@ export class CookieMetadataWriter extends MetadataWriter {
 
   /**
    * @param cookieMap - A map linking metadata predicate URIs to cookie definitions.
-   * @param baseUrl - Base URL of the server. Used to enable the `Secure` flag when the server runs over `https`.
-   * @param secure - Explicitly enable/disable the `Secure` cookie flag.
-   *                 When undefined, the flag is derived from `baseUrl` (enabled for `https` deployments).
+   * @param baseUrl - Base URL of the server.
+   * @param secure - Enable/disable the `Secure` cookie flag.
+   *                 Defaults to `true` when the `baseUrl` scheme is `https`.
    * @param httpOnly - Enable/disable the `HttpOnly` cookie flag. Defaults to `true`.
    */
   public constructor(
@@ -43,8 +43,6 @@ export class CookieMetadataWriter extends MetadataWriter {
             expirationUri: expirationUri ? DataFactory.namedNode(expirationUri) : undefined,
           },
         ]));
-    // Only enable the `Secure` flag when the server is behind `https`,
-    // as an `https`-only cookie would never be sent to an `http` deployment.
     this.secure = secure ?? Boolean(baseUrl?.startsWith('https:'));
     this.httpOnly = httpOnly;
   }
@@ -56,12 +54,6 @@ export class CookieMetadataWriter extends MetadataWriter {
       if (value) {
         const expiration = expirationUri && metadata.get(expirationUri)?.value;
         const expires = typeof expiration === 'string' ? new Date(expiration) : undefined;
-        // `HttpOnly` prevents client-side JavaScript from reading the cookie, mitigating session theft via XSS.
-        // This is safe because the account UI never reads the cookie through `document.cookie`;
-        // the browser attaches it automatically, and the JSON API also returns the value in an `authorization`
-        // field for use as a `CSS-Account-Token` header.
-        // `Secure` restricts the cookie to `https`; it is only enabled when the server runs over `https`,
-        // since an `https`-only cookie would never be sent to an `http` deployment (breaking login there).
         // SameSite: Lax makes it so the cookie gets sent if the origin is the server,
         // or if the browser navigates there from another site.
         // Setting the path to `/` so it applies to the entire server.

--- a/test/unit/http/output/metadata/CookieMetadataWriter.test.ts
+++ b/test/unit/http/output/metadata/CookieMetadataWriter.test.ts
@@ -7,10 +7,10 @@ import namedNode = DataFactory.namedNode;
 import literal = DataFactory.literal;
 
 describe('A CookieMetadataWriter', (): void => {
-  const writer = new CookieMetadataWriter({
+  const cookieMap = {
     'http://example.com/pred1': { name: 'custom1' },
     'http://example.com/pred2': { name: 'custom2', expirationUri: 'http://example.com/pred2expiration' },
-  });
+  };
   let metadata: RepresentationMetadata;
   let response: HttpResponse;
 
@@ -19,21 +19,85 @@ describe('A CookieMetadataWriter', (): void => {
     response = createResponse() as HttpResponse;
   });
 
-  it('adds no headers if there is no relevant metadata.', async(): Promise<void> => {
-    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
-    expect(response.getHeaders()).toEqual({});
-  });
-
-  it('adds the relevant set-cookie headers.', async(): Promise<void> => {
+  // Adds all cookie predicates, including an expiration date for the second cookie.
+  function addCookieMetadata(): void {
     const date = new Date('2015-10-21T07:28:00.000Z');
     metadata.add(namedNode('http://example.com/pred1'), literal('my-value'));
     metadata.add(namedNode('http://example.com/pred2'), literal('other-value'));
     metadata.add(namedNode('http://example.com/pred2expiration'), literal(date.toISOString()));
     metadata.add(namedNode('http://example.com/unknown'), literal('unknown-value'));
+  }
+
+  it('adds no headers if there is no relevant metadata.', async(): Promise<void> => {
+    const writer = new CookieMetadataWriter(cookieMap);
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+    expect(response.getHeaders()).toEqual({});
+  });
+
+  it('adds the relevant set-cookie headers with the HttpOnly flag by default.', async(): Promise<void> => {
+    const writer = new CookieMetadataWriter(cookieMap);
+    addCookieMetadata();
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+    expect(response.getHeader('set-cookie')).toEqual([
+      'custom1=my-value; Path=/; HttpOnly; SameSite=Lax',
+      'custom2=other-value; Path=/; Expires=Wed, 21 Oct 2015 07:28:00 GMT; HttpOnly; SameSite=Lax',
+    ]);
+  });
+
+  it('does not set the Secure flag for an http base URL.', async(): Promise<void> => {
+    const writer = new CookieMetadataWriter(cookieMap, 'http://example.com/');
+    addCookieMetadata();
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+    expect(response.getHeader('set-cookie')).toEqual([
+      'custom1=my-value; Path=/; HttpOnly; SameSite=Lax',
+      'custom2=other-value; Path=/; Expires=Wed, 21 Oct 2015 07:28:00 GMT; HttpOnly; SameSite=Lax',
+    ]);
+  });
+
+  it('sets the Secure flag for an https base URL.', async(): Promise<void> => {
+    const writer = new CookieMetadataWriter(cookieMap, 'https://example.com/');
+    addCookieMetadata();
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+    expect(response.getHeader('set-cookie')).toEqual([
+      'custom1=my-value; Path=/; HttpOnly; Secure; SameSite=Lax',
+      'custom2=other-value; Path=/; Expires=Wed, 21 Oct 2015 07:28:00 GMT; HttpOnly; Secure; SameSite=Lax',
+    ]);
+  });
+
+  it('allows the Secure flag to be enabled explicitly on an http base URL.', async(): Promise<void> => {
+    const writer = new CookieMetadataWriter(cookieMap, 'http://example.com/', true);
+    addCookieMetadata();
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+    expect(response.getHeader('set-cookie')).toEqual([
+      'custom1=my-value; Path=/; HttpOnly; Secure; SameSite=Lax',
+      'custom2=other-value; Path=/; Expires=Wed, 21 Oct 2015 07:28:00 GMT; HttpOnly; Secure; SameSite=Lax',
+    ]);
+  });
+
+  it('allows the Secure flag to be disabled explicitly on an https base URL.', async(): Promise<void> => {
+    const writer = new CookieMetadataWriter(cookieMap, 'https://example.com/', false);
+    addCookieMetadata();
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+    expect(response.getHeader('set-cookie')).toEqual([
+      'custom1=my-value; Path=/; HttpOnly; SameSite=Lax',
+      'custom2=other-value; Path=/; Expires=Wed, 21 Oct 2015 07:28:00 GMT; HttpOnly; SameSite=Lax',
+    ]);
+  });
+
+  it('allows the HttpOnly flag to be disabled.', async(): Promise<void> => {
+    const writer = new CookieMetadataWriter(cookieMap, undefined, undefined, false);
+    addCookieMetadata();
     await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
     expect(response.getHeader('set-cookie')).toEqual([
       'custom1=my-value; Path=/; SameSite=Lax',
       'custom2=other-value; Path=/; Expires=Wed, 21 Oct 2015 07:28:00 GMT; SameSite=Lax',
     ]);
+  });
+
+  it('creates a session cookie when the expiration value is missing.', async(): Promise<void> => {
+    const writer = new CookieMetadataWriter(cookieMap);
+    metadata.add(namedNode('http://example.com/pred2'), literal('other-value'));
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+    expect(response.getHeader('set-cookie')).toBe('custom2=other-value; Path=/; HttpOnly; SameSite=Lax');
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — an upstream issue must be created before this is submitted to CommunitySolidServer (the PR template requires one).

#### ✍️ Description

The `css-account` session cookie is serialized with only `{ path: '/', sameSite: 'lax', expires }` — no `HttpOnly` and no `Secure` — so it can be read by any script running on the page (session theft via XSS) and is sent over plain http. This adds both flags to `CookieMetadataWriter`: `HttpOnly` on by default, and `Secure` derived from the server `baseUrl` scheme (on for `https`, off for `http`), each overridable through a new constructor parameter.

`HttpOnly` is safe to enable by default because no client-side code reads this cookie: a repo-wide search for `document.cookie` has zero hits. The account UI (`templates/scripts/util.js`) is entirely `fetch`-based — the browser attaches the cookie automatically — and the JSON API returns the token value in the login response body (the `authorization` field, used as a `CSS-Account-Token` header), never via `document.cookie`. The pre-existing comment claiming `HttpOnly` would block JS API access did not match how the account UI works.

`Secure` is deliberately conditional rather than unconditional: an unconditional `Secure` would break login on http deployments (including `http://localhost`), since the browser would never send the cookie. Deriving it from `baseUrl` gives https deployments the flag automatically while an http deployment's `Set-Cookie` header stays identical to before apart from the added `; HttpOnly` (the `cookie` library only appends flags when truthy). `SameSite=Lax` is kept unchanged — tightening to `strict` could break OIDC redirect flows.

Verified beyond the unit tests by booting `config/file.json` (http baseUrl): after a password login the response is `Set-Cookie: css-account=...; Path=/; HttpOnly; SameSite=Lax` — `HttpOnly` present, `Secure` correctly absent on http, and login succeeds, confirming the fetch-based account UI is unaffected. The unit tests cover the `HttpOnly` default, the http/https `Secure` derivation, both explicit `Secure` overrides, disabling `HttpOnly`, and the session-cookie (no expiration) path.

Intended semver level: **minor** (backwards-compatible additions — optional constructor parameters and hardened defaults); note the changed default `Set-Cookie` output is a behaviour change a maintainer may prefer to treat as major. Because it changes a constructor signature and default config behaviour, the upstream submission should target the latest `versions/*` branch (`versions/next-major`), not `main`.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
