### PR TITLE
fix: Only wipe the Redis lock namespace on shutdown in single-instance mode

### DIFF
--- a/config/util/resource-locker/redis.json
+++ b/config/util/resource-locker/redis.json
@@ -16,7 +16,7 @@
       "@type": "SequenceHandler",
       "handlers": [
         {
-          "comment": "Makes sure the RedisLocker starts with a clean slate when the application is started.",
+          "comment": "Lets the RedisLocker run its boot-time hook. By default it keeps existing locks so instances sharing a namespace (HA) are not disturbed; set the locker's clearLocksOnStart to true for a single instance that should wipe stale locks on boot.",
           "@type": "InitializableHandler",
           "initializable": { "@id": "urn:solid-server:default:RedisLocker" }
         }

--- a/config/util/resource-locker/redis.json
+++ b/config/util/resource-locker/redis.json
@@ -16,7 +16,7 @@
       "@type": "SequenceHandler",
       "handlers": [
         {
-          "comment": "Lets the RedisLocker run its boot-time hook. By default it keeps existing locks so instances sharing a namespace (HA) are not disturbed; set the locker's clearLocksOnStart to true for a single instance that should wipe stale locks on boot.",
+          "comment": "Runs the boot-time initialization of the RedisLocker, which only clears existing locks when clearLocksOnStart is enabled.",
           "@type": "InitializableHandler",
           "initializable": { "@id": "urn:solid-server:default:RedisLocker" }
         }
@@ -27,7 +27,7 @@
       "@type": "SequenceHandler",
       "handlers": [
         {
-          "comment": "Makes sure the redis connection is closed when the application needs to stop. Also deletes still-existing locks and counters.",
+          "comment": "Makes sure the redis connection is closed when the application needs to stop. Also deletes still-existing locks and counters when clearLocksOnStart is enabled.",
           "@type": "FinalizableHandler",
           "finalizable": { "@id": "urn:solid-server:default:RedisLocker" }
         }

--- a/src/util/locking/RedisLocker.ts
+++ b/src/util/locking/RedisLocker.ts
@@ -44,6 +44,19 @@ export interface RedisSettings {
    * the in-process lock expiration. Defaults to {@link DEFAULT_TTL} (30000ms).
    */
   ttl?: number;
+  /**
+   * Whether to delete every lock in this namespace when the locker starts (see {@link RedisLocker.initialize}).
+   *
+   * This is only safe when a single instance exclusively owns the Redis namespace: it lets that
+   * instance recover from locks left behind by a previous crashed run. When multiple instances share
+   * a namespace (the setup required for HA coordination) a restarting instance cannot tell its own
+   * stale locks from the live locks of its peers, so wiping the namespace on boot would corrupt peers
+   * that still hold those locks. Because a crashed holder's lock now auto-expires through its TTL lease
+   * (see {@link RedisSettings.ttl}), boot-time clearing is no longer needed for correctness, so this
+   * defaults to `false` (multi-instance-safe). Set it to `true` for a single-instance deployment that
+   * prefers stale locks cleared immediately on boot rather than waiting for the TTL to elapse.
+   */
+  clearLocksOnStart?: boolean;
 }
 
 /**
@@ -82,6 +95,7 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   private readonly attemptSettings: Required<AttemptSettings>;
   private readonly namespacePrefix: string;
   private readonly ttl: number;
+  private readonly clearLocksOnStart: boolean;
   private readonly renewalInterval: number;
   private readonly renewalTimers = new Map<string, NodeJS.Timeout>();
   private finalized = false;
@@ -99,11 +113,13 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     redisSettings?: RedisSettings,
   ) {
     redisSettings = { namespacePrefix: '', ...redisSettings };
-    const { namespacePrefix, ttl, ...options } = redisSettings;
+    const { namespacePrefix, ttl, clearLocksOnStart, ...options } = redisSettings;
     this.redis = this.createRedisClient(redisClient, options);
     this.attemptSettings = { ...attemptDefaults, ...attemptSettings };
     this.namespacePrefix = namespacePrefix!;
     this.ttl = ttl ?? DEFAULT_TTL;
+    // Default to NOT wiping the namespace on boot so peers sharing it (HA) are never disturbed.
+    this.clearLocksOnStart = clearLocksOnStart ?? false;
     // Renew at half the TTL so a live holder refreshes its lock long before it could expire.
     this.renewalInterval = Math.max(1, Math.floor(this.ttl / 2));
 
@@ -122,7 +138,10 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
    * @param redisClientString - A string that contains either a host address and a
    *                            port number like '127.0.0.1:6379' or just a port number like '6379'.
    */
-  private createRedisClient(redisClientString: string, options: Omit<RedisSettings, 'namespacePrefix' | 'ttl'>): Redis {
+  private createRedisClient(
+    redisClientString: string,
+    options: Omit<RedisSettings, 'namespacePrefix' | 'ttl' | 'clearLocksOnStart'>,
+  ): Redis {
     if (redisClientString.length > 0) {
       // Check if port number or ip with port number
       // Definitely not perfect, but configuring this is only for experienced users
@@ -297,7 +316,16 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   /* Initializer & Finalizer methods */
 
   public async initialize(): Promise<void> {
-    // On server start: remove all existing (dangling) locks, so new requests are not blocked.
+    if (!this.clearLocksOnStart) {
+      // Multiple instances may share this namespace to coordinate (HA). This instance cannot tell its
+      // own stale locks from the live locks of its peers, so it must NOT wipe the namespace on boot:
+      // deleting a peer's held lock would open a corruption window. A crashed holder's lock instead
+      // self-heals via its TTL lease. Single-instance deployments can opt back in via `clearLocksOnStart`.
+      this.logger.debug('Skipping boot-time lock cleanup; relying on lock TTLs (clearLocksOnStart is disabled).');
+      return;
+    }
+    // On server start (single-instance only): remove all existing (dangling) locks left behind by a
+    // previous crashed run, so new requests are not blocked while waiting for those locks' TTLs.
     return this.clearLocks();
   }
 

--- a/src/util/locking/RedisLocker.ts
+++ b/src/util/locking/RedisLocker.ts
@@ -337,10 +337,19 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     }
     this.renewalTimers.clear();
     try {
-      // On controlled server shutdown: clean up all existing locks.
-      await this.clearLocks();
+      if (this.clearLocksOnStart) {
+        // Single-instance mode (the same mode that wipes on boot): this instance exclusively owns the
+        // namespace, so on a controlled shutdown it cleans up every lock it left behind.
+        await this.clearLocks();
+      } else {
+        // Multiple instances may share this namespace to coordinate (HA). A gracefully stopping instance
+        // cannot tell its own locks from the live locks of its peers, so it must NOT wipe the namespace on
+        // shutdown: deleting a peer's held lock would open the same corruption window as a boot-time wipe.
+        // This instance's own locks self-heal via their TTL leases once it stops renewing them above.
+        this.logger.debug('Skipping shutdown lock cleanup; relying on lock TTLs (clearLocksOnStart is disabled).');
+      }
     } finally {
-      // Always quit the redis client
+      // Always quit the redis client, whether or not the namespace was cleared, so no connection leaks.
       await this.redis.quit();
     }
   }

--- a/src/util/locking/RedisLocker.ts
+++ b/src/util/locking/RedisLocker.ts
@@ -3,6 +3,7 @@ import type { ResourceIdentifier } from '../../http/representation/ResourceIdent
 import type { Finalizable } from '../../init/final/Finalizable';
 import type { Initializable } from '../../init/Initializable';
 import { getLoggerFor } from '../../logging/LogUtil';
+import { createErrorMessage } from '../errors/ErrorUtil';
 import type { AttemptSettings } from '../LockUtils';
 import { retryFunction } from '../LockUtils';
 import type { PromiseOrValue } from '../PromiseUtil';
@@ -17,6 +18,16 @@ const attemptDefaults: Required<AttemptSettings> = { retryCount: -1, retryDelay:
 const PREFIX_RW = '__RW__';
 const PREFIX_LOCK = '__L__';
 
+/**
+ * Default time-to-live (in ms) for a Redis lock key.
+ *
+ * A crashed lock holder's key auto-expires after this time so that other instances cannot deadlock
+ * on the abandoned resource. It is deliberately several times larger than the in-process lock
+ * expiration (see {@link WrappedExpiringReadWriteLocker}, 6000ms by default), and it is actively
+ * renewed while a lock is legitimately held, so a normal operation never loses its lock.
+ */
+const DEFAULT_TTL = 30000;
+
 export interface RedisSettings {
   /* Override default namespacePrefixes (used to prefix keys in Redis) */
   namespacePrefix?: string;
@@ -26,6 +37,13 @@ export interface RedisSettings {
   password?: string;
   /* The number of the database to use */
   db?: number;
+  /**
+   * Time-to-live (in ms) for the Redis lock keys. A crashed holder's key auto-expires after this
+   * time so peers do not deadlock. While a lock is legitimately held it is renewed at half this
+   * interval, so this value only bounds how long peers wait after a hard crash. Must be larger than
+   * the in-process lock expiration. Defaults to {@link DEFAULT_TTL} (30000ms).
+   */
+  ttl?: number;
 }
 
 /**
@@ -63,6 +81,9 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   private readonly redisLock: RedisResourceLock;
   private readonly attemptSettings: Required<AttemptSettings>;
   private readonly namespacePrefix: string;
+  private readonly ttl: number;
+  private readonly renewalInterval: number;
+  private readonly renewalTimers = new Map<string, NodeJS.Timeout>();
   private finalized = false;
 
   /**
@@ -78,10 +99,13 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     redisSettings?: RedisSettings,
   ) {
     redisSettings = { namespacePrefix: '', ...redisSettings };
-    const { namespacePrefix, ...options } = redisSettings;
+    const { namespacePrefix, ttl, ...options } = redisSettings;
     this.redis = this.createRedisClient(redisClient, options);
     this.attemptSettings = { ...attemptDefaults, ...attemptSettings };
     this.namespacePrefix = namespacePrefix!;
+    this.ttl = ttl ?? DEFAULT_TTL;
+    // Renew at half the TTL so a live holder refreshes its lock long before it could expire.
+    this.renewalInterval = Math.max(1, Math.floor(this.ttl / 2));
 
     // Register lua scripts
     for (const [ name, script ] of Object.entries(REDIS_LUA_SCRIPTS)) {
@@ -98,7 +122,7 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
    * @param redisClientString - A string that contains either a host address and a
    *                            port number like '127.0.0.1:6379' or just a port number like '6379'.
    */
-  private createRedisClient(redisClientString: string, options: Omit<RedisSettings, 'namespacePrefix'>): Redis {
+  private createRedisClient(redisClientString: string, options: Omit<RedisSettings, 'namespacePrefix' | 'ttl'>): Redis {
     if (redisClientString.length > 0) {
       // Check if port number or ip with port number
       // Definitely not perfect, but configuring this is only for experienced users
@@ -138,6 +162,54 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     return `${this.namespacePrefix}${PREFIX_LOCK}${identifier.path}`;
   }
 
+  /* Lease renewal */
+
+  /**
+   * Creates an interval timer that periodically refreshes the TTL of a held Redis lock (a lease).
+   * As long as the process is alive the lock keeps being renewed, so a legitimate (even long-running)
+   * operation never loses its lock. Once the process crashes the timer dies with it and the Redis key
+   * expires after the TTL, releasing the abandoned lock so peers do not deadlock.
+   *
+   * @param renew - Refreshes the TTL of the relevant Redis key. Rejections are swallowed and logged,
+   *                as a single missed refresh is recovered by the next interval tick.
+   *
+   * @returns The interval timer, which must be cleared with {@link clearInterval} once the lock is released.
+   */
+  private createRenewalTimer(renew: () => Promise<RedisAnswer>): NodeJS.Timeout {
+    const timer = setInterval((): void => {
+      renew().catch((error: unknown): void => {
+        this.logger.warn(`Could not renew Redis lock TTL: ${createErrorMessage(error)}`);
+      });
+    }, this.renewalInterval);
+    // A background renewal timer should never keep the Node.js process alive on its own.
+    timer.unref();
+    return timer;
+  }
+
+  /**
+   * Starts renewing the TTL of a resource lock and tracks the timer so it can be stopped on release.
+   *
+   * @param key - The Redis key of the acquired resource lock.
+   * @param renew - Refreshes the TTL of the resource lock key.
+   */
+  private startRenewal(key: string, renew: () => Promise<RedisAnswer>): void {
+    this.stopRenewal(key);
+    this.renewalTimers.set(key, this.createRenewalTimer(renew));
+  }
+
+  /**
+   * Stops renewing the TTL of a resource lock, if a renewal timer is active for the given key.
+   *
+   * @param key - The Redis key of the resource lock to stop renewing.
+   */
+  private stopRenewal(key: string): void {
+    const timer = this.renewalTimers.get(key);
+    if (timer) {
+      clearInterval(timer);
+      this.renewalTimers.delete(key);
+    }
+  }
+
   /* ReadWriteLocker methods */
 
   /**
@@ -163,12 +235,16 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   public async withReadLock<T>(identifier: ResourceIdentifier, whileLocked: () => PromiseOrValue<T>): Promise<T> {
     const key = this.getReadWriteKey(identifier);
     await retryFunction(
-      this.swallowFalse(this.redisRw.acquireReadLock.bind(this.redisRw, key)),
+      this.swallowFalse(this.redisRw.acquireReadLock.bind(this.redisRw, key, this.ttl)),
       this.attemptSettings,
+    );
+    const renewalTimer = this.createRenewalTimer(
+      async(): Promise<RedisAnswer> => this.redisRw.renewReadLock(key, this.ttl),
     );
     try {
       return await whileLocked();
     } finally {
+      clearInterval(renewalTimer);
       await retryFunction(
         this.swallowFalse(this.redisRw.releaseReadLock.bind(this.redisRw, key)),
         this.attemptSettings,
@@ -179,12 +255,16 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   public async withWriteLock<T>(identifier: ResourceIdentifier, whileLocked: () => PromiseOrValue<T>): Promise<T> {
     const key = this.getReadWriteKey(identifier);
     await retryFunction(
-      this.swallowFalse(this.redisRw.acquireWriteLock.bind(this.redisRw, key)),
+      this.swallowFalse(this.redisRw.acquireWriteLock.bind(this.redisRw, key, this.ttl)),
       this.attemptSettings,
+    );
+    const renewalTimer = this.createRenewalTimer(
+      async(): Promise<RedisAnswer> => this.redisRw.renewWriteLock(key, this.ttl),
     );
     try {
       return await whileLocked();
     } finally {
+      clearInterval(renewalTimer);
       await retryFunction(
         this.swallowFalse(this.redisRw.releaseWriteLock.bind(this.redisRw, key)),
         this.attemptSettings,
@@ -197,13 +277,17 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   public async acquire(identifier: ResourceIdentifier): Promise<void> {
     const key = this.getResourceKey(identifier);
     await retryFunction(
-      this.swallowFalse(this.redisLock.acquireLock.bind(this.redisLock, key)),
+      this.swallowFalse(this.redisLock.acquireLock.bind(this.redisLock, key, this.ttl)),
       this.attemptSettings,
     );
+    // A resource lock is held across separate acquire()/release() calls, so keep renewing its TTL
+    // until it is explicitly released (or the process crashes).
+    this.startRenewal(key, async(): Promise<RedisAnswer> => this.redisLock.renewLock(key, this.ttl));
   }
 
   public async release(identifier: ResourceIdentifier): Promise<void> {
     const key = this.getResourceKey(identifier);
+    this.stopRenewal(key);
     await retryFunction(
       this.swallowFalse(this.redisLock.releaseLock.bind(this.redisLock, key)),
       this.attemptSettings,
@@ -219,6 +303,11 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
 
   public async finalize(): Promise<void> {
     this.finalized = true;
+    // Stop any active resource-lock renewals so their timers cannot outlive the locker.
+    for (const timer of this.renewalTimers.values()) {
+      clearInterval(timer);
+    }
+    this.renewalTimers.clear();
     try {
       // On controlled server shutdown: clean up all existing locks.
       await this.clearLocks();

--- a/src/util/locking/RedisLocker.ts
+++ b/src/util/locking/RedisLocker.ts
@@ -18,14 +18,7 @@ const attemptDefaults: Required<AttemptSettings> = { retryCount: -1, retryDelay:
 const PREFIX_RW = '__RW__';
 const PREFIX_LOCK = '__L__';
 
-/**
- * Default time-to-live (in ms) for a Redis lock key.
- *
- * A crashed lock holder's key auto-expires after this time so that other instances cannot deadlock
- * on the abandoned resource. It is deliberately several times larger than the in-process lock
- * expiration (see {@link WrappedExpiringReadWriteLocker}, 6000ms by default), and it is actively
- * renewed while a lock is legitimately held, so a normal operation never loses its lock.
- */
+// Default time-to-live (in ms) for a Redis lock key
 const DEFAULT_TTL = 30000;
 
 export interface RedisSettings {
@@ -38,23 +31,16 @@ export interface RedisSettings {
   /* The number of the database to use */
   db?: number;
   /**
-   * Time-to-live (in ms) for the Redis lock keys. A crashed holder's key auto-expires after this
-   * time so peers do not deadlock. While a lock is legitimately held it is renewed at half this
-   * interval, so this value only bounds how long peers wait after a hard crash. Must be larger than
-   * the in-process lock expiration. Defaults to {@link DEFAULT_TTL} (30000ms).
+   * Time-to-live (in ms) for the Redis lock keys, so a crashed holder's lock releases itself
+   * instead of deadlocking peers. Held locks are renewed well before they can expire,
+   * so this only needs to be larger than the in-process lock expiration. Defaults to 30000.
    */
   ttl?: number;
   /**
-   * Whether to delete every lock in this namespace when the locker starts (see {@link RedisLocker.initialize}).
-   *
-   * This is only safe when a single instance exclusively owns the Redis namespace: it lets that
-   * instance recover from locks left behind by a previous crashed run. When multiple instances share
-   * a namespace (the setup required for HA coordination) a restarting instance cannot tell its own
-   * stale locks from the live locks of its peers, so wiping the namespace on boot would corrupt peers
-   * that still hold those locks. Because a crashed holder's lock now auto-expires through its TTL lease
-   * (see {@link RedisSettings.ttl}), boot-time clearing is no longer needed for correctness, so this
-   * defaults to `false` (multi-instance-safe). Set it to `true` for a single-instance deployment that
-   * prefers stale locks cleared immediately on boot rather than waiting for the TTL to elapse.
+   * Whether to delete every lock in this namespace when the locker starts or stops.
+   * This is only safe when a single instance exclusively owns the namespace,
+   * as instances sharing it cannot tell stale locks from those held by live peers.
+   * Defaults to `false`, leaving stale locks to expire through their TTL.
    */
   clearLocksOnStart?: boolean;
 }
@@ -118,9 +104,8 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     this.attemptSettings = { ...attemptDefaults, ...attemptSettings };
     this.namespacePrefix = namespacePrefix!;
     this.ttl = ttl ?? DEFAULT_TTL;
-    // Default to NOT wiping the namespace on boot so peers sharing it (HA) are never disturbed.
     this.clearLocksOnStart = clearLocksOnStart ?? false;
-    // Renew at half the TTL so a live holder refreshes its lock long before it could expire.
+    // Renewing at half the TTL refreshes a held lock long before it can expire.
     this.renewalInterval = Math.max(1, Math.floor(this.ttl / 2));
 
     // Register lua scripts
@@ -184,15 +169,13 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   /* Lease renewal */
 
   /**
-   * Creates an interval timer that periodically refreshes the TTL of a held Redis lock (a lease).
-   * As long as the process is alive the lock keeps being renewed, so a legitimate (even long-running)
-   * operation never loses its lock. Once the process crashes the timer dies with it and the Redis key
-   * expires after the TTL, releasing the abandoned lock so peers do not deadlock.
+   * Creates an interval timer that keeps refreshing the TTL of a held Redis lock.
+   * When the process crashes, the timer dies with it and the lock expires on its own.
    *
-   * @param renew - Refreshes the TTL of the relevant Redis key. Rejections are swallowed and logged,
-   *                as a single missed refresh is recovered by the next interval tick.
+   * @param renew - Refreshes the TTL of the relevant Redis key.
+   *                Rejections are only logged since the next interval recovers a missed refresh.
    *
-   * @returns The interval timer, which must be cleared with {@link clearInterval} once the lock is released.
+   * @returns The timer, which needs to be cleared once the lock is released.
    */
   private createRenewalTimer(renew: () => Promise<RedisAnswer>): NodeJS.Timeout {
     const timer = setInterval((): void => {
@@ -200,16 +183,13 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
         this.logger.warn(`Could not renew Redis lock TTL: ${createErrorMessage(error)}`);
       });
     }, this.renewalInterval);
-    // A background renewal timer should never keep the Node.js process alive on its own.
+    // Prevent the timer from keeping the Node.js process alive
     timer.unref();
     return timer;
   }
 
   /**
-   * Starts renewing the TTL of a resource lock and tracks the timer so it can be stopped on release.
-   *
-   * @param key - The Redis key of the acquired resource lock.
-   * @param renew - Refreshes the TTL of the resource lock key.
+   * Starts renewing the TTL of the resource lock with the given key.
    */
   private startRenewal(key: string, renew: () => Promise<RedisAnswer>): void {
     this.stopRenewal(key);
@@ -217,9 +197,7 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
   }
 
   /**
-   * Stops renewing the TTL of a resource lock, if a renewal timer is active for the given key.
-   *
-   * @param key - The Redis key of the resource lock to stop renewing.
+   * Stops renewing the TTL of the resource lock with the given key.
    */
   private stopRenewal(key: string): void {
     const timer = this.renewalTimers.get(key);
@@ -299,8 +277,7 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
       this.swallowFalse(this.redisLock.acquireLock.bind(this.redisLock, key, this.ttl)),
       this.attemptSettings,
     );
-    // A resource lock is held across separate acquire()/release() calls, so keep renewing its TTL
-    // until it is explicitly released (or the process crashes).
+    // A resource lock is held across separate calls, so its renewal timer has to be tracked until release.
     this.startRenewal(key, async(): Promise<RedisAnswer> => this.redisLock.renewLock(key, this.ttl));
   }
 
@@ -317,15 +294,11 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
 
   public async initialize(): Promise<void> {
     if (!this.clearLocksOnStart) {
-      // Multiple instances may share this namespace to coordinate (HA). This instance cannot tell its
-      // own stale locks from the live locks of its peers, so it must NOT wipe the namespace on boot:
-      // deleting a peer's held lock would open a corruption window. A crashed holder's lock instead
-      // self-heals via its TTL lease. Single-instance deployments can opt back in via `clearLocksOnStart`.
+      // Existing locks might be held by peers sharing this namespace; stale ones expire through their TTL.
       this.logger.debug('Skipping boot-time lock cleanup; relying on lock TTLs (clearLocksOnStart is disabled).');
       return;
     }
-    // On server start (single-instance only): remove all existing (dangling) locks left behind by a
-    // previous crashed run, so new requests are not blocked while waiting for those locks' TTLs.
+    // On server start: remove all existing (dangling) locks, so new requests are not blocked.
     return this.clearLocks();
   }
 
@@ -338,18 +311,14 @@ export class RedisLocker implements ReadWriteLocker, ResourceLocker, Initializab
     this.renewalTimers.clear();
     try {
       if (this.clearLocksOnStart) {
-        // Single-instance mode (the same mode that wipes on boot): this instance exclusively owns the
-        // namespace, so on a controlled shutdown it cleans up every lock it left behind.
+        // On controlled server shutdown: clean up all existing locks.
         await this.clearLocks();
       } else {
-        // Multiple instances may share this namespace to coordinate (HA). A gracefully stopping instance
-        // cannot tell its own locks from the live locks of its peers, so it must NOT wipe the namespace on
-        // shutdown: deleting a peer's held lock would open the same corruption window as a boot-time wipe.
-        // This instance's own locks self-heal via their TTL leases once it stops renewing them above.
+        // Locks might be held by peers sharing this namespace; those of this instance expire through their TTL.
         this.logger.debug('Skipping shutdown lock cleanup; relying on lock TTLs (clearLocksOnStart is disabled).');
       }
     } finally {
-      // Always quit the redis client, whether or not the namespace was cleared, so no connection leaks.
+      // Always quit the redis client
       await this.redis.quit();
     }
   }

--- a/src/util/locking/scripts/RedisLuaScripts.ts
+++ b/src/util/locking/scripts/RedisLuaScripts.ts
@@ -17,8 +17,7 @@ export const REDIS_LUA_SCRIPTS = {
       return 0
     end
 
-    -- Increment the read counter and (re)set its TTL (in ms, ARGV[1]) atomically, so a crashed
-    -- reader can never keep the counter alive (and thus deadlock writers) forever.
+    -- Increment the read counter and (re)set its TTL (in ms, ARGV[1]) atomically
     local countKey = KEYS[1].."${SUFFIX_COUNT}"
     local count = redis.call("incr", countKey)
     redis.call("pexpire", countKey, ARGV[1])
@@ -33,8 +32,7 @@ export const REDIS_LUA_SCRIPTS = {
       return 0
     end
 
-    -- Set the write lock together with a TTL (in ms, ARGV[1]) and respond with 'OK' if succeeded
-    -- (otherwise null). The TTL ensures a crashed holder's lock auto-releases instead of deadlocking peers.
+    -- Set the lock with a TTL (in ms, ARGV[1]) and respond with 'OK' if succeeded (otherwise null)
     return redis.call("set", lockKey, "${LOCKED}", "PX", ARGV[1]);
     `,
   releaseReadLock: `
@@ -58,14 +56,12 @@ export const REDIS_LUA_SCRIPTS = {
       end
     `,
   renewReadLock: `
-      -- Refresh the read counter TTL (in ms, ARGV[1]) while at least one reader legitimately holds
-      -- the lock, so the counter never expires mid-operation and lets a writer in.
+      -- Refresh the read counter TTL (in ms, ARGV[1])
       local countKey = KEYS[1].."${SUFFIX_COUNT}"
       return redis.call("pexpire", countKey, ARGV[1])
       `,
   renewWriteLock: `
-      -- Refresh the write lock TTL (in ms, ARGV[1]) while it is legitimately held, so a long-running
-      -- operation never loses its lock.
+      -- Refresh the write lock TTL (in ms, ARGV[1])
       local lockKey = KEYS[1].."${SUFFIX_WLOCK}"
       return redis.call("pexpire", lockKey, ARGV[1])
       `,
@@ -76,8 +72,7 @@ export const REDIS_LUA_SCRIPTS = {
         return 0
       end
 
-      -- Set the lock with a TTL (in ms, ARGV[1]) and return 'OK' if succeeded. The TTL ensures a
-      -- crashed holder's lock auto-releases instead of deadlocking peers.
+      -- Set the lock with a TTL (in ms, ARGV[1]) and return 'OK' if succeeded (otherwise null)
       return redis.call("set", key, "${LOCKED}", "PX", ARGV[1]);
       `,
   releaseLock: `
@@ -91,7 +86,7 @@ export const REDIS_LUA_SCRIPTS = {
       end
     `,
   renewLock: `
-      -- Refresh the lock TTL (in ms, ARGV[1]) while it is legitimately held.
+      -- Refresh the lock TTL (in ms, ARGV[1])
       local key = KEYS[1].."${SUFFIX_LOCK}"
       return redis.call("pexpire", key, ARGV[1])
       `,
@@ -133,9 +128,7 @@ export interface RedisReadWriteLock extends Redis {
   /**
    * Try to acquire a readLock on `resourceIdentifierPath`.
    * Will succeed if there are no write locks.
-   *
-   * @param resourceIdentifierPath - The key to lock.
-   * @param ttl - Time-to-live (in ms) set on the read counter, so a crashed reader auto-releases.
+   * The corresponding read counter expires after `ttl` ms unless renewed.
    *
    * @returns 1 if succeeded. 0 if not possible.
    */
@@ -144,29 +137,21 @@ export interface RedisReadWriteLock extends Redis {
   /**
    * Try to acquire a writeLock on `resourceIdentifierPath`.
    * Only works if no other write lock is present and the read counter is 0.
-   *
-   * @param resourceIdentifierPath - The key to lock.
-   * @param ttl - Time-to-live (in ms) set on the write lock, so a crashed holder auto-releases.
+   * The lock expires after `ttl` ms unless renewed.
    *
    * @returns 'OK' if succeeded, 0 if not possible.
    */
   acquireWriteLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
 
   /**
-   * Refresh the TTL of the read counter while the lock is legitimately held (a lease renewal).
-   *
-   * @param resourceIdentifierPath - The key whose read counter TTL should be refreshed.
-   * @param ttl - Time-to-live (in ms) to (re)set on the read counter.
+   * Refresh the TTL (in ms) of the read counter of `resourceIdentifierPath`.
    *
    * @returns 1 if the TTL was refreshed, 0 if the counter no longer exists.
    */
   renewReadLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<number>) => Promise<RedisAnswer>;
 
   /**
-   * Refresh the TTL of the write lock while it is legitimately held (a lease renewal).
-   *
-   * @param resourceIdentifierPath - The key whose write lock TTL should be refreshed.
-   * @param ttl - Time-to-live (in ms) to (re)set on the write lock.
+   * Refresh the TTL (in ms) of the write lock on `resourceIdentifierPath`.
    *
    * @returns 1 if the TTL was refreshed, 0 if the lock no longer exists.
    */
@@ -191,19 +176,14 @@ export interface RedisResourceLock extends Redis {
   /**
    * Try to acquire a lock  on `resourceIdentifierPath`.
    * Only works if no other lock is present.
-   *
-   * @param resourceIdentifierPath - The key to lock.
-   * @param ttl - Time-to-live (in ms) set on the lock, so a crashed holder auto-releases.
+   * The lock expires after `ttl` ms unless renewed.
    *
    * @returns 'OK' if succeeded, 0 if not possible.
    */
   acquireLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
 
   /**
-   * Refresh the TTL of the lock while it is legitimately held (a lease renewal).
-   *
-   * @param resourceIdentifierPath - The key whose lock TTL should be refreshed.
-   * @param ttl - Time-to-live (in ms) to (re)set on the lock.
+   * Refresh the TTL (in ms) of the lock on `resourceIdentifierPath`.
    *
    * @returns 1 if the TTL was refreshed, 0 if the lock no longer exists.
    */

--- a/src/util/locking/scripts/RedisLuaScripts.ts
+++ b/src/util/locking/scripts/RedisLuaScripts.ts
@@ -16,10 +16,13 @@ export const REDIS_LUA_SCRIPTS = {
     if redis.call("exists", lockKey) == 1 then
       return 0
     end
-    
-    -- Return true if succeeded (and counter is incremented)
+
+    -- Increment the read counter and (re)set its TTL (in ms, ARGV[1]) atomically, so a crashed
+    -- reader can never keep the counter alive (and thus deadlock writers) forever.
     local countKey = KEYS[1].."${SUFFIX_COUNT}"
-    return redis.call("incr", countKey) > 0
+    local count = redis.call("incr", countKey)
+    redis.call("pexpire", countKey, ARGV[1])
+    return count > 0
     `,
   acquireWriteLock: `
     -- Return 0 if a lock entry already exists or read count is > 0
@@ -29,9 +32,10 @@ export const REDIS_LUA_SCRIPTS = {
     if ((redis.call("exists", lockKey) == 1) or (count ~= nil and count > 0)) then
       return 0
     end
-    
-    -- Set lock and respond with 'OK' if succeeded (otherwise null)
-    return redis.call("set", lockKey, "${LOCKED}");
+
+    -- Set the write lock together with a TTL (in ms, ARGV[1]) and respond with 'OK' if succeeded
+    -- (otherwise null). The TTL ensures a crashed holder's lock auto-releases instead of deadlocking peers.
+    return redis.call("set", lockKey, "${LOCKED}", "PX", ARGV[1]);
     `,
   releaseReadLock: `
       -- Return 1 after decreasing the counter, if counter is < 0 now: return '-ERR'
@@ -53,15 +57,28 @@ export const REDIS_LUA_SCRIPTS = {
         return redis.error_reply("Error trying to release writelock that did not exist.")
       end
     `,
+  renewReadLock: `
+      -- Refresh the read counter TTL (in ms, ARGV[1]) while at least one reader legitimately holds
+      -- the lock, so the counter never expires mid-operation and lets a writer in.
+      local countKey = KEYS[1].."${SUFFIX_COUNT}"
+      return redis.call("pexpire", countKey, ARGV[1])
+      `,
+  renewWriteLock: `
+      -- Refresh the write lock TTL (in ms, ARGV[1]) while it is legitimately held, so a long-running
+      -- operation never loses its lock.
+      local lockKey = KEYS[1].."${SUFFIX_WLOCK}"
+      return redis.call("pexpire", lockKey, ARGV[1])
+      `,
   acquireLock: `
       -- Return 0 if lock entry already exists, or 'OK' if it succeeds in setting the lock entry.
       local key = KEYS[1].."${SUFFIX_LOCK}"
       if redis.call("exists", key) == 1 then
         return 0
       end
-      
-      -- Return 'OK' if succeeded setting entry
-      return redis.call("set", key, "${LOCKED}");
+
+      -- Set the lock with a TTL (in ms, ARGV[1]) and return 'OK' if succeeded. The TTL ensures a
+      -- crashed holder's lock auto-releases instead of deadlocking peers.
+      return redis.call("set", key, "${LOCKED}", "PX", ARGV[1]);
       `,
   releaseLock: `
       -- Release the lock and reply with 1 if succeeded (otherwise return '-ERR')
@@ -73,6 +90,11 @@ export const REDIS_LUA_SCRIPTS = {
         return redis.error_reply("Error trying to release lock that did not exist.")
       end
     `,
+  renewLock: `
+      -- Refresh the lock TTL (in ms, ARGV[1]) while it is legitimately held.
+      local key = KEYS[1].."${SUFFIX_LOCK}"
+      return redis.call("pexpire", key, ARGV[1])
+      `,
 } as const;
 
 export type RedisAnswer = 0 | 1 | null | string;
@@ -112,17 +134,43 @@ export interface RedisReadWriteLock extends Redis {
    * Try to acquire a readLock on `resourceIdentifierPath`.
    * Will succeed if there are no write locks.
    *
+   * @param resourceIdentifierPath - The key to lock.
+   * @param ttl - Time-to-live (in ms) set on the read counter, so a crashed reader auto-releases.
+   *
    * @returns 1 if succeeded. 0 if not possible.
    */
-  acquireReadLock: (resourceIdentifierPath: string, callback?: Callback<string>) => Promise<RedisAnswer>;
+  acquireReadLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
 
   /**
    * Try to acquire a writeLock on `resourceIdentifierPath`.
    * Only works if no other write lock is present and the read counter is 0.
    *
+   * @param resourceIdentifierPath - The key to lock.
+   * @param ttl - Time-to-live (in ms) set on the write lock, so a crashed holder auto-releases.
+   *
    * @returns 'OK' if succeeded, 0 if not possible.
    */
-  acquireWriteLock: (resourceIdentifierPath: string, callback?: Callback<string>) => Promise<RedisAnswer>;
+  acquireWriteLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
+
+  /**
+   * Refresh the TTL of the read counter while the lock is legitimately held (a lease renewal).
+   *
+   * @param resourceIdentifierPath - The key whose read counter TTL should be refreshed.
+   * @param ttl - Time-to-live (in ms) to (re)set on the read counter.
+   *
+   * @returns 1 if the TTL was refreshed, 0 if the counter no longer exists.
+   */
+  renewReadLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<number>) => Promise<RedisAnswer>;
+
+  /**
+   * Refresh the TTL of the write lock while it is legitimately held (a lease renewal).
+   *
+   * @param resourceIdentifierPath - The key whose write lock TTL should be refreshed.
+   * @param ttl - Time-to-live (in ms) to (re)set on the write lock.
+   *
+   * @returns 1 if the TTL was refreshed, 0 if the lock no longer exists.
+   */
+  renewWriteLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<number>) => Promise<RedisAnswer>;
 
   /**
    * Release readLock. This means decrementing the read counter with 1.
@@ -144,9 +192,22 @@ export interface RedisResourceLock extends Redis {
    * Try to acquire a lock  on `resourceIdentifierPath`.
    * Only works if no other lock is present.
    *
+   * @param resourceIdentifierPath - The key to lock.
+   * @param ttl - Time-to-live (in ms) set on the lock, so a crashed holder auto-releases.
+   *
    * @returns 'OK' if succeeded, 0 if not possible.
    */
-  acquireLock: (resourceIdentifierPath: string, callback?: Callback<string>) => Promise<RedisAnswer>;
+  acquireLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<string>) => Promise<RedisAnswer>;
+
+  /**
+   * Refresh the TTL of the lock while it is legitimately held (a lease renewal).
+   *
+   * @param resourceIdentifierPath - The key whose lock TTL should be refreshed.
+   * @param ttl - Time-to-live (in ms) to (re)set on the lock.
+   *
+   * @returns 1 if the TTL was refreshed, 0 if the lock no longer exists.
+   */
+  renewLock: (resourceIdentifierPath: string, ttl: number, callback?: Callback<number>) => Promise<RedisAnswer>;
 
   /**
    * Release lock. This means deleting the lock.

--- a/test/unit/util/locking/RedisLocker.test.ts
+++ b/test/unit/util/locking/RedisLocker.test.ts
@@ -641,10 +641,24 @@ describe('A RedisLocker', (): void => {
     });
 
     describe('initialize()', (): void => {
-      it('should clear all locks when initialize() is called.', async(): Promise<void> => {
+      it('does not clear locks on boot by default, so peer instances keep their locks.', async(): Promise<void> => {
+        store.reset();
         await locker.acquire({ path: 'path1' });
         await locker.acquire({ path: 'path2' });
         await locker.initialize();
+        // The default is multi-instance-safe: a restarting instance must not wipe its peers' locks.
+        expect(Object.keys(store.internal)).toHaveLength(2);
+        // Release the acquired resource locks so their renewal timers do not leak into later tests.
+        await locker.release({ path: 'path1' });
+        await locker.release({ path: 'path2' });
+      });
+
+      it('clears all locks on boot when clearLocksOnStart is enabled.', async(): Promise<void> => {
+        store.reset();
+        const clearingLocker = new RedisLocker('6379', { retryCount: 5 }, { clearLocksOnStart: true });
+        await clearingLocker.acquire({ path: 'path1' });
+        await clearingLocker.acquire({ path: 'path2' });
+        await clearingLocker.initialize();
         expect(Object.keys(store.internal)).toHaveLength(0);
       });
     });

--- a/test/unit/util/locking/RedisLocker.test.ts
+++ b/test/unit/util/locking/RedisLocker.test.ts
@@ -87,12 +87,15 @@ const redis: jest.Mocked<Redis & RedisResourceLock & RedisReadWriteLock> = {
     store.acquireReadLock(key)),
   acquireWriteLock: jest.fn().mockImplementation(async(key: string): Promise<number | null | 'OK'> =>
     store.acquireWriteLock(key)),
+  renewReadLock: jest.fn().mockResolvedValue(1),
+  renewWriteLock: jest.fn().mockResolvedValue(1),
   releaseReadLock: jest.fn().mockImplementation(async(key: string): Promise<number> =>
     store.releaseReadLock(key)),
   releaseWriteLock: jest.fn().mockImplementation(async(key: string): Promise<number | null> =>
     store.releaseWriteLock(key)),
   acquireLock: jest.fn().mockImplementation(async(key: string): Promise<number | null | 'OK'> =>
     store.acquireLock(key)),
+  renewLock: jest.fn().mockResolvedValue(1),
   releaseLock: jest.fn().mockImplementation(async(key: string): Promise<number | null | string> =>
     store.releaseLock(key)),
 } as any;
@@ -124,6 +127,8 @@ describe('A RedisLocker', (): void => {
     afterEach(async(): Promise<void> => {
     // In case some locks are not released by a test the timers will still be running
       jest.clearAllTimers();
+      // Restore real timers in case a test enabled fake timers for renewal assertions
+      jest.useRealTimers();
     });
 
     it('will fill in default arguments when constructed with empty arguments.', (): void => {
@@ -418,6 +423,93 @@ describe('A RedisLocker', (): void => {
       await expect(promise).rejects.toThrow('Unexpected Redis answer received! (unexpected)');
     });
 
+    describe('lock TTL', (): void => {
+      const key = `__RW__${resource1.path}`;
+
+      it('sets the default TTL when acquiring a read lock.', async(): Promise<void> => {
+        await locker.withReadLock(resource1, (): number => 5);
+        expect(redis.acquireReadLock).toHaveBeenCalledTimes(1);
+        expect(redis.acquireReadLock).toHaveBeenCalledWith(key, 30000);
+      });
+
+      it('sets the default TTL when acquiring a write lock.', async(): Promise<void> => {
+        await locker.withWriteLock(resource1, (): number => 5);
+        expect(redis.acquireWriteLock).toHaveBeenCalledTimes(1);
+        expect(redis.acquireWriteLock).toHaveBeenCalledWith(key, 30000);
+      });
+
+      it('uses a custom TTL when one is configured.', async(): Promise<void> => {
+        const customLocker = new RedisLocker('6379', {}, { ttl: 12000 });
+        await customLocker.withWriteLock(resource1, (): number => 5);
+        expect(redis.acquireWriteLock).toHaveBeenCalledWith(key, 12000);
+      });
+
+      it('renews the write lock TTL while the lock is held, and stops after release.', async(): Promise<void> => {
+        jest.useFakeTimers();
+        const emitter = new EventEmitter();
+        const promise = locker.withWriteLock(resource1, async(): Promise<void> =>
+          new Promise<void>((resolve): any => emitter.on('release', resolve)));
+
+        // Allow the acquire to resolve and the renewal timer to be scheduled
+        await flushPromises();
+
+        // The renewal fires at half the TTL and refreshes the write lock key with the full TTL
+        jest.advanceTimersByTime(15000);
+        expect(redis.renewWriteLock).toHaveBeenCalledTimes(1);
+        expect(redis.renewWriteLock).toHaveBeenLastCalledWith(key, 30000);
+        jest.advanceTimersByTime(15000);
+        expect(redis.renewWriteLock).toHaveBeenCalledTimes(2);
+
+        emitter.emit('release');
+        await promise;
+
+        // Once released the renewal timer is cleared and no further renewals happen
+        jest.advanceTimersByTime(60000);
+        expect(redis.renewWriteLock).toHaveBeenCalledTimes(2);
+      });
+
+      it('renews the read lock counter TTL while the lock is held.', async(): Promise<void> => {
+        jest.useFakeTimers();
+        const emitter = new EventEmitter();
+        const promise = locker.withReadLock(resource1, async(): Promise<void> =>
+          new Promise<void>((resolve): any => emitter.on('release', resolve)));
+
+        await flushPromises();
+
+        jest.advanceTimersByTime(15000);
+        expect(redis.renewReadLock).toHaveBeenCalledTimes(1);
+        expect(redis.renewReadLock).toHaveBeenLastCalledWith(key, 30000);
+
+        emitter.emit('release');
+        await promise;
+
+        jest.advanceTimersByTime(60000);
+        expect(redis.renewReadLock).toHaveBeenCalledTimes(1);
+      });
+
+      it('logs a warning when a lock renewal fails.', async(): Promise<void> => {
+        jest.useFakeTimers();
+        const logger = (locker as any).logger;
+        const warnSpy = jest.spyOn(logger, 'warn').mockImplementation((): any => undefined);
+        redis.renewWriteLock.mockRejectedValueOnce(new Error('renewal boom'));
+
+        const emitter = new EventEmitter();
+        const promise = locker.withWriteLock(resource1, async(): Promise<void> =>
+          new Promise<void>((resolve): any => emitter.on('release', resolve)));
+
+        await flushPromises();
+        jest.advanceTimersByTime(15000);
+        // Allow the rejected renewal promise to settle so the catch handler runs
+        await flushPromises();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenLastCalledWith(expect.stringContaining('Could not renew Redis lock TTL'));
+
+        emitter.emit('release');
+        await promise;
+        warnSpy.mockRestore();
+      });
+    });
+
     describe('finalize()', (): void => {
       it('should call quit and clear Read-Write locks when finalize() is called.', async(): Promise<void> => {
         const promise = locker.withWriteLock(resource1, async(): Promise<any> => {
@@ -443,6 +535,8 @@ describe('A RedisLocker', (): void => {
     afterEach(async(): Promise<void> => {
     // In case some locks are not released by a test the timers will still be running
       jest.clearAllTimers();
+      // Restore real timers in case a test enabled fake timers for renewal assertions
+      jest.useRealTimers();
     });
 
     it('will fill in default arguments when constructed with empty arguments.', (): void => {
@@ -455,6 +549,38 @@ describe('A RedisLocker', (): void => {
       await expect(locker.release(identifier)).resolves.toBeUndefined();
       expect(redis.acquireLock).toHaveBeenCalledTimes(1);
       expect(redis.releaseLock).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets a TTL when acquiring a resource lock.', async(): Promise<void> => {
+      await locker.acquire(identifier);
+      expect(redis.acquireLock).toHaveBeenCalledTimes(1);
+      expect(redis.acquireLock).toHaveBeenCalledWith(`__L__${identifier.path}`, 30000);
+      await locker.release(identifier);
+    });
+
+    it('renews a held resource lock TTL until it is released.', async(): Promise<void> => {
+      jest.useFakeTimers();
+      const key = `__L__${identifier.path}`;
+      await locker.acquire(identifier);
+
+      jest.advanceTimersByTime(15000);
+      expect(redis.renewLock).toHaveBeenCalledTimes(1);
+      expect(redis.renewLock).toHaveBeenLastCalledWith(key, 30000);
+
+      await locker.release(identifier);
+
+      // No renewals happen once the resource lock is released
+      jest.advanceTimersByTime(60000);
+      expect(redis.renewLock).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops renewing held resource locks on finalize.', async(): Promise<void> => {
+      jest.useFakeTimers();
+      await locker.acquire({ path: 'path1' });
+      await locker.finalize();
+
+      jest.advanceTimersByTime(60000);
+      expect(redis.renewLock).not.toHaveBeenCalled();
     });
 
     it('can lock a resource again after it was unlocked.', async(): Promise<void> => {

--- a/test/unit/util/locking/RedisLocker.test.ts
+++ b/test/unit/util/locking/RedisLocker.test.ts
@@ -514,9 +514,7 @@ describe('A RedisLocker', (): void => {
       it('does not wipe Read-Write locks on shutdown by default, but still quits.', async(): Promise<void> => {
         const promise = locker.withWriteLock(resource1, async(): Promise<any> => {
           await locker.finalize();
-          // Default is multi-instance-safe: the peer-visible lock namespace is left intact on shutdown.
           expect(Object.keys(store.internal)).toHaveLength(1);
-          // The redis client is always disconnected, even when the namespace is not wiped.
           expect(redis.quit).toHaveBeenCalledTimes(1);
         });
         // Auto-release of Read-Write lock should result in an exception, as the Locker has been finalized.
@@ -525,11 +523,10 @@ describe('A RedisLocker', (): void => {
 
       it('wipes Read-Write locks on shutdown when clearLocksOnStart is enabled.', async(): Promise<void> => {
         const clearingLocker = new RedisLocker('6379', {}, { clearLocksOnStart: true });
-        // Leaves a Read-Write key in the store (lock released, but the key persists to be cleaned on shutdown).
+        // The released lock leaves a Read-Write key in the store to be cleaned up on shutdown.
         await clearingLocker.withWriteLock(resource1, (): number => 5);
         expect(Object.keys(store.internal)).toHaveLength(1);
         await clearingLocker.finalize();
-        // Single-instance mode still cleans up the namespace it exclusively owns on shutdown.
         expect(Object.keys(store.internal)).toHaveLength(0);
         expect(redis.quit).toHaveBeenCalledTimes(1);
       });
@@ -541,8 +538,7 @@ describe('A RedisLocker', (): void => {
     const identifier = { path: 'http://test.com/foo' };
 
     beforeEach(async(): Promise<void> => {
-      // Reset the shared store so a lock left behind by a prior test (finalize no longer wipes the
-      // namespace by default) cannot leak into the next test.
+      // Reset the shared store so locks left behind by a prior test cannot leak into this one.
       store.reset();
       jest.clearAllMocks();
       locker = new RedisLocker('6379', { retryCount: 5 });
@@ -662,7 +658,6 @@ describe('A RedisLocker', (): void => {
         await locker.acquire({ path: 'path1' });
         await locker.acquire({ path: 'path2' });
         await locker.initialize();
-        // The default is multi-instance-safe: a restarting instance must not wipe its peers' locks.
         expect(Object.keys(store.internal)).toHaveLength(2);
         // Release the acquired resource locks so their renewal timers do not leak into later tests.
         await locker.release({ path: 'path1' });
@@ -692,9 +687,7 @@ describe('A RedisLocker', (): void => {
         await locker.acquire({ path: 'path1' });
         await locker.acquire({ path: 'path2' });
         await locker.finalize();
-        // Default is multi-instance-safe: a peer's locks must survive this instance's graceful shutdown.
         expect(Object.keys(store.internal)).toHaveLength(2);
-        // The redis client is always disconnected, so no connection leaks even when nothing is wiped.
         expect(redis.quit).toHaveBeenCalledTimes(1);
       });
 
@@ -704,7 +697,6 @@ describe('A RedisLocker', (): void => {
         await clearingLocker.acquire({ path: 'path1' });
         await clearingLocker.acquire({ path: 'path2' });
         await clearingLocker.finalize();
-        // Single-instance mode still cleans up the namespace it exclusively owns on shutdown.
         expect(Object.keys(store.internal)).toHaveLength(0);
         expect(redis.quit).toHaveBeenCalledTimes(1);
       });

--- a/test/unit/util/locking/RedisLocker.test.ts
+++ b/test/unit/util/locking/RedisLocker.test.ts
@@ -511,14 +511,27 @@ describe('A RedisLocker', (): void => {
     });
 
     describe('finalize()', (): void => {
-      it('should call quit and clear Read-Write locks when finalize() is called.', async(): Promise<void> => {
+      it('does not wipe Read-Write locks on shutdown by default, but still quits.', async(): Promise<void> => {
         const promise = locker.withWriteLock(resource1, async(): Promise<any> => {
           await locker.finalize();
-          expect(Object.keys(store.internal)).toHaveLength(0);
+          // Default is multi-instance-safe: the peer-visible lock namespace is left intact on shutdown.
+          expect(Object.keys(store.internal)).toHaveLength(1);
+          // The redis client is always disconnected, even when the namespace is not wiped.
           expect(redis.quit).toHaveBeenCalledTimes(1);
         });
         // Auto-release of Read-Write lock should result in an exception, as the Locker has been finalized.
         await expect(promise).rejects.toThrow(/Invalid state/u);
+      });
+
+      it('wipes Read-Write locks on shutdown when clearLocksOnStart is enabled.', async(): Promise<void> => {
+        const clearingLocker = new RedisLocker('6379', {}, { clearLocksOnStart: true });
+        // Leaves a Read-Write key in the store (lock released, but the key persists to be cleaned on shutdown).
+        await clearingLocker.withWriteLock(resource1, (): number => 5);
+        expect(Object.keys(store.internal)).toHaveLength(1);
+        await clearingLocker.finalize();
+        // Single-instance mode still cleans up the namespace it exclusively owns on shutdown.
+        expect(Object.keys(store.internal)).toHaveLength(0);
+        expect(redis.quit).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -528,6 +541,9 @@ describe('A RedisLocker', (): void => {
     const identifier = { path: 'http://test.com/foo' };
 
     beforeEach(async(): Promise<void> => {
+      // Reset the shared store so a lock left behind by a prior test (finalize no longer wipes the
+      // namespace by default) cannot leak into the next test.
+      store.reset();
       jest.clearAllMocks();
       locker = new RedisLocker('6379', { retryCount: 5 });
     });
@@ -664,16 +680,31 @@ describe('A RedisLocker', (): void => {
     });
 
     describe('finalize()', (): void => {
-      it('should clear all locks (even when empty) when finalize() is called.', async(): Promise<void> => {
+      it('quits the redis client even when there are no locks to clear.', async(): Promise<void> => {
+        store.reset();
         await locker.finalize();
         expect(Object.keys(store.internal)).toHaveLength(0);
         expect(redis.quit).toHaveBeenCalledTimes(1);
       });
 
-      it('should clear all locks when finalize() is called.', async(): Promise<void> => {
+      it('does not wipe the lock namespace on shutdown by default, but still quits.', async(): Promise<void> => {
+        store.reset();
         await locker.acquire({ path: 'path1' });
         await locker.acquire({ path: 'path2' });
         await locker.finalize();
+        // Default is multi-instance-safe: a peer's locks must survive this instance's graceful shutdown.
+        expect(Object.keys(store.internal)).toHaveLength(2);
+        // The redis client is always disconnected, so no connection leaks even when nothing is wiped.
+        expect(redis.quit).toHaveBeenCalledTimes(1);
+      });
+
+      it('wipes the whole lock namespace on shutdown when clearLocksOnStart is enabled.', async(): Promise<void> => {
+        store.reset();
+        const clearingLocker = new RedisLocker('6379', { retryCount: 5 }, { clearLocksOnStart: true });
+        await clearingLocker.acquire({ path: 'path1' });
+        await clearingLocker.acquire({ path: 'path2' });
+        await clearingLocker.finalize();
+        // Single-instance mode still cleans up the namespace it exclusively owns on shutdown.
         expect(Object.keys(store.internal)).toHaveLength(0);
         expect(redis.quit).toHaveBeenCalledTimes(1);
       });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready)

**Stacks on #75** (which stacks on #68) — review those first; this PR's own commit is the `finalize()` gating.

#### 📁 Related issues

None yet — an upstream issue describing the multi-instance Redis locking hazard still needs to be created before this is submitted to CommunitySolidServer (the upstream PR template requires one).

#### ✍️ Description

`RedisLocker.finalize()` always ran the namespace-wide `clearLocks()` on graceful shutdown. When multiple server instances share a Redis namespace to coordinate locking, a stopping instance cannot tell its own locks from the live locks of its peers, so the clean-stop half of a rolling restart deleted locks still held by live instances and opened the same corruption window that #75 closes for boot-time clearing.

The shutdown wipe is now gated behind the same `clearLocksOnStart` flag that #75 introduced for the boot wipe:

- `clearLocksOnStart: false` (default): `finalize()` leaves the namespace intact. The stopping instance's own locks expire through the TTL leases from #68 once it stops renewing them, so nothing leaks.
- `clearLocksOnStart: true`: the full wipe on shutdown is preserved exactly as before, for a single instance that exclusively owns the namespace.

The redis client still disconnects in both branches: `this.redis.quit()` stays in the `finally`, so it also runs if `clearLocks()` throws. The resource-lock renewal timers are likewise stopped in both branches.

Why not a separate flag for the shutdown wipe: boot and shutdown clearing are safe under exactly the same condition (a single instance exclusively owning the namespace), so a second flag would only allow inconsistent middle states. The flag effectively means "this instance owns the whole namespace".

Verification is unit-driven: tests cover both `finalize()` branches (locks survive and the client quits by default; the namespace is wiped and the client quits with `clearLocksOnStart`), and the server boots cleanly with the Redis locker configured.

Together with #68 (TTL leases) and #75 (boot gating), neither an instance's boot nor its clean shutdown can delete peers' still-held locks.

For the upstream submission this should target the latest `versions/*` branch rather than `main`, since the stack changes default configuration behaviour (the boot/shutdown wipe becomes opt-in) and adds `RedisSettings` options. Intended semver level, stated in prose since contributors cannot set the labels: **semver.major** by the checklist's definition (changed configuration behaviour); the maintainer may judge it semver.minor if the old unconditional wipe is considered a bug.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
