### PR TITLE
fix: Do not wipe peer instances' Redis locks on boot

### DIFF
--- a/config/util/resource-locker/redis.json
+++ b/config/util/resource-locker/redis.json
@@ -16,7 +16,7 @@
       "@type": "SequenceHandler",
       "handlers": [
         {
-          "comment": "Lets the RedisLocker run its boot-time hook. By default it keeps existing locks so instances sharing a namespace (HA) are not disturbed; set the locker's clearLocksOnStart to true for a single instance that should wipe stale locks on boot.",
+          "comment": "Makes sure the RedisLocker starts with a clean slate when the application is started, if clearLocksOnStart is enabled.",
           "@type": "InitializableHandler",
           "initializable": { "@id": "urn:solid-server:default:RedisLocker" }
         }

--- a/config/util/resource-locker/redis.json
+++ b/config/util/resource-locker/redis.json
@@ -16,7 +16,7 @@
       "@type": "SequenceHandler",
       "handlers": [
         {
-          "comment": "Makes sure the RedisLocker starts with a clean slate when the application is started.",
+          "comment": "Lets the RedisLocker run its boot-time hook. By default it keeps existing locks so instances sharing a namespace (HA) are not disturbed; set the locker's clearLocksOnStart to true for a single instance that should wipe stale locks on boot.",
           "@type": "InitializableHandler",
           "initializable": { "@id": "urn:solid-server:default:RedisLocker" }
         }

--- a/src/util/locking/RedisLocker.ts
+++ b/src/util/locking/RedisLocker.ts
@@ -45,16 +45,10 @@ export interface RedisSettings {
    */
   ttl?: number;
   /**
-   * Whether to delete every lock in this namespace when the locker starts (see {@link RedisLocker.initialize}).
-   *
-   * This is only safe when a single instance exclusively owns the Redis namespace: it lets that
-   * instance recover from locks left behind by a previous crashed run. When multiple instances share
-   * a namespace (the setup required for HA coordination) a restarting instance cannot tell its own
-   * stale locks from the live locks of its peers, so wiping the namespace on boot would corrupt peers
-   * that still hold those locks. Because a crashed holder's lock now auto-expires through its TTL lease
-   * (see {@link RedisSettings.ttl}), boot-time clearing is no longer needed for correctness, so this
-   * defaults to `false` (multi-instance-safe). Set it to `true` for a single-instance deployment that
-   * prefers stale locks cleared immediately on boot rather than waiting for the TTL to elapse.
+   * Whether to delete every lock in this namespace when the locker starts.
+   * Only safe when a single instance exclusively owns the namespace: instances sharing a namespace
+   * cannot tell their own stale locks from the live locks of their peers.
+   * Defaults to `false`; a crashed holder's locks expire through their TTL instead.
    */
   clearLocksOnStart?: boolean;
 }
@@ -118,7 +112,6 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     this.attemptSettings = { ...attemptDefaults, ...attemptSettings };
     this.namespacePrefix = namespacePrefix!;
     this.ttl = ttl ?? DEFAULT_TTL;
-    // Default to NOT wiping the namespace on boot so peers sharing it (HA) are never disturbed.
     this.clearLocksOnStart = clearLocksOnStart ?? false;
     // Renew at half the TTL so a live holder refreshes its lock long before it could expire.
     this.renewalInterval = Math.max(1, Math.floor(this.ttl / 2));
@@ -317,15 +310,10 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
 
   public async initialize(): Promise<void> {
     if (!this.clearLocksOnStart) {
-      // Multiple instances may share this namespace to coordinate (HA). This instance cannot tell its
-      // own stale locks from the live locks of its peers, so it must NOT wipe the namespace on boot:
-      // deleting a peer's held lock would open a corruption window. A crashed holder's lock instead
-      // self-heals via its TTL lease. Single-instance deployments can opt back in via `clearLocksOnStart`.
       this.logger.debug('Skipping boot-time lock cleanup; relying on lock TTLs (clearLocksOnStart is disabled).');
       return;
     }
-    // On server start (single-instance only): remove all existing (dangling) locks left behind by a
-    // previous crashed run, so new requests are not blocked while waiting for those locks' TTLs.
+    // On server start: remove all existing (dangling) locks, so new requests are not blocked.
     return this.clearLocks();
   }
 

--- a/src/util/locking/RedisLocker.ts
+++ b/src/util/locking/RedisLocker.ts
@@ -44,6 +44,19 @@ export interface RedisSettings {
    * the in-process lock expiration. Defaults to {@link DEFAULT_TTL} (30000ms).
    */
   ttl?: number;
+  /**
+   * Whether to delete every lock in this namespace when the locker starts (see {@link RedisLocker.initialize}).
+   *
+   * This is only safe when a single instance exclusively owns the Redis namespace: it lets that
+   * instance recover from locks left behind by a previous crashed run. When multiple instances share
+   * a namespace (the setup required for HA coordination) a restarting instance cannot tell its own
+   * stale locks from the live locks of its peers, so wiping the namespace on boot would corrupt peers
+   * that still hold those locks. Because a crashed holder's lock now auto-expires through its TTL lease
+   * (see {@link RedisSettings.ttl}), boot-time clearing is no longer needed for correctness, so this
+   * defaults to `false` (multi-instance-safe). Set it to `true` for a single-instance deployment that
+   * prefers stale locks cleared immediately on boot rather than waiting for the TTL to elapse.
+   */
+  clearLocksOnStart?: boolean;
 }
 
 /**
@@ -82,6 +95,7 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   private readonly attemptSettings: Required<AttemptSettings>;
   private readonly namespacePrefix: string;
   private readonly ttl: number;
+  private readonly clearLocksOnStart: boolean;
   private readonly renewalInterval: number;
   private readonly renewalTimers = new Map<string, NodeJS.Timeout>();
   private finalized = false;
@@ -99,11 +113,13 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     redisSettings?: RedisSettings,
   ) {
     redisSettings = { namespacePrefix: '', ...redisSettings };
-    const { namespacePrefix, ttl, ...options } = redisSettings;
+    const { namespacePrefix, ttl, clearLocksOnStart, ...options } = redisSettings;
     this.redis = this.createRedisClient(redisClient, options);
     this.attemptSettings = { ...attemptDefaults, ...attemptSettings };
     this.namespacePrefix = namespacePrefix!;
     this.ttl = ttl ?? DEFAULT_TTL;
+    // Default to NOT wiping the namespace on boot so peers sharing it (HA) are never disturbed.
+    this.clearLocksOnStart = clearLocksOnStart ?? false;
     // Renew at half the TTL so a live holder refreshes its lock long before it could expire.
     this.renewalInterval = Math.max(1, Math.floor(this.ttl / 2));
 
@@ -122,7 +138,10 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
    * @param redisClientString - A string that contains either a host address and a
    *                            port number like '127.0.0.1:6379' or just a port number like '6379'.
    */
-  private createRedisClient(redisClientString: string, options: Omit<RedisSettings, 'namespacePrefix' | 'ttl'>): Redis {
+  private createRedisClient(
+    redisClientString: string,
+    options: Omit<RedisSettings, 'namespacePrefix' | 'ttl' | 'clearLocksOnStart'>,
+  ): Redis {
     if (redisClientString.length > 0) {
       // Check if port number or ip with port number
       // Definitely not perfect, but configuring this is only for experienced users
@@ -297,7 +316,16 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   /* Initializer & Finalizer methods */
 
   public async initialize(): Promise<void> {
-    // On server start: remove all existing (dangling) locks, so new requests are not blocked.
+    if (!this.clearLocksOnStart) {
+      // Multiple instances may share this namespace to coordinate (HA). This instance cannot tell its
+      // own stale locks from the live locks of its peers, so it must NOT wipe the namespace on boot:
+      // deleting a peer's held lock would open a corruption window. A crashed holder's lock instead
+      // self-heals via its TTL lease. Single-instance deployments can opt back in via `clearLocksOnStart`.
+      this.logger.debug('Skipping boot-time lock cleanup; relying on lock TTLs (clearLocksOnStart is disabled).');
+      return;
+    }
+    // On server start (single-instance only): remove all existing (dangling) locks left behind by a
+    // previous crashed run, so new requests are not blocked while waiting for those locks' TTLs.
     return this.clearLocks();
   }
 

--- a/src/util/locking/RedisLocker.ts
+++ b/src/util/locking/RedisLocker.ts
@@ -3,6 +3,7 @@ import type { ResourceIdentifier } from '../../http/representation/ResourceIdent
 import type { Finalizable } from '../../init/final/Finalizable';
 import type { Initializable } from '../../init/Initializable';
 import { getLoggerFor } from '../../logging/LogUtil';
+import { createErrorMessage } from '../errors/ErrorUtil';
 import type { AttemptSettings } from '../LockUtils';
 import { retryFunction } from '../LockUtils';
 import type { PromiseOrValue } from '../PromiseUtil';
@@ -17,6 +18,16 @@ const attemptDefaults: Required<AttemptSettings> = { retryCount: -1, retryDelay:
 const PREFIX_RW = '__RW__';
 const PREFIX_LOCK = '__L__';
 
+/**
+ * Default time-to-live (in ms) for a Redis lock key.
+ *
+ * A crashed lock holder's key auto-expires after this time so that other instances cannot deadlock
+ * on the abandoned resource. It is deliberately several times larger than the in-process lock
+ * expiration (see {@link WrappedExpiringReadWriteLocker}, 6000ms by default), and it is actively
+ * renewed while a lock is legitimately held, so a normal operation never loses its lock.
+ */
+const DEFAULT_TTL = 30000;
+
 export interface RedisSettings {
   /* Override default namespacePrefixes (used to prefix keys in Redis) */
   namespacePrefix?: string;
@@ -26,6 +37,13 @@ export interface RedisSettings {
   password?: string;
   /* The number of the database to use */
   db?: number;
+  /**
+   * Time-to-live (in ms) for the Redis lock keys. A crashed holder's key auto-expires after this
+   * time so peers do not deadlock. While a lock is legitimately held it is renewed at half this
+   * interval, so this value only bounds how long peers wait after a hard crash. Must be larger than
+   * the in-process lock expiration. Defaults to {@link DEFAULT_TTL} (30000ms).
+   */
+  ttl?: number;
 }
 
 /**
@@ -63,6 +81,9 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   private readonly redisLock: RedisResourceLock;
   private readonly attemptSettings: Required<AttemptSettings>;
   private readonly namespacePrefix: string;
+  private readonly ttl: number;
+  private readonly renewalInterval: number;
+  private readonly renewalTimers = new Map<string, NodeJS.Timeout>();
   private finalized = false;
 
   /**
@@ -78,10 +99,13 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     redisSettings?: RedisSettings,
   ) {
     redisSettings = { namespacePrefix: '', ...redisSettings };
-    const { namespacePrefix, ...options } = redisSettings;
+    const { namespacePrefix, ttl, ...options } = redisSettings;
     this.redis = this.createRedisClient(redisClient, options);
     this.attemptSettings = { ...attemptDefaults, ...attemptSettings };
     this.namespacePrefix = namespacePrefix!;
+    this.ttl = ttl ?? DEFAULT_TTL;
+    // Renew at half the TTL so a live holder refreshes its lock long before it could expire.
+    this.renewalInterval = Math.max(1, Math.floor(this.ttl / 2));
 
     // Register lua scripts
     for (const [ name, script ] of Object.entries(REDIS_LUA_SCRIPTS)) {
@@ -98,7 +122,7 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
    * @param redisClientString - A string that contains either a host address and a
    *                            port number like '127.0.0.1:6379' or just a port number like '6379'.
    */
-  private createRedisClient(redisClientString: string, options: Omit<RedisSettings, 'namespacePrefix'>): Redis {
+  private createRedisClient(redisClientString: string, options: Omit<RedisSettings, 'namespacePrefix' | 'ttl'>): Redis {
     if (redisClientString.length > 0) {
       // Check if port number or ip with port number
       // Definitely not perfect, but configuring this is only for experienced users
@@ -138,6 +162,54 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     return `${this.namespacePrefix}${PREFIX_LOCK}${identifier.path}`;
   }
 
+  /* Lease renewal */
+
+  /**
+   * Creates an interval timer that periodically refreshes the TTL of a held Redis lock (a lease).
+   * As long as the process is alive the lock keeps being renewed, so a legitimate (even long-running)
+   * operation never loses its lock. Once the process crashes the timer dies with it and the Redis key
+   * expires after the TTL, releasing the abandoned lock so peers do not deadlock.
+   *
+   * @param renew - Refreshes the TTL of the relevant Redis key. Rejections are swallowed and logged,
+   *                as a single missed refresh is recovered by the next interval tick.
+   *
+   * @returns The interval timer, which must be cleared with {@link clearInterval} once the lock is released.
+   */
+  private createRenewalTimer(renew: () => Promise<RedisAnswer>): NodeJS.Timeout {
+    const timer = setInterval((): void => {
+      renew().catch((error: unknown): void => {
+        this.logger.warn(`Could not renew Redis lock TTL: ${createErrorMessage(error)}`);
+      });
+    }, this.renewalInterval);
+    // A background renewal timer should never keep the Node.js process alive on its own.
+    timer.unref();
+    return timer;
+  }
+
+  /**
+   * Starts renewing the TTL of a resource lock and tracks the timer so it can be stopped on release.
+   *
+   * @param key - The Redis key of the acquired resource lock.
+   * @param renew - Refreshes the TTL of the resource lock key.
+   */
+  private startRenewal(key: string, renew: () => Promise<RedisAnswer>): void {
+    this.stopRenewal(key);
+    this.renewalTimers.set(key, this.createRenewalTimer(renew));
+  }
+
+  /**
+   * Stops renewing the TTL of a resource lock, if a renewal timer is active for the given key.
+   *
+   * @param key - The Redis key of the resource lock to stop renewing.
+   */
+  private stopRenewal(key: string): void {
+    const timer = this.renewalTimers.get(key);
+    if (timer) {
+      clearInterval(timer);
+      this.renewalTimers.delete(key);
+    }
+  }
+
   /* ReadWriteLocker methods */
 
   /**
@@ -163,12 +235,16 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   public async withReadLock<T>(identifier: ResourceIdentifier, whileLocked: () => PromiseOrValue<T>): Promise<T> {
     const key = this.getReadWriteKey(identifier);
     await retryFunction(
-      this.swallowFalse(this.redisRw.acquireReadLock.bind(this.redisRw, key)),
+      this.swallowFalse(this.redisRw.acquireReadLock.bind(this.redisRw, key, this.ttl)),
       this.attemptSettings,
+    );
+    const renewalTimer = this.createRenewalTimer(
+      async(): Promise<RedisAnswer> => this.redisRw.renewReadLock(key, this.ttl),
     );
     try {
       return await whileLocked();
     } finally {
+      clearInterval(renewalTimer);
       await retryFunction(
         this.swallowFalse(this.redisRw.releaseReadLock.bind(this.redisRw, key)),
         this.attemptSettings,
@@ -179,12 +255,16 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   public async withWriteLock<T>(identifier: ResourceIdentifier, whileLocked: () => PromiseOrValue<T>): Promise<T> {
     const key = this.getReadWriteKey(identifier);
     await retryFunction(
-      this.swallowFalse(this.redisRw.acquireWriteLock.bind(this.redisRw, key)),
+      this.swallowFalse(this.redisRw.acquireWriteLock.bind(this.redisRw, key, this.ttl)),
       this.attemptSettings,
+    );
+    const renewalTimer = this.createRenewalTimer(
+      async(): Promise<RedisAnswer> => this.redisRw.renewWriteLock(key, this.ttl),
     );
     try {
       return await whileLocked();
     } finally {
+      clearInterval(renewalTimer);
       await retryFunction(
         this.swallowFalse(this.redisRw.releaseWriteLock.bind(this.redisRw, key)),
         this.attemptSettings,
@@ -197,13 +277,17 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   public async acquire(identifier: ResourceIdentifier): Promise<void> {
     const key = this.getResourceKey(identifier);
     await retryFunction(
-      this.swallowFalse(this.redisLock.acquireLock.bind(this.redisLock, key)),
+      this.swallowFalse(this.redisLock.acquireLock.bind(this.redisLock, key, this.ttl)),
       this.attemptSettings,
     );
+    // A resource lock is held across separate acquire()/release() calls, so keep renewing its TTL
+    // until it is explicitly released (or the process crashes).
+    this.startRenewal(key, async(): Promise<RedisAnswer> => this.redisLock.renewLock(key, this.ttl));
   }
 
   public async release(identifier: ResourceIdentifier): Promise<void> {
     const key = this.getResourceKey(identifier);
+    this.stopRenewal(key);
     await retryFunction(
       this.swallowFalse(this.redisLock.releaseLock.bind(this.redisLock, key)),
       this.attemptSettings,
@@ -219,6 +303,11 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
 
   public async finalize(): Promise<void> {
     this.finalized = true;
+    // Stop any active resource-lock renewals so their timers cannot outlive the locker.
+    for (const timer of this.renewalTimers.values()) {
+      clearInterval(timer);
+    }
+    this.renewalTimers.clear();
     try {
       // On controlled server shutdown: clean up all existing locks.
       await this.clearLocks();

--- a/src/util/locking/scripts/RedisLuaScripts.ts
+++ b/src/util/locking/scripts/RedisLuaScripts.ts
@@ -16,10 +16,13 @@ export const REDIS_LUA_SCRIPTS = {
     if redis.call("exists", lockKey) == 1 then
       return 0
     end
-    
-    -- Return true if succeeded (and counter is incremented)
+
+    -- Increment the read counter and (re)set its TTL (in ms, ARGV[1]) atomically, so a crashed
+    -- reader can never keep the counter alive (and thus deadlock writers) forever.
     local countKey = KEYS[1].."${SUFFIX_COUNT}"
-    return redis.call("incr", countKey) > 0
+    local count = redis.call("incr", countKey)
+    redis.call("pexpire", countKey, ARGV[1])
+    return count > 0
     `,
   acquireWriteLock: `
     -- Return 0 if a lock entry already exists or read count is > 0
@@ -29,9 +32,10 @@ export const REDIS_LUA_SCRIPTS = {
     if ((redis.call("exists", lockKey) == 1) or (count ~= nil and count > 0)) then
       return 0
     end
-    
-    -- Set lock and respond with 'OK' if succeeded (otherwise null)
-    return redis.call("set", lockKey, "${LOCKED}");
+
+    -- Set the write lock together with a TTL (in ms, ARGV[1]) and respond with 'OK' if succeeded
+    -- (otherwise null). The TTL ensures a crashed holder's lock auto-releases instead of deadlocking peers.
+    return redis.call("set", lockKey, "${LOCKED}", "PX", ARGV[1]);
     `,
   releaseReadLock: `
       -- Return 1 after decreasing the counter, if counter is < 0 now: return '-ERR'
@@ -53,15 +57,28 @@ export const REDIS_LUA_SCRIPTS = {
         return redis.error_reply("Error trying to release writelock that did not exist.")
       end
     `,
+  renewReadLock: `
+      -- Refresh the read counter TTL (in ms, ARGV[1]) while at least one reader legitimately holds
+      -- the lock, so the counter never expires mid-operation and lets a writer in.
+      local countKey = KEYS[1].."${SUFFIX_COUNT}"
+      return redis.call("pexpire", countKey, ARGV[1])
+      `,
+  renewWriteLock: `
+      -- Refresh the write lock TTL (in ms, ARGV[1]) while it is legitimately held, so a long-running
+      -- operation never loses its lock.
+      local lockKey = KEYS[1].."${SUFFIX_WLOCK}"
+      return redis.call("pexpire", lockKey, ARGV[1])
+      `,
   acquireLock: `
       -- Return 0 if lock entry already exists, or 'OK' if it succeeds in setting the lock entry.
       local key = KEYS[1].."${SUFFIX_LOCK}"
       if redis.call("exists", key) == 1 then
         return 0
       end
-      
-      -- Return 'OK' if succeeded setting entry
-      return redis.call("set", key, "${LOCKED}");
+
+      -- Set the lock with a TTL (in ms, ARGV[1]) and return 'OK' if succeeded. The TTL ensures a
+      -- crashed holder's lock auto-releases instead of deadlocking peers.
+      return redis.call("set", key, "${LOCKED}", "PX", ARGV[1]);
       `,
   releaseLock: `
       -- Release the lock and reply with 1 if succeeded (otherwise return '-ERR')
@@ -73,6 +90,11 @@ export const REDIS_LUA_SCRIPTS = {
         return redis.error_reply("Error trying to release lock that did not exist.")
       end
     `,
+  renewLock: `
+      -- Refresh the lock TTL (in ms, ARGV[1]) while it is legitimately held.
+      local key = KEYS[1].."${SUFFIX_LOCK}"
+      return redis.call("pexpire", key, ARGV[1])
+      `,
 } as const;
 
 export type RedisAnswer = 0 | 1 | null | string;
@@ -112,17 +134,43 @@ export interface RedisReadWriteLock extends Redis {
    * Try to acquire a readLock on `resourceIdentifierPath`.
    * Will succeed if there are no write locks.
    *
+   * @param resourceIdentifierPath - The key to lock.
+   * @param ttl - Time-to-live (in ms) set on the read counter, so a crashed reader auto-releases.
+   *
    * @returns 1 if succeeded. 0 if not possible.
    */
-  acquireReadLock: (resourceIdentifierPath: string, callback?: Callback<string>) => Promise<RedisAnswer>;
+  acquireReadLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
 
   /**
    * Try to acquire a writeLock on `resourceIdentifierPath`.
    * Only works if no other write lock is present and the read counter is 0.
    *
+   * @param resourceIdentifierPath - The key to lock.
+   * @param ttl - Time-to-live (in ms) set on the write lock, so a crashed holder auto-releases.
+   *
    * @returns 'OK' if succeeded, 0 if not possible.
    */
-  acquireWriteLock: (resourceIdentifierPath: string, callback?: Callback<string>) => Promise<RedisAnswer>;
+  acquireWriteLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
+
+  /**
+   * Refresh the TTL of the read counter while the lock is legitimately held (a lease renewal).
+   *
+   * @param resourceIdentifierPath - The key whose read counter TTL should be refreshed.
+   * @param ttl - Time-to-live (in ms) to (re)set on the read counter.
+   *
+   * @returns 1 if the TTL was refreshed, 0 if the counter no longer exists.
+   */
+  renewReadLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<number>) => Promise<RedisAnswer>;
+
+  /**
+   * Refresh the TTL of the write lock while it is legitimately held (a lease renewal).
+   *
+   * @param resourceIdentifierPath - The key whose write lock TTL should be refreshed.
+   * @param ttl - Time-to-live (in ms) to (re)set on the write lock.
+   *
+   * @returns 1 if the TTL was refreshed, 0 if the lock no longer exists.
+   */
+  renewWriteLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<number>) => Promise<RedisAnswer>;
 
   /**
    * Release readLock. This means decrementing the read counter with 1.
@@ -144,9 +192,22 @@ export interface RedisResourceLock extends Redis {
    * Try to acquire a lock  on `resourceIdentifierPath`.
    * Only works if no other lock is present.
    *
+   * @param resourceIdentifierPath - The key to lock.
+   * @param ttl - Time-to-live (in ms) set on the lock, so a crashed holder auto-releases.
+   *
    * @returns 'OK' if succeeded, 0 if not possible.
    */
-  acquireLock: (resourceIdentifierPath: string, callback?: Callback<string>) => Promise<RedisAnswer>;
+  acquireLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
+
+  /**
+   * Refresh the TTL of the lock while it is legitimately held (a lease renewal).
+   *
+   * @param resourceIdentifierPath - The key whose lock TTL should be refreshed.
+   * @param ttl - Time-to-live (in ms) to (re)set on the lock.
+   *
+   * @returns 1 if the TTL was refreshed, 0 if the lock no longer exists.
+   */
+  renewLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<number>) => Promise<RedisAnswer>;
 
   /**
    * Release lock. This means deleting the lock.

--- a/test/unit/util/locking/RedisLocker.test.ts
+++ b/test/unit/util/locking/RedisLocker.test.ts
@@ -641,14 +641,13 @@ describe('A RedisLocker', (): void => {
     });
 
     describe('initialize()', (): void => {
-      it('does not clear locks on boot by default, so peer instances keep their locks.', async(): Promise<void> => {
+      it('does not clear locks on boot by default.', async(): Promise<void> => {
         store.reset();
         await locker.acquire({ path: 'path1' });
         await locker.acquire({ path: 'path2' });
         await locker.initialize();
-        // The default is multi-instance-safe: a restarting instance must not wipe its peers' locks.
         expect(Object.keys(store.internal)).toHaveLength(2);
-        // Release the acquired resource locks so their renewal timers do not leak into later tests.
+        // Release the locks so their renewal timers do not leak into later tests.
         await locker.release({ path: 'path1' });
         await locker.release({ path: 'path2' });
       });

--- a/test/unit/util/locking/RedisLocker.test.ts
+++ b/test/unit/util/locking/RedisLocker.test.ts
@@ -641,10 +641,24 @@ describe('A RedisLocker', (): void => {
     });
 
     describe('initialize()', (): void => {
-      it('should clear all locks when initialize() is called.', async(): Promise<void> => {
+      it('does not clear locks on boot by default, so peer instances keep their locks.', async(): Promise<void> => {
+        store.reset();
         await locker.acquire({ path: 'path1' });
         await locker.acquire({ path: 'path2' });
         await locker.initialize();
+        // The default is multi-instance-safe: a restarting instance must not wipe its peers' locks.
+        expect(Object.keys(store.internal)).toHaveLength(2);
+        // Release the acquired resource locks so their renewal timers do not leak into later tests.
+        await locker.release({ path: 'path1' });
+        await locker.release({ path: 'path2' });
+      });
+
+      it('clears all locks on boot when clearLocksOnStart is enabled.', async(): Promise<void> => {
+        store.reset();
+        const clearingLocker = new RedisLocker('6379', { retryCount: 5 }, { clearLocksOnStart: true });
+        await clearingLocker.acquire({ path: 'path1' });
+        await clearingLocker.acquire({ path: 'path2' });
+        await clearingLocker.initialize();
         expect(Object.keys(store.internal)).toHaveLength(0);
       });
     });

--- a/test/unit/util/locking/RedisLocker.test.ts
+++ b/test/unit/util/locking/RedisLocker.test.ts
@@ -87,12 +87,15 @@ const redis: jest.Mocked<Redis & RedisResourceLock & RedisReadWriteLock> = {
     store.acquireReadLock(key)),
   acquireWriteLock: jest.fn().mockImplementation(async(key: string): Promise<number | null | 'OK'> =>
     store.acquireWriteLock(key)),
+  renewReadLock: jest.fn().mockResolvedValue(1),
+  renewWriteLock: jest.fn().mockResolvedValue(1),
   releaseReadLock: jest.fn().mockImplementation(async(key: string): Promise<number> =>
     store.releaseReadLock(key)),
   releaseWriteLock: jest.fn().mockImplementation(async(key: string): Promise<number | null> =>
     store.releaseWriteLock(key)),
   acquireLock: jest.fn().mockImplementation(async(key: string): Promise<number | null | 'OK'> =>
     store.acquireLock(key)),
+  renewLock: jest.fn().mockResolvedValue(1),
   releaseLock: jest.fn().mockImplementation(async(key: string): Promise<number | null | string> =>
     store.releaseLock(key)),
 } as any;
@@ -124,6 +127,8 @@ describe('A RedisLocker', (): void => {
     afterEach(async(): Promise<void> => {
     // In case some locks are not released by a test the timers will still be running
       jest.clearAllTimers();
+      // Restore real timers in case a test enabled fake timers for renewal assertions
+      jest.useRealTimers();
     });
 
     it('will fill in default arguments when constructed with empty arguments.', (): void => {
@@ -418,6 +423,93 @@ describe('A RedisLocker', (): void => {
       await expect(promise).rejects.toThrow('Unexpected Redis answer received! (unexpected)');
     });
 
+    describe('lock TTL', (): void => {
+      const key = `__RW__${resource1.path}`;
+
+      it('sets the default TTL when acquiring a read lock.', async(): Promise<void> => {
+        await locker.withReadLock(resource1, (): number => 5);
+        expect(redis.acquireReadLock).toHaveBeenCalledTimes(1);
+        expect(redis.acquireReadLock).toHaveBeenCalledWith(key, 30000);
+      });
+
+      it('sets the default TTL when acquiring a write lock.', async(): Promise<void> => {
+        await locker.withWriteLock(resource1, (): number => 5);
+        expect(redis.acquireWriteLock).toHaveBeenCalledTimes(1);
+        expect(redis.acquireWriteLock).toHaveBeenCalledWith(key, 30000);
+      });
+
+      it('uses a custom TTL when one is configured.', async(): Promise<void> => {
+        const customLocker = new RedisLocker('6379', {}, { ttl: 12000 });
+        await customLocker.withWriteLock(resource1, (): number => 5);
+        expect(redis.acquireWriteLock).toHaveBeenCalledWith(key, 12000);
+      });
+
+      it('renews the write lock TTL while the lock is held, and stops after release.', async(): Promise<void> => {
+        jest.useFakeTimers();
+        const emitter = new EventEmitter();
+        const promise = locker.withWriteLock(resource1, async(): Promise<void> =>
+          new Promise<void>((resolve): any => emitter.on('release', resolve)));
+
+        // Allow the acquire to resolve and the renewal timer to be scheduled
+        await flushPromises();
+
+        // The renewal fires at half the TTL and refreshes the write lock key with the full TTL
+        jest.advanceTimersByTime(15000);
+        expect(redis.renewWriteLock).toHaveBeenCalledTimes(1);
+        expect(redis.renewWriteLock).toHaveBeenLastCalledWith(key, 30000);
+        jest.advanceTimersByTime(15000);
+        expect(redis.renewWriteLock).toHaveBeenCalledTimes(2);
+
+        emitter.emit('release');
+        await promise;
+
+        // Once released the renewal timer is cleared and no further renewals happen
+        jest.advanceTimersByTime(60000);
+        expect(redis.renewWriteLock).toHaveBeenCalledTimes(2);
+      });
+
+      it('renews the read lock counter TTL while the lock is held.', async(): Promise<void> => {
+        jest.useFakeTimers();
+        const emitter = new EventEmitter();
+        const promise = locker.withReadLock(resource1, async(): Promise<void> =>
+          new Promise<void>((resolve): any => emitter.on('release', resolve)));
+
+        await flushPromises();
+
+        jest.advanceTimersByTime(15000);
+        expect(redis.renewReadLock).toHaveBeenCalledTimes(1);
+        expect(redis.renewReadLock).toHaveBeenLastCalledWith(key, 30000);
+
+        emitter.emit('release');
+        await promise;
+
+        jest.advanceTimersByTime(60000);
+        expect(redis.renewReadLock).toHaveBeenCalledTimes(1);
+      });
+
+      it('logs a warning when a lock renewal fails.', async(): Promise<void> => {
+        jest.useFakeTimers();
+        const logger = (locker as any).logger;
+        const warnSpy = jest.spyOn(logger, 'warn').mockImplementation((): any => undefined);
+        redis.renewWriteLock.mockRejectedValueOnce(new Error('renewal boom'));
+
+        const emitter = new EventEmitter();
+        const promise = locker.withWriteLock(resource1, async(): Promise<void> =>
+          new Promise<void>((resolve): any => emitter.on('release', resolve)));
+
+        await flushPromises();
+        jest.advanceTimersByTime(15000);
+        // Allow the rejected renewal promise to settle so the catch handler runs
+        await flushPromises();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenLastCalledWith(expect.stringContaining('Could not renew Redis lock TTL'));
+
+        emitter.emit('release');
+        await promise;
+        warnSpy.mockRestore();
+      });
+    });
+
     describe('finalize()', (): void => {
       it('should call quit and clear Read-Write locks when finalize() is called.', async(): Promise<void> => {
         const promise = locker.withWriteLock(resource1, async(): Promise<any> => {
@@ -443,6 +535,8 @@ describe('A RedisLocker', (): void => {
     afterEach(async(): Promise<void> => {
     // In case some locks are not released by a test the timers will still be running
       jest.clearAllTimers();
+      // Restore real timers in case a test enabled fake timers for renewal assertions
+      jest.useRealTimers();
     });
 
     it('will fill in default arguments when constructed with empty arguments.', (): void => {
@@ -455,6 +549,38 @@ describe('A RedisLocker', (): void => {
       await expect(locker.release(identifier)).resolves.toBeUndefined();
       expect(redis.acquireLock).toHaveBeenCalledTimes(1);
       expect(redis.releaseLock).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets a TTL when acquiring a resource lock.', async(): Promise<void> => {
+      await locker.acquire(identifier);
+      expect(redis.acquireLock).toHaveBeenCalledTimes(1);
+      expect(redis.acquireLock).toHaveBeenCalledWith(`__L__${identifier.path}`, 30000);
+      await locker.release(identifier);
+    });
+
+    it('renews a held resource lock TTL until it is released.', async(): Promise<void> => {
+      jest.useFakeTimers();
+      const key = `__L__${identifier.path}`;
+      await locker.acquire(identifier);
+
+      jest.advanceTimersByTime(15000);
+      expect(redis.renewLock).toHaveBeenCalledTimes(1);
+      expect(redis.renewLock).toHaveBeenLastCalledWith(key, 30000);
+
+      await locker.release(identifier);
+
+      // No renewals happen once the resource lock is released
+      jest.advanceTimersByTime(60000);
+      expect(redis.renewLock).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops renewing held resource locks on finalize.', async(): Promise<void> => {
+      jest.useFakeTimers();
+      await locker.acquire({ path: 'path1' });
+      await locker.finalize();
+
+      jest.advanceTimersByTime(60000);
+      expect(redis.renewLock).not.toHaveBeenCalled();
     });
 
     it('can lock a resource again after it was unlocked.', async(): Promise<void> => {


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

**Stacks on #68** (`fix/redis-lock-ttl` — renewed TTL leases for Redis locks). Review after #68; the diff shown against `main` includes #68's commit.

#### 📁 Related issues

None yet — an issue describing the multi-instance boot-wipe problem needs to be opened on CommunitySolidServer before this is submitted upstream (the upstream PR template requires a related issue).

#### ✍️ Description

On boot, `RedisLocker.initialize()` deletes every lock key in its namespace (`CleanupInitializer` → `clearLocks`). Multi-instance (HA) deployments have to share a namespace so instances see each other's locks, which means a rolling restart of one instance wipes locks still held by its live peers — a corruption window.

Ownership tagging cannot repair the wipe: every lock value is the constant string `"locked"`, so an instance has no way to tell its own stale locks from a peer's live ones, and per-instance tags would complicate the mutual-exclusion Lua scripts. The boot-time clear is instead gated behind a new `RedisSettings.clearLocksOnStart`, default `false`. The wipe is no longer needed for crash recovery because #68 (this branch's base) gives every lock a renewed TTL lease, so a crashed holder's lock auto-expires; #68 covers the *crash* path, this covers the *restart* path. A single-instance deployment that prefers immediate boot cleanup over waiting out the TTL can set `clearLocksOnStart: true`, which reproduces the previous behaviour exactly. Acquire/release/renew semantics and `finalize()` (graceful-shutdown cleanup) are untouched.

Out of scope, needs a separate PR: `finalize()` also wipes the whole namespace on *graceful* shutdown, so the clean-stop half of a rolling restart still clears peers' locks; it should get the same treatment.

Verified against a live Redis by planting a fake peer-held lock key: a default boot leaves it in place (`EXISTS` = 1); an opt-in boot (`clearLocksOnStart: true`) clears it (`EXISTS` = 0). The unit tests cover both branches; the full unit suite passes the 100% `./src` coverage thresholds and eslint reports zero warnings.

**Branch target and semver.** On upstream submission this should target the latest `versions/*` branch (currently `versions/next-major`), not `main`: it adds a `RedisSettings` field and changes the default boot behaviour of the existing Redis configuration. Intended semver level: **major** by the template's definition (configuration behaviour changes — the boot wipe becomes opt-in); if the boot wipe is judged an internal detail, **minor** (a backwards-compatible new setting).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
