### PR TITLE
fix: Reserve quota space per scope to prevent concurrent overshoot

### DIFF
--- a/src/storage/quota/GlobalQuotaStrategy.ts
+++ b/src/storage/quota/GlobalQuotaStrategy.ts
@@ -14,7 +14,6 @@ export class GlobalQuotaStrategy extends QuotaStrategy {
   }
 
   public async getQuotaScope(): Promise<string> {
-    // A global quota is shared by the whole server, so every write reserves against the same scope.
     return this.base;
   }
 

--- a/src/storage/quota/GlobalQuotaStrategy.ts
+++ b/src/storage/quota/GlobalQuotaStrategy.ts
@@ -13,6 +13,11 @@ export class GlobalQuotaStrategy extends QuotaStrategy {
     this.base = base;
   }
 
+  public async getQuotaScope(): Promise<string> {
+    // A global quota is shared by the whole server, so every write reserves against the same scope.
+    return this.base;
+  }
+
   protected async getTotalSpaceUsed(): Promise<Size> {
     return this.reporter.getSize({ path: this.base });
   }

--- a/src/storage/quota/PodQuotaStrategy.ts
+++ b/src/storage/quota/PodQuotaStrategy.ts
@@ -26,6 +26,14 @@ export class PodQuotaStrategy extends QuotaStrategy {
     this.accessor = accessor;
   }
 
+  public async getQuotaScope(identifier: ResourceIdentifier): Promise<string> {
+    const pimStorage = await this.searchPimStorage(identifier);
+
+    // No pim:storage was found, so this identifier points to an internal location where quota
+    // does not apply. Returning an empty string signals that no reservation should be made.
+    return pimStorage?.path ?? '';
+  }
+
   protected async getTotalSpaceUsed(identifier: ResourceIdentifier): Promise<Size> {
     const pimStorage = await this.searchPimStorage(identifier);
 

--- a/src/storage/quota/PodQuotaStrategy.ts
+++ b/src/storage/quota/PodQuotaStrategy.ts
@@ -29,8 +29,7 @@ export class PodQuotaStrategy extends QuotaStrategy {
   public async getQuotaScope(identifier: ResourceIdentifier): Promise<string> {
     const pimStorage = await this.searchPimStorage(identifier);
 
-    // No pim:storage was found, so this identifier points to an internal location where quota
-    // does not apply. Returning an empty string signals that no reservation should be made.
+    // No pim:storage was found, so this identifier points to an internal location where quota does not apply
     return pimStorage?.path ?? '';
   }
 

--- a/src/storage/quota/QuotaStrategy.ts
+++ b/src/storage/quota/QuotaStrategy.ts
@@ -55,15 +55,13 @@ export abstract class QuotaStrategy {
 
   /**
    * Get the scope within which quota is shared for the given identifier.
-   *
-   * Concurrent writes that resolve to the same scope compete for the same available space,
-   * so the returned value is used as the key under which space is reserved during a write.
-   * The value only needs to be stable and unique per shared-quota area; it is not dereferenced.
+   * Concurrent writes to the same scope compete for the same available space,
+   * so this is used as the key under which space is reserved during a write.
    *
    * @param identifier - the identifier of the resource that is being written
    *
-   * @returns a stable string key identifying the shared-quota scope,
-   * or an empty string when quota does not apply to this identifier (no reservation is needed)
+   * @returns a stable string key identifying the shared-quota scope.
+   * If quota is not relevant for this identifier, an empty string should be returned
    */
   public abstract getQuotaScope(identifier: ResourceIdentifier): Promise<string>;
 

--- a/src/storage/quota/QuotaStrategy.ts
+++ b/src/storage/quota/QuotaStrategy.ts
@@ -54,6 +54,20 @@ export abstract class QuotaStrategy {
   }
 
   /**
+   * Get the scope within which quota is shared for the given identifier.
+   *
+   * Concurrent writes that resolve to the same scope compete for the same available space,
+   * so the returned value is used as the key under which space is reserved during a write.
+   * The value only needs to be stable and unique per shared-quota area; it is not dereferenced.
+   *
+   * @param identifier - the identifier of the resource that is being written
+   *
+   * @returns a stable string key identifying the shared-quota scope,
+   * or an empty string when quota does not apply to this identifier (no reservation is needed)
+   */
+  public abstract getQuotaScope(identifier: ResourceIdentifier): Promise<string>;
+
+  /**
    * Get the currently used/occupied space.
    *
    * @param identifier - the identifier that should be used to calculate the total

--- a/src/storage/validators/QuotaValidator.ts
+++ b/src/storage/validators/QuotaValidator.ts
@@ -11,17 +11,11 @@ import type { QuotaStrategy } from '../quota/QuotaStrategy';
 /**
  * The QuotaValidator validates data streams by making sure they would not exceed the limits of a QuotaStrategy.
  *
- * When the size of a write is known up front (advertised `Content-Length`), the validator reserves that
- * amount of space for the duration of the write. Reservations are keyed on the scope returned by
- * {@link QuotaStrategy.getQuotaScope}, so two concurrent writes measured against the same available-space
- * snapshot can no longer both pass and jointly exceed the quota. The reservation is released again exactly
- * once when the write stream settles (finish, error or abort).
- *
- * The reservation map is kept per-instance. Since the `QuotaValidator` is instantiated as a single
- * component this is effectively per-process, which is sufficient for a single server instance.
- * A multi-instance/multi-process deployment sharing one backend would need shared reservation state;
- * this is a documented follow-up. Writes with an unknown size (chunked, no `Content-Length`) cannot be
- * reserved and fall back to the streaming guard alone, so they retain the original overshoot window.
+ * When the size of a write is known up front, that amount of space is reserved until the write settles.
+ * Reservations are keyed on the scope returned by {@link QuotaStrategy.getQuotaScope},
+ * so concurrent writes in the same scope can not jointly exceed the available space.
+ * Writes with an unknown size can not be reserved and are only checked while streaming.
+ * Reservations are kept in memory and thus not shared between multiple server instances.
  */
 export class QuotaValidator extends Validator {
   private readonly strategy: QuotaStrategy;
@@ -41,8 +35,7 @@ export class QuotaValidator extends Validator {
     // 2. Get the estimated size of the resource that is being written
     const estimatedSize = await this.strategy.estimateSize(metadata);
 
-    // 3. When the size is known up front, account for space already reserved by other in-flight
-    //    writes in the same scope, reject if it no longer fits, and otherwise reserve it ourselves.
+    // 3. Check if the estimated size still fits next to the space reserved by in-flight writes, then reserve it
     let release: (() => void) | undefined;
     if (estimatedSize) {
       const scope = await this.strategy.getQuotaScope(identifier);
@@ -62,13 +55,12 @@ export class QuotaValidator extends Validator {
         };
       }
 
-      // An empty scope means quota does not apply to this identifier, so nothing is reserved.
       if (scope) {
         release = this.reserve(scope, estimatedSize.amount);
       }
     }
 
-    // 4. Track if quota is exceeded during writing (also the only guard for unknown-size writes)
+    // 4. Track if quota is exceeded during writing
     const tracking: Guarded<PassThrough> = await this.strategy.createQuotaGuard(identifier);
 
     // 5. Double check quota is not exceeded after write (concurrent writing possible)
@@ -82,9 +74,7 @@ export class QuotaValidator extends Validator {
 
     const tracked = pipeSafely(pipeSafely(data, tracking), afterWrite);
 
-    // 6. Release the reservation exactly once when the write settles.
-    //    `endOfStream` invokes its callback a single time on finish, error and close (abort) alike,
-    //    so the reserved space is always returned and never released twice.
+    // 6. Release the reservation when the write settles; endOfStream fires exactly once on finish, error and abort
     if (release) {
       endOfStream(tracked).then(release, release);
     }
@@ -96,11 +86,10 @@ export class QuotaValidator extends Validator {
   }
 
   /**
-   * Adds `amount` to the bytes reserved for the given scope and returns a function that releases
-   * exactly that amount again. The release function is meant to be called a single time when the
-   * write settles; it removes the scope from the map once no reservations remain.
+   * Adds `amount` to the bytes reserved for the given scope.
+   * The returned function releases the reservation again and is expected to be called exactly once.
    *
-   * @param scope - the shared-quota scope to reserve space in
+   * @param scope - the scope to reserve space in
    * @param amount - the number of bytes to reserve
    *
    * @returns a function that releases the reserved amount

--- a/src/storage/validators/QuotaValidator.ts
+++ b/src/storage/validators/QuotaValidator.ts
@@ -5,14 +5,27 @@ import type { Representation } from '../../http/representation/Representation';
 import { PayloadHttpError } from '../../util/errors/PayloadHttpError';
 import type { Guarded } from '../../util/GuardedStream';
 import { guardStream } from '../../util/GuardedStream';
-import { pipeSafely } from '../../util/StreamUtil';
+import { endOfStream, pipeSafely } from '../../util/StreamUtil';
 import type { QuotaStrategy } from '../quota/QuotaStrategy';
 
 /**
  * The QuotaValidator validates data streams by making sure they would not exceed the limits of a QuotaStrategy.
+ *
+ * When the size of a write is known up front (advertised `Content-Length`), the validator reserves that
+ * amount of space for the duration of the write. Reservations are keyed on the scope returned by
+ * {@link QuotaStrategy.getQuotaScope}, so two concurrent writes measured against the same available-space
+ * snapshot can no longer both pass and jointly exceed the quota. The reservation is released again exactly
+ * once when the write stream settles (finish, error or abort).
+ *
+ * The reservation map is kept per-instance. Since the `QuotaValidator` is instantiated as a single
+ * component this is effectively per-process, which is sufficient for a single server instance.
+ * A multi-instance/multi-process deployment sharing one backend would need shared reservation state;
+ * this is a documented follow-up. Writes with an unknown size (chunked, no `Content-Length`) cannot be
+ * reserved and fall back to the streaming guard alone, so they retain the original overshoot window.
  */
 export class QuotaValidator extends Validator {
   private readonly strategy: QuotaStrategy;
+  private readonly reservations = new Map<string, number>();
 
   public constructor(strategy: QuotaStrategy) {
     super();
@@ -25,27 +38,40 @@ export class QuotaValidator extends Validator {
     // 1. Get the available size
     const availableSize = await this.strategy.getAvailableSpace(identifier);
 
-    // 2. Check if the estimated size is bigger then the available size
+    // 2. Get the estimated size of the resource that is being written
     const estimatedSize = await this.strategy.estimateSize(metadata);
 
-    if (estimatedSize && availableSize.amount < estimatedSize.amount) {
-      return {
-        ...representation,
-        data: guardStream(new Readable({
-          read(this): void {
-            this.destroy(new PayloadHttpError(
-              `Quota exceeded: Advertised Content-Length is ${estimatedSize.amount} ${estimatedSize.unit} ` +
-              `and only ${availableSize.amount} ${availableSize.unit} is available`,
-            ));
-          },
-        })),
-      };
+    // 3. When the size is known up front, account for space already reserved by other in-flight
+    //    writes in the same scope, reject if it no longer fits, and otherwise reserve it ourselves.
+    let release: (() => void) | undefined;
+    if (estimatedSize) {
+      const scope = await this.strategy.getQuotaScope(identifier);
+      const reserved = scope ? this.reservations.get(scope) ?? 0 : 0;
+
+      if (availableSize.amount - reserved < estimatedSize.amount) {
+        return {
+          ...representation,
+          data: guardStream(new Readable({
+            read(this): void {
+              this.destroy(new PayloadHttpError(
+                `Quota exceeded: Advertised Content-Length is ${estimatedSize.amount} ${estimatedSize.unit} ` +
+                `and only ${availableSize.amount - reserved} ${availableSize.unit} is available`,
+              ));
+            },
+          })),
+        };
+      }
+
+      // An empty scope means quota does not apply to this identifier, so nothing is reserved.
+      if (scope) {
+        release = this.reserve(scope, estimatedSize.amount);
+      }
     }
 
-    // 3. Track if quota is exceeded during writing
+    // 4. Track if quota is exceeded during writing (also the only guard for unknown-size writes)
     const tracking: Guarded<PassThrough> = await this.strategy.createQuotaGuard(identifier);
 
-    // 4. Double check quota is not exceeded after write (concurrent writing possible)
+    // 5. Double check quota is not exceeded after write (concurrent writing possible)
     const afterWrite = new PassThrough({
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       flush: async(done): Promise<void> => {
@@ -54,9 +80,42 @@ export class QuotaValidator extends Validator {
       },
     });
 
+    const tracked = pipeSafely(pipeSafely(data, tracking), afterWrite);
+
+    // 6. Release the reservation exactly once when the write settles.
+    //    `endOfStream` invokes its callback a single time on finish, error and close (abort) alike,
+    //    so the reserved space is always returned and never released twice.
+    if (release) {
+      endOfStream(tracked).then(release, release);
+    }
+
     return {
       ...representation,
-      data: pipeSafely(pipeSafely(data, tracking), afterWrite),
+      data: tracked,
+    };
+  }
+
+  /**
+   * Adds `amount` to the bytes reserved for the given scope and returns a function that releases
+   * exactly that amount again. The release function is meant to be called a single time when the
+   * write settles; it removes the scope from the map once no reservations remain.
+   *
+   * @param scope - the shared-quota scope to reserve space in
+   * @param amount - the number of bytes to reserve
+   *
+   * @returns a function that releases the reserved amount
+   */
+  private reserve(scope: string, amount: number): () => void {
+    const { reservations } = this;
+    reservations.set(scope, (reservations.get(scope) ?? 0) + amount);
+
+    return (): void => {
+      const remaining = reservations.get(scope)! - amount;
+      if (remaining > 0) {
+        reservations.set(scope, remaining);
+      } else {
+        reservations.delete(scope);
+      }
     };
   }
 }

--- a/test/unit/quota/GlobalQuotaStrategy.test.ts
+++ b/test/unit/quota/GlobalQuotaStrategy.test.ts
@@ -34,4 +34,10 @@ describe('GlobalQuotaStrategy', (): void => {
       );
     });
   });
+
+  describe('getQuotaScope()', (): void => {
+    it('should return the server base since quota is shared globally.', async(): Promise<void> => {
+      await expect(strategy.getQuotaScope({ path: 'any/path' })).resolves.toBe(mockBase);
+    });
+  });
 });

--- a/test/unit/quota/PodQuotaStrategy.test.ts
+++ b/test/unit/quota/PodQuotaStrategy.test.ts
@@ -77,4 +77,15 @@ describe('PodQuotaStrategy', (): void => {
       await expect(result).rejects.toThrow('error');
     });
   });
+
+  describe('getQuotaScope()', (): void => {
+    it('should return the pim:storage container path when writing inside a pod.', async(): Promise<void> => {
+      await expect(strategy.getQuotaScope({ path: `${base}nested/nested2/file.txt` }))
+        .resolves.toBe(`${base}nested/`);
+    });
+
+    it('should return an empty string when writing outside a pod.', async(): Promise<void> => {
+      await expect(strategy.getQuotaScope({ path: `${base}file.txt` })).resolves.toBe('');
+    });
+  });
 });

--- a/test/unit/quota/QuotaStrategy.test.ts
+++ b/test/unit/quota/QuotaStrategy.test.ts
@@ -14,6 +14,7 @@ class QuotaStrategyWrapper extends QuotaStrategy {
   }
 
   public getAvailableSpace = async(): Promise<Size> => ({ unit: UNIT_BYTES, amount: 5 });
+  public getQuotaScope = async(): Promise<string> => 'scope';
   protected getTotalSpaceUsed = async(): Promise<Size> => ({ unit: UNIT_BYTES, amount: 5 });
 }
 

--- a/test/unit/storage/validators/QuotaValidator.test.ts
+++ b/test/unit/storage/validators/QuotaValidator.test.ts
@@ -12,6 +12,13 @@ import { guardStream } from '../../../../src/util/GuardedStream';
 import type { Guarded } from '../../../../src/util/GuardedStream';
 import { guardedStreamFrom, readableToString } from '../../../../src/util/StreamUtil';
 
+// Flushes pending micro- and macrotasks so a settled stream's reservation release has run.
+async function flush(): Promise<void> {
+  await new Promise<void>((resolve): void => {
+    setImmediate(resolve);
+  });
+}
+
 describe('QuotaValidator', (): void => {
   let mockedStrategy: jest.Mocked<QuotaStrategy>;
   let validator: QuotaValidator;
@@ -41,10 +48,20 @@ describe('QuotaValidator', (): void => {
       limit: { unit: UNIT_BYTES, amount: 8 },
       getAvailableSpace: jest.fn().mockResolvedValue({ unit: UNIT_BYTES, amount: 10 }),
       estimateSize: jest.fn().mockResolvedValue({ unit: UNIT_BYTES, amount: 8 }),
-      createQuotaGuard: jest.fn().mockResolvedValue(guardStream(new PassThrough())),
+      getQuotaScope: jest.fn().mockResolvedValue('scope'),
+      // Return a fresh guard for every call so a validator can handle multiple writes.
+      createQuotaGuard: jest.fn(async(): Promise<Guarded<PassThrough>> => guardStream(new PassThrough())),
     } as any;
     validator = new QuotaValidator(mockedStrategy);
   });
+
+  // Builds an input with a fresh, single-use data stream so `handle` can be called repeatedly.
+  function freshInput(): ValidatorInput {
+    return {
+      representation: new BasicRepresentation(guardedStreamFrom([ 'test string' ]), new RepresentationMetadata()),
+      identifier,
+    };
+  }
 
   describe('handle()', (): void => {
     // Step 2
@@ -115,6 +132,80 @@ describe('QuotaValidator', (): void => {
       await expect(result).resolves.toBeDefined();
       const awaitedResult = await result;
       await expect(readableToString(awaitedResult.data)).resolves.toBe('test string');
+    });
+
+    it('should reject a concurrent write when earlier writes reserved the space.', async(): Promise<void> => {
+      mockedStrategy.estimateSize.mockResolvedValue({ unit: UNIT_BYTES, amount: 6 });
+
+      // First write reserves 6 of the 10 available bytes but is left in-flight (not consumed).
+      const first = await validator.handle(freshInput());
+      expect(first.data).toBeDefined();
+
+      // Second write only has 4 bytes left after the reservation, so its 6 bytes no longer fit.
+      const second = await validator.handle(freshInput());
+      await expect(readableToString(second.data))
+        .rejects.toThrow('Quota exceeded: Advertised Content-Length is 6 bytes and only 4 bytes is available');
+    });
+
+    it('should release the reservation on finish so a following write succeeds.', async(): Promise<void> => {
+      // With only 2 bytes to spare, a leaked 8-byte reservation would reject the second write.
+      mockedStrategy.getAvailableSpace.mockResolvedValue({ unit: UNIT_BYTES, amount: 10 });
+
+      const first = await validator.handle(freshInput());
+      await expect(readableToString(first.data)).resolves.toBe('test string');
+      await flush();
+
+      const second = await validator.handle(freshInput());
+      await expect(readableToString(second.data)).resolves.toBe('test string');
+    });
+
+    it('should release the reservation when the write is aborted so no space is leaked.', async(): Promise<void> => {
+      const first = await validator.handle(freshInput());
+      // Simulate a client abort by destroying the returned stream before it finishes.
+      first.data.destroy();
+      await flush();
+
+      const second = await validator.handle(freshInput());
+      await expect(readableToString(second.data)).resolves.toBe('test string');
+    });
+
+    it('should keep the reservations of other in-flight writes when one write settles.', async(): Promise<void> => {
+      mockedStrategy.getAvailableSpace.mockResolvedValue({ unit: UNIT_BYTES, amount: 100 });
+      mockedStrategy.estimateSize.mockResolvedValue({ unit: UNIT_BYTES, amount: 8 });
+
+      // Two in-flight writes reserve 16 bytes in total.
+      const first = await validator.handle(freshInput());
+      const second = await validator.handle(freshInput());
+      expect(second.data).toBeDefined();
+
+      // Finishing the first write releases only its 8 bytes, leaving the second's 8 reserved.
+      await readableToString(first.data);
+      await flush();
+
+      // A 93-byte write no longer fits (100 - 8 < 93), proving the remaining reservation was kept.
+      mockedStrategy.estimateSize.mockResolvedValueOnce({ unit: UNIT_BYTES, amount: 93 });
+      const third = await validator.handle(freshInput());
+      await expect(readableToString(third.data)).rejects.toThrow('Quota exceeded');
+    });
+
+    it('should fall back to the streaming guard when the size is unknown.', async(): Promise<void> => {
+      mockedStrategy.estimateSize.mockResolvedValue(undefined);
+
+      const result = await validator.handle(freshInput());
+      await expect(readableToString(result.data)).resolves.toBe('test string');
+      // An unknown size cannot be reserved, so the scope is never even resolved.
+      expect(mockedStrategy.getQuotaScope).not.toHaveBeenCalled();
+    });
+
+    it('should not reserve space for identifiers without a quota scope.', async(): Promise<void> => {
+      mockedStrategy.getQuotaScope.mockResolvedValue('');
+
+      // The write is allowed, and because nothing is reserved a following equal write still fits.
+      const first = await validator.handle(freshInput());
+      await expect(readableToString(first.data)).resolves.toBe('test string');
+
+      const second = await validator.handle(freshInput());
+      await expect(readableToString(second.data)).resolves.toBe('test string');
     });
   });
 });

--- a/test/unit/storage/validators/QuotaValidator.test.ts
+++ b/test/unit/storage/validators/QuotaValidator.test.ts
@@ -141,7 +141,6 @@ describe('QuotaValidator', (): void => {
       const first = await validator.handle(freshInput());
       expect(first.data).toBeDefined();
 
-      // Second write only has 4 bytes left after the reservation, so its 6 bytes no longer fit.
       const second = await validator.handle(freshInput());
       await expect(readableToString(second.data))
         .rejects.toThrow('Quota exceeded: Advertised Content-Length is 6 bytes and only 4 bytes is available');
@@ -173,16 +172,14 @@ describe('QuotaValidator', (): void => {
       mockedStrategy.getAvailableSpace.mockResolvedValue({ unit: UNIT_BYTES, amount: 100 });
       mockedStrategy.estimateSize.mockResolvedValue({ unit: UNIT_BYTES, amount: 8 });
 
-      // Two in-flight writes reserve 16 bytes in total.
       const first = await validator.handle(freshInput());
       const second = await validator.handle(freshInput());
       expect(second.data).toBeDefined();
 
-      // Finishing the first write releases only its 8 bytes, leaving the second's 8 reserved.
       await readableToString(first.data);
       await flush();
 
-      // A 93-byte write no longer fits (100 - 8 < 93), proving the remaining reservation was kept.
+      // A 93-byte write no longer fits (100 - 8 < 93), proving the second write's reservation was kept.
       mockedStrategy.estimateSize.mockResolvedValueOnce({ unit: UNIT_BYTES, amount: 93 });
       const third = await validator.handle(freshInput());
       await expect(readableToString(third.data)).rejects.toThrow('Quota exceeded');


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

- Follow-up to #70, whose description documents the concurrent-overshoot race fixed here.
- No upstream issue exists yet — the upstream template requires one, so an issue describing the overshoot must be created on CommunitySolidServer/CommunitySolidServer before this is submitted there.

#### ✍️ Description

`QuotaValidator` checks a write against a snapshot of the available space taken before the write starts. Two concurrent writes therefore measure against the same snapshot: each can pass the check individually while together they exceed the quota.

This adds a reserve-then-commit layer for writes whose size is known up front (advertised `Content-Length`):

- A new abstract method `QuotaStrategy.getQuotaScope(identifier)` returns the key under which concurrent writes compete for the same space: `GlobalQuotaStrategy` returns the storage base (one scope for the whole server), `PodQuotaStrategy` the resolved `pim:storage` container path, and an empty string means quota does not apply (internal locations), so nothing is reserved. The value is only used as a map key, never dereferenced.
- `QuotaValidator` keeps a per-scope map of reserved bytes. A known-size write is rejected (413) when `available − reserved < size`; otherwise its size is reserved and released again when the write settles. The release is wired as `endOfStream(stream).then(release, release)`: `end-of-stream` invokes its callback exactly once (finish, error, or close/abort), so a reservation can neither leak after a failed or aborted write nor be released twice.
- Writes with an unknown size (chunked, no `Content-Length`) cannot be reserved and keep the existing streaming guard + after-write recheck, so the original overshoot window remains for that case only.

Notes for review:

- Quota is opt-in: with the default (no-quota) configs none of this code runs. When nothing is reserved, the 413 threshold and error message are identical to before.
- The reservation map is per-instance; the `QuotaValidator` is a single Components.js component, so effectively per-process. A multi-instance deployment sharing one backend would need shared reservation state — the same limitation the existing snapshot check already has; left as a follow-up.
- Minor: `PodQuotaStrategy` now resolves `pim:storage` twice for known-size writes (`getAvailableSpace` + `getQuotaScope`); correctness-neutral.
- Does not touch `ValidatingDataAccessor` (#70) or the per-chunk guard logic (#61); trivial rebase against #61 (both add methods to `QuotaStrategy.ts`).
- Since `getQuotaScope` is a new abstract method on `QuotaStrategy`, existing downstream `QuotaStrategy` implementations no longer compile without it: the intended semver level is **semver.major**, and upstream this should target the latest `versions/*` branch (currently `versions/next-major`) rather than `main`. It targets `main` here only because that is this fork's integration branch.
- Tests: 22 unit tests across the touched files (concurrent joint-exceed rejected, release on finish and on abort, other in-flight reservations kept, unknown-size fallback, no-scope writes not reserved, scope resolution of both strategies), plus `test/integration/Quota.test.ts` green.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
