### PR TITLE
feat: Add saturation gauges for locks and notification connections

### DIFF
--- a/config/util/metrics/default.json
+++ b/config/util/metrics/default.json
@@ -6,7 +6,7 @@
         "OPT-IN Prometheus metrics. This file is NOT imported by any shipped config: add it next to your main config, e.g. `community-solid-server -c config/file.json -c config/util/metrics/default.json`.",
         "SECURITY: the /metrics endpoint is UNAUTHENTICATED and exposes internal counters (request rates, latencies, process cpu/memory, saturation gauges). Restrict it at your reverse proxy or firewall; never expose it to the public internet.",
         "This recipe assumes the default handler waterfall (config/http/handler/default.json). If you use a different handler configuration, adjust the Override list below to match its handlers.",
-        "The saturation gauges below assume the default single-threaded stack: the in-memory resource locker (config/util/resource-locker/memory.json) and the WebSocket + Streaming HTTP notifications (config/http/notifications/all.json), exactly as in config/default.json. Each source is OPTIONAL: if your config omits one (e.g. a non in-memory locker, or config/http/notifications/disabled.json), remove the matching `locker`/`webSocketMap`/`streamingHttpMap` reference from the collector below so Components.js does not fail to resolve a missing @id."
+        "The saturation gauges assume the default in-memory locker and WebSocket + Streaming HTTP notifications. Every collector source is optional: remove a `locker`/`webSocketMap`/`streamingHttpMap` reference below if your config does not create the matching @id, as Components.js cannot resolve absent references."
       ]
     },
     {
@@ -22,9 +22,8 @@
     },
     {
       "comment": [
-        "Observe-only saturation gauges: current held resource locks (solid_resource_locks) and active notification connections (solid_notification_connections{type}).",
-        "Read lazily on each /metrics scrape via a prom-client collect callback (Map.size / lock count), so nothing runs on the request/notification hot path and no lock is ever taken.",
-        "Each source is optional; see the top-of-file comment before removing one for a non-default stack."
+        "Registers saturation gauges: currently held resource locks (solid_resource_locks) and open notification connections (solid_notification_connections{type}), read on each /metrics scrape.",
+        "Every source is optional; see the comment at the top of this file before removing one."
       ],
       "@id": "urn:solid-server:metrics:MetricsSaturationCollector",
       "@type": "MetricsSaturationCollector",
@@ -34,7 +33,7 @@
       "streamingHttpMap": { "@id": "urn:solid-server:default:StreamingHttpMap" }
     },
     {
-      "comment": "Instantiates the saturation collector and registers its gauges at start-up by adding it to the primary initializer chain (these initializers always run in single-threaded mode, which the in-memory locker requires).",
+      "comment": "Adds the saturation collector to the primary initializer chain so its gauges are registered at start-up.",
       "@id": "urn:solid-server:default:PrimaryParallelInitializer",
       "@type": "ParallelHandler",
       "handlers": [

--- a/config/util/metrics/default.json
+++ b/config/util/metrics/default.json
@@ -34,6 +34,14 @@
       "streamingHttpMap": { "@id": "urn:solid-server:default:StreamingHttpMap" }
     },
     {
+      "comment": "Instantiates the saturation collector and registers its gauges at start-up by adding it to the primary initializer chain (these initializers always run in single-threaded mode, which the in-memory locker requires).",
+      "@id": "urn:solid-server:default:PrimaryParallelInitializer",
+      "@type": "ParallelHandler",
+      "handlers": [
+        { "@id": "urn:solid-server:metrics:MetricsSaturationCollector" }
+      ]
+    },
+    {
       "comment": "Adds the observe-only metrics configurator to the existing (parallel) set of server configurators.",
       "@id": "urn:solid-server:default:ServerConfigurator",
       "@type": "ParallelHandler",

--- a/config/util/metrics/default.json
+++ b/config/util/metrics/default.json
@@ -1,0 +1,56 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": [
+        "OPT-IN Prometheus metrics. This file is NOT imported by any shipped config: add it next to your main config, e.g. `community-solid-server -c config/file.json -c config/util/metrics/default.json`.",
+        "SECURITY: the /metrics endpoint is UNAUTHENTICATED and exposes internal counters (request rates, latencies, process cpu/memory). Restrict it at your reverse proxy or firewall; never expose it to the public internet.",
+        "This recipe assumes the default handler waterfall (config/http/handler/default.json). If you use a different handler configuration, adjust the Override list below to match its handlers."
+      ]
+    },
+    {
+      "comment": "Prometheus registry holding the default process metrics and the HTTP request instruments.",
+      "@id": "urn:solid-server:metrics:PrometheusMetrics",
+      "@type": "PrometheusMetrics"
+    },
+    {
+      "comment": "Observe-only configurator: records request rate/latency without ever writing to the response.",
+      "@id": "urn:solid-server:metrics:MetricsServerConfigurator",
+      "@type": "MetricsServerConfigurator",
+      "metrics": { "@id": "urn:solid-server:metrics:PrometheusMetrics" }
+    },
+    {
+      "comment": "Adds the observe-only metrics configurator to the existing (parallel) set of server configurators.",
+      "@id": "urn:solid-server:default:ServerConfigurator",
+      "@type": "ParallelHandler",
+      "handlers": [
+        { "@id": "urn:solid-server:metrics:MetricsServerConfigurator" }
+      ]
+    },
+    {
+      "comment": "Serves the Prometheus registry on GET /metrics.",
+      "@id": "urn:solid-server:metrics:MetricsHandler",
+      "@type": "MetricsHandler",
+      "metrics": { "@id": "urn:solid-server:metrics:PrometheusMetrics" },
+      "path": "/metrics"
+    },
+    {
+      "comment": "Places the metrics handler first in the waterfall so a scrape is answered immediately and never traverses the LDP stack.",
+      "@type": "Override",
+      "overrideInstance": { "@id": "urn:solid-server:default:BaseHttpHandler" },
+      "overrideParameters": {
+        "@type": "WaterfallHandler",
+        "handlers": [
+          { "@id": "urn:solid-server:metrics:MetricsHandler" },
+          { "@id": "urn:solid-server:default:StaticAssetHandler" },
+          { "@id": "urn:solid-server:default:OidcHandler" },
+          { "@id": "urn:solid-server:default:NotificationHttpHandler" },
+          { "@id": "urn:solid-server:default:StorageDescriptionHandler" },
+          { "@id": "urn:solid-server:default:AuthResourceHttpHandler" },
+          { "@id": "urn:solid-server:default:IdentityProviderHandler" },
+          { "@id": "urn:solid-server:default:LdpHandler" }
+        ]
+      }
+    }
+  ]
+}

--- a/config/util/metrics/default.json
+++ b/config/util/metrics/default.json
@@ -4,8 +4,9 @@
     {
       "comment": [
         "OPT-IN Prometheus metrics. This file is NOT imported by any shipped config: add it next to your main config, e.g. `community-solid-server -c config/file.json -c config/util/metrics/default.json`.",
-        "SECURITY: the /metrics endpoint is UNAUTHENTICATED and exposes internal counters (request rates, latencies, process cpu/memory). Restrict it at your reverse proxy or firewall; never expose it to the public internet.",
-        "This recipe assumes the default handler waterfall (config/http/handler/default.json). If you use a different handler configuration, adjust the Override list below to match its handlers."
+        "SECURITY: the /metrics endpoint is UNAUTHENTICATED and exposes internal counters (request rates, latencies, process cpu/memory, saturation gauges). Restrict it at your reverse proxy or firewall; never expose it to the public internet.",
+        "This recipe assumes the default handler waterfall (config/http/handler/default.json). If you use a different handler configuration, adjust the Override list below to match its handlers.",
+        "The saturation gauges below assume the default single-threaded stack: the in-memory resource locker (config/util/resource-locker/memory.json) and the WebSocket + Streaming HTTP notifications (config/http/notifications/all.json), exactly as in config/default.json. Each source is OPTIONAL: if your config omits one (e.g. a non in-memory locker, or config/http/notifications/disabled.json), remove the matching `locker`/`webSocketMap`/`streamingHttpMap` reference from the collector below so Components.js does not fail to resolve a missing @id."
       ]
     },
     {
@@ -18,6 +19,19 @@
       "@id": "urn:solid-server:metrics:MetricsServerConfigurator",
       "@type": "MetricsServerConfigurator",
       "metrics": { "@id": "urn:solid-server:metrics:PrometheusMetrics" }
+    },
+    {
+      "comment": [
+        "Observe-only saturation gauges: current held resource locks (solid_resource_locks) and active notification connections (solid_notification_connections{type}).",
+        "Read lazily on each /metrics scrape via a prom-client collect callback (Map.size / lock count), so nothing runs on the request/notification hot path and no lock is ever taken.",
+        "Each source is optional; see the top-of-file comment before removing one for a non-default stack."
+      ],
+      "@id": "urn:solid-server:metrics:MetricsSaturationCollector",
+      "@type": "MetricsSaturationCollector",
+      "metrics": { "@id": "urn:solid-server:metrics:PrometheusMetrics" },
+      "locker": { "@id": "urn:solid-server:default:MemoryResourceLocker" },
+      "webSocketMap": { "@id": "urn:solid-server:default:WebSocketMap" },
+      "streamingHttpMap": { "@id": "urn:solid-server:default:StreamingHttpMap" }
     },
     {
       "comment": "Adds the observe-only metrics configurator to the existing (parallel) set of server configurators.",

--- a/config/util/resource-locker/memory.json
+++ b/config/util/resource-locker/memory.json
@@ -8,6 +8,8 @@
       "locker": {
         "@type": "GreedyReadWriteLocker",
         "locker": {
+          "comment": "Named so its held-lock count can be observed by the opt-in saturation metrics.",
+          "@id": "urn:solid-server:default:MemoryResourceLocker",
           "@type": "MemoryResourceLocker"
         },
         "storage": { "@id": "urn:solid-server:default:LockStorage" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "n3": "^1.17.1",
         "nodemailer": "^9.0.1",
         "oidc-provider": "^8.4.0",
+        "prom-client": "^15.1.3",
         "proper-lockfile": "^4.1.2",
         "pump": "^3.0.0",
         "punycode": "^2.3.0",
@@ -5446,6 +5447,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -7605,6 +7615,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -14501,6 +14517,19 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-polyfill": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
@@ -16098,6 +16127,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {
@@ -21579,6 +21617,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
+    },
     "@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -23160,6 +23203,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "brace-expansion": {
       "version": "1.1.14",
@@ -28163,6 +28211,15 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "requires": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise-polyfill": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
@@ -29412,6 +29469,14 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
       "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
       "dev": true
+    },
+    "tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "requires": {
+        "bintrees": "1.0.2"
+      }
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "n3": "^1.17.1",
     "nodemailer": "^9.0.1",
     "oidc-provider": "^8.4.0",
+    "prom-client": "^15.1.3",
     "proper-lockfile": "^4.1.2",
     "pump": "^3.0.0",
     "punycode": "^2.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -382,6 +382,7 @@ export * from './server/middleware/WebSocketAdvertiser';
 
 // Server/Metrics
 export * from './server/metrics/MetricsHandler';
+export * from './server/metrics/MetricsSaturationCollector';
 export * from './server/metrics/MetricsServerConfigurator';
 export * from './server/metrics/PrometheusMetrics';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -380,6 +380,11 @@ export * from './server/middleware/HeaderHandler';
 export * from './server/middleware/StaticAssetHandler';
 export * from './server/middleware/WebSocketAdvertiser';
 
+// Server/Metrics
+export * from './server/metrics/MetricsHandler';
+export * from './server/metrics/MetricsServerConfigurator';
+export * from './server/metrics/PrometheusMetrics';
+
 // Server/Notifications/Generate
 export * from './server/notifications/generate/ActivityNotificationGenerator';
 export * from './server/notifications/generate/AddRemoveNotificationGenerator';

--- a/src/server/metrics/MetricsHandler.ts
+++ b/src/server/metrics/MetricsHandler.ts
@@ -1,0 +1,48 @@
+import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import type { HttpHandlerInput } from '../HttpHandler';
+import { HttpHandler } from '../HttpHandler';
+import type { PrometheusMetrics } from './PrometheusMetrics';
+
+/**
+ * An {@link HttpHandler} that exposes the collected Prometheus metrics on a fixed path (default `/metrics`).
+ *
+ * Only `GET` requests on the configured path are handled;
+ * any other request is rejected with a {@link NotImplementedHttpError} so it continues down the waterfall.
+ *
+ * The response is UNAUTHENTICATED and exposes internal counters:
+ * make sure this endpoint is restricted at the reverse proxy or firewall when the server is publicly reachable.
+ */
+export class MetricsHandler extends HttpHandler {
+  private readonly metrics: PrometheusMetrics;
+  private readonly path: string;
+
+  /**
+   * @param metrics - The {@link PrometheusMetrics} exposing the registry to serialize.
+   * @param path - The path on which the metrics are exposed. Defaults to `/metrics`.
+   */
+  public constructor(metrics: PrometheusMetrics, path = '/metrics') {
+    super();
+    this.metrics = metrics;
+    this.path = path;
+  }
+
+  public async canHandle({ request }: HttpHandlerInput): Promise<void> {
+    if (request.method !== 'GET') {
+      throw new NotImplementedHttpError('Only GET requests are supported');
+    }
+    // Strip a potential query string before comparing to the configured path.
+    if (request.url?.split('?')[0] !== this.path) {
+      throw new NotImplementedHttpError(`Only ${this.path} is supported`);
+    }
+  }
+
+  public async handle({ response }: HttpHandlerInput): Promise<void> {
+    const { registry } = this.metrics;
+    const body = await registry.metrics();
+    response.writeHead(200, {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'content-type': registry.contentType,
+    });
+    response.end(body);
+  }
+}

--- a/src/server/metrics/MetricsSaturationCollector.ts
+++ b/src/server/metrics/MetricsSaturationCollector.ts
@@ -1,0 +1,84 @@
+import { Gauge } from 'prom-client';
+import type { MemoryResourceLocker } from '../../util/locking/MemoryResourceLocker';
+import type { StreamingHttpMap } from '../notifications/StreamingHttpChannel2023/StreamingHttpMap';
+import type { WebSocketMap } from '../notifications/WebSocketChannel2023/WebSocketMap';
+import type { PrometheusMetrics } from './PrometheusMetrics';
+
+/**
+ * Registers runtime *saturation* gauges on the {@link PrometheusMetrics} registry.
+ *
+ * Where the {@link PrometheusMetrics} request instruments describe throughput (how much traffic is
+ * flowing), these gauges describe *pressure*: how close the running server is to exhausting a bounded
+ * runtime resource. They observe live, single-threaded in-memory state and are therefore only
+ * meaningful in a non-clustered setup.
+ *
+ * Two gauges are registered:
+ * - `solid_resource_locks`: the number of resource locks currently held by the in-memory locker.
+ * - `solid_notification_connections{type}`: the number of currently open notification connections,
+ *   labelled by channel `type` (`websocket` or `streaming`).
+ *
+ * The label set is intentionally kept low-cardinality: the connection gauge is labelled only by the
+ * fixed channel `type` and never by anything unbounded (such as a resource URL, subscription id, or
+ * remote address), which would otherwise cause a cardinality explosion in the time-series database.
+ *
+ * Every source is *optional*: a source that is not wired in (for example a configuration without
+ * WebSocket notifications, or one using a non in-memory locker) simply leaves its gauge unset. The
+ * unlabelled lock gauge then reports `0` and the labelled connection gauge omits the missing label,
+ * so this collector is safe to add to any configuration.
+ *
+ * The gauges are read lazily through a prom-client `collect` callback that fires once per `/metrics`
+ * scrape. This keeps the request and notification hot paths free of any instrumentation overhead. The
+ * callback performs pure, side-effect-free reads (`Map.size` / a lock count): it never mutates, locks,
+ * iterates with side effects, or otherwise disturbs the observed state.
+ */
+export class MetricsSaturationCollector {
+  private readonly locker?: MemoryResourceLocker;
+  private readonly webSocketMap?: WebSocketMap;
+  private readonly streamingHttpMap?: StreamingHttpMap;
+
+  private readonly resourceLocks: Gauge;
+  private readonly notificationConnections: Gauge<'type'>;
+
+  /**
+   * @param metrics - The {@link PrometheusMetrics} whose registry the gauges are registered on.
+   * @param locker - The in-memory resource locker whose held-lock count is observed. Optional.
+   * @param webSocketMap - The map holding the open WebSocket notification connections. Optional.
+   * @param streamingHttpMap - The map holding the open Streaming HTTP notification connections. Optional.
+   */
+  public constructor(
+    metrics: PrometheusMetrics,
+    locker?: MemoryResourceLocker,
+    webSocketMap?: WebSocketMap,
+    streamingHttpMap?: StreamingHttpMap,
+  ) {
+    this.locker = locker;
+    this.webSocketMap = webSocketMap;
+    this.streamingHttpMap = streamingHttpMap;
+
+    this.resourceLocks = new Gauge({
+      name: 'solid_resource_locks',
+      help: 'Number of resource locks currently held by the in-memory resource locker.',
+      registers: [ metrics.registry ],
+      collect: (): void => {
+        if (this.locker) {
+          this.resourceLocks.set(this.locker.getLockCount());
+        }
+      },
+    });
+
+    this.notificationConnections = new Gauge({
+      name: 'solid_notification_connections',
+      help: 'Number of currently open notification connections, labelled by channel type.',
+      labelNames: [ 'type' ],
+      registers: [ metrics.registry ],
+      collect: (): void => {
+        if (this.webSocketMap) {
+          this.notificationConnections.set({ type: 'websocket' }, this.webSocketMap.size);
+        }
+        if (this.streamingHttpMap) {
+          this.notificationConnections.set({ type: 'streaming' }, this.streamingHttpMap.size);
+        }
+      },
+    });
+  }
+}

--- a/src/server/metrics/MetricsSaturationCollector.ts
+++ b/src/server/metrics/MetricsSaturationCollector.ts
@@ -63,30 +63,36 @@ export class MetricsSaturationCollector extends Initializer {
    * Called once at server start-up through the primary initializer chain.
    */
   public async handle(): Promise<void> {
+    // Capture the sources as locals so the `collect` callbacks (regular functions, whose `this` is the
+    // gauge) can read them without aliasing the collector's `this`.
+    const { locker, webSocketMap, streamingHttpMap } = this;
+
     const resourceLocks = new Gauge({
       name: 'solid_resource_locks',
       help: 'Number of resource locks currently held by the in-memory resource locker.',
-      registers: [ this.metrics.registry ],
+      registers: [],
+      collect(): void {
+        if (locker) {
+          this.set(locker.getLockCount());
+        }
+      },
     });
-    resourceLocks.collect = (): void => {
-      if (this.locker) {
-        resourceLocks.set(this.locker.getLockCount());
-      }
-    };
+    this.metrics.registry.registerMetric(resourceLocks);
 
     const notificationConnections = new Gauge<'type'>({
       name: 'solid_notification_connections',
       help: 'Number of currently open notification connections, labelled by channel type.',
       labelNames: [ 'type' ],
-      registers: [ this.metrics.registry ],
+      registers: [],
+      collect(): void {
+        if (webSocketMap) {
+          this.set({ type: 'websocket' }, webSocketMap.size);
+        }
+        if (streamingHttpMap) {
+          this.set({ type: 'streaming' }, streamingHttpMap.size);
+        }
+      },
     });
-    notificationConnections.collect = (): void => {
-      if (this.webSocketMap) {
-        notificationConnections.set({ type: 'websocket' }, this.webSocketMap.size);
-      }
-      if (this.streamingHttpMap) {
-        notificationConnections.set({ type: 'streaming' }, this.streamingHttpMap.size);
-      }
-    };
+    this.metrics.registry.registerMetric(notificationConnections);
   }
 }

--- a/src/server/metrics/MetricsSaturationCollector.ts
+++ b/src/server/metrics/MetricsSaturationCollector.ts
@@ -1,11 +1,13 @@
 import { Gauge } from 'prom-client';
+import { Initializer } from '../../init/Initializer';
 import type { MemoryResourceLocker } from '../../util/locking/MemoryResourceLocker';
 import type { StreamingHttpMap } from '../notifications/StreamingHttpChannel2023/StreamingHttpMap';
 import type { WebSocketMap } from '../notifications/WebSocketChannel2023/WebSocketMap';
 import type { PrometheusMetrics } from './PrometheusMetrics';
 
 /**
- * Registers runtime *saturation* gauges on the {@link PrometheusMetrics} registry.
+ * An {@link Initializer} that registers runtime *saturation* gauges on the {@link PrometheusMetrics}
+ * registry when the server starts.
  *
  * Where the {@link PrometheusMetrics} request instruments describe throughput (how much traffic is
  * flowing), these gauges describe *pressure*: how close the running server is to exhausting a bounded
@@ -31,13 +33,11 @@ import type { PrometheusMetrics } from './PrometheusMetrics';
  * callback performs pure, side-effect-free reads (`Map.size` / a lock count): it never mutates, locks,
  * iterates with side effects, or otherwise disturbs the observed state.
  */
-export class MetricsSaturationCollector {
+export class MetricsSaturationCollector extends Initializer {
+  private readonly metrics: PrometheusMetrics;
   private readonly locker?: MemoryResourceLocker;
   private readonly webSocketMap?: WebSocketMap;
   private readonly streamingHttpMap?: StreamingHttpMap;
-
-  private readonly resourceLocks: Gauge;
-  private readonly notificationConnections: Gauge<'type'>;
 
   /**
    * @param metrics - The {@link PrometheusMetrics} whose registry the gauges are registered on.
@@ -51,34 +51,42 @@ export class MetricsSaturationCollector {
     webSocketMap?: WebSocketMap,
     streamingHttpMap?: StreamingHttpMap,
   ) {
+    super();
+    this.metrics = metrics;
     this.locker = locker;
     this.webSocketMap = webSocketMap;
     this.streamingHttpMap = streamingHttpMap;
+  }
 
-    this.resourceLocks = new Gauge({
+  /**
+   * Registers the saturation gauges on the shared metrics registry.
+   * Called once at server start-up through the primary initializer chain.
+   */
+  public async handle(): Promise<void> {
+    const resourceLocks = new Gauge({
       name: 'solid_resource_locks',
       help: 'Number of resource locks currently held by the in-memory resource locker.',
-      registers: [ metrics.registry ],
-      collect: (): void => {
-        if (this.locker) {
-          this.resourceLocks.set(this.locker.getLockCount());
-        }
-      },
+      registers: [ this.metrics.registry ],
     });
+    resourceLocks.collect = (): void => {
+      if (this.locker) {
+        resourceLocks.set(this.locker.getLockCount());
+      }
+    };
 
-    this.notificationConnections = new Gauge({
+    const notificationConnections = new Gauge<'type'>({
       name: 'solid_notification_connections',
       help: 'Number of currently open notification connections, labelled by channel type.',
       labelNames: [ 'type' ],
-      registers: [ metrics.registry ],
-      collect: (): void => {
-        if (this.webSocketMap) {
-          this.notificationConnections.set({ type: 'websocket' }, this.webSocketMap.size);
-        }
-        if (this.streamingHttpMap) {
-          this.notificationConnections.set({ type: 'streaming' }, this.streamingHttpMap.size);
-        }
-      },
+      registers: [ this.metrics.registry ],
     });
+    notificationConnections.collect = (): void => {
+      if (this.webSocketMap) {
+        notificationConnections.set({ type: 'websocket' }, this.webSocketMap.size);
+      }
+      if (this.streamingHttpMap) {
+        notificationConnections.set({ type: 'streaming' }, this.streamingHttpMap.size);
+      }
+    };
   }
 }

--- a/src/server/metrics/MetricsSaturationCollector.ts
+++ b/src/server/metrics/MetricsSaturationCollector.ts
@@ -6,32 +6,12 @@ import type { WebSocketMap } from '../notifications/WebSocketChannel2023/WebSock
 import type { PrometheusMetrics } from './PrometheusMetrics';
 
 /**
- * An {@link Initializer} that registers runtime *saturation* gauges on the {@link PrometheusMetrics}
- * registry when the server starts.
- *
- * Where the {@link PrometheusMetrics} request instruments describe throughput (how much traffic is
- * flowing), these gauges describe *pressure*: how close the running server is to exhausting a bounded
- * runtime resource. They observe live, single-threaded in-memory state and are therefore only
- * meaningful in a non-clustered setup.
- *
- * Two gauges are registered:
- * - `solid_resource_locks`: the number of resource locks currently held by the in-memory locker.
- * - `solid_notification_connections{type}`: the number of currently open notification connections,
- *   labelled by channel `type` (`websocket` or `streaming`).
- *
- * The label set is intentionally kept low-cardinality: the connection gauge is labelled only by the
- * fixed channel `type` and never by anything unbounded (such as a resource URL, subscription id, or
- * remote address), which would otherwise cause a cardinality explosion in the time-series database.
- *
- * Every source is *optional*: a source that is not wired in (for example a configuration without
- * WebSocket notifications, or one using a non in-memory locker) simply leaves its gauge unset. The
- * unlabelled lock gauge then reports `0` and the labelled connection gauge omits the missing label,
- * so this collector is safe to add to any configuration.
- *
- * The gauges are read lazily through a prom-client `collect` callback that fires once per `/metrics`
- * scrape. This keeps the request and notification hot paths free of any instrumentation overhead. The
- * callback performs pure, side-effect-free reads (`Map.size` / a lock count): it never mutates, locks,
- * iterates with side effects, or otherwise disturbs the observed state.
+ * An {@link Initializer} that registers saturation gauges on the {@link PrometheusMetrics} registry:
+ * `solid_resource_locks` (resource locks currently held by the in-memory locker) and
+ * `solid_notification_connections{type}` (open notification connections per channel type).
+ * The sources are only read on each `/metrics` scrape, through a prom-client `collect` callback,
+ * so the request and notification hot paths are untouched.
+ * Every source is optional: an absent source leaves its gauge unset.
  */
 export class MetricsSaturationCollector extends Initializer {
   private readonly metrics: PrometheusMetrics;
@@ -41,9 +21,9 @@ export class MetricsSaturationCollector extends Initializer {
 
   /**
    * @param metrics - The {@link PrometheusMetrics} whose registry the gauges are registered on.
-   * @param locker - The in-memory resource locker whose held-lock count is observed. Optional.
-   * @param webSocketMap - The map holding the open WebSocket notification connections. Optional.
-   * @param streamingHttpMap - The map holding the open Streaming HTTP notification connections. Optional.
+   * @param locker - Optional in-memory resource locker whose held-lock count is observed.
+   * @param webSocketMap - Optional map holding the open WebSocket notification connections.
+   * @param streamingHttpMap - Optional map holding the open Streaming HTTP notification connections.
    */
   public constructor(
     metrics: PrometheusMetrics,
@@ -58,13 +38,8 @@ export class MetricsSaturationCollector extends Initializer {
     this.streamingHttpMap = streamingHttpMap;
   }
 
-  /**
-   * Registers the saturation gauges on the shared metrics registry.
-   * Called once at server start-up through the primary initializer chain.
-   */
   public async handle(): Promise<void> {
-    // Capture the sources as locals so the `collect` callbacks (regular functions, whose `this` is the
-    // gauge) can read them without aliasing the collector's `this`.
+    // In a `collect` callback `this` is the gauge, so capture the sources as locals.
     const { locker, webSocketMap, streamingHttpMap } = this;
 
     const resourceLocks = new Gauge({

--- a/src/server/metrics/MetricsSaturationCollector.ts
+++ b/src/server/metrics/MetricsSaturationCollector.ts
@@ -11,7 +11,8 @@ import type { PrometheusMetrics } from './PrometheusMetrics';
  * `solid_notification_connections{type}` (open notification connections per channel type).
  * The sources are only read on each `/metrics` scrape, through a prom-client `collect` callback,
  * so the request and notification hot paths are untouched.
- * Every source is optional: an absent source leaves its gauge unset.
+ * Every source is optional: without a locker the lock gauge reports `0`,
+ * while a missing notification map omits its labelled series.
  */
 export class MetricsSaturationCollector extends Initializer {
   private readonly metrics: PrometheusMetrics;

--- a/src/server/metrics/MetricsServerConfigurator.ts
+++ b/src/server/metrics/MetricsServerConfigurator.ts
@@ -1,0 +1,52 @@
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
+import { getLoggerFor } from '../../logging/LogUtil';
+import { createErrorMessage } from '../../util/errors/ErrorUtil';
+import { ServerConfigurator } from '../ServerConfigurator';
+import type { PrometheusMetrics } from './PrometheusMetrics';
+
+/**
+ * A {@link ServerConfigurator} that attaches an observe-only listener to the `request` event of a
+ * {@link Server} to record Prometheus metrics.
+ *
+ * The listener runs alongside the main request listener without interfering with it:
+ * it never writes to the response, never consumes the request body,
+ * and never throws into the request flow.
+ * Any error while instrumenting or recording is caught and logged so that a metrics failure
+ * can never break request handling.
+ *
+ * On every request a timer is started; when the response emits `finish` the duration is observed and
+ * the request counter is incremented with the request method and the response status code.
+ */
+export class MetricsServerConfigurator extends ServerConfigurator {
+  protected readonly logger = getLoggerFor(this);
+
+  private readonly metrics: PrometheusMetrics;
+
+  /**
+   * @param metrics - The {@link PrometheusMetrics} holding the registry and request instruments.
+   */
+  public constructor(metrics: PrometheusMetrics) {
+    super();
+    this.metrics = metrics;
+  }
+
+  public async handle(server: Server): Promise<void> {
+    server.on('request', (request: IncomingMessage, response: ServerResponse): void => {
+      try {
+        // Start timing before the request is handled; the returned function observes the duration.
+        const stopTimer = this.metrics.requestDuration.startTimer();
+        response.on('finish', (): void => {
+          try {
+            const labels = { method: request.method ?? 'UNKNOWN', code: response.statusCode };
+            this.metrics.requestsTotal.inc(labels);
+            stopTimer(labels);
+          } catch (error: unknown) {
+            this.logger.error(`Unable to record request metrics: ${createErrorMessage(error)}`);
+          }
+        });
+      } catch (error: unknown) {
+        this.logger.error(`Unable to instrument request for metrics: ${createErrorMessage(error)}`);
+      }
+    });
+  }
+}

--- a/src/server/metrics/PrometheusMetrics.ts
+++ b/src/server/metrics/PrometheusMetrics.ts
@@ -1,0 +1,39 @@
+import { collectDefaultMetrics, Counter, Histogram, Registry } from 'prom-client';
+
+/**
+ * Creates and owns a Prometheus {@link Registry} together with the instruments used to observe
+ * incoming HTTP requests.
+ *
+ * Default process metrics (CPU, memory, event loop lag, garbage collection, ...) are collected on the
+ * same registry through `collectDefaultMetrics`.
+ *
+ * The request instruments are intentionally kept low-cardinality: they are only labelled by the
+ * request `method` and the response status `code`.
+ * The request target/path is deliberately *not* used as a label:
+ * the unbounded number of resource URLs would cause a cardinality explosion in the time-series database.
+ */
+export class PrometheusMetrics {
+  public readonly registry: Registry;
+  public readonly requestsTotal: Counter<'code' | 'method'>;
+  public readonly requestDuration: Histogram<'code' | 'method'>;
+
+  public constructor() {
+    this.registry = new Registry();
+    // Collect the default Node.js/process metrics (cpu, memory, event loop lag, gc, ...) on this registry.
+    collectDefaultMetrics({ register: this.registry });
+
+    this.requestsTotal = new Counter({
+      name: 'http_requests_total',
+      help: 'Total number of HTTP requests, labelled by request method and response status code.',
+      labelNames: [ 'method', 'code' ],
+      registers: [ this.registry ],
+    });
+
+    this.requestDuration = new Histogram({
+      name: 'http_request_duration_seconds',
+      help: 'Duration of HTTP requests in seconds, labelled by request method and response status code.',
+      labelNames: [ 'method', 'code' ],
+      registers: [ this.registry ],
+    });
+  }
+}

--- a/src/util/locking/MemoryResourceLocker.ts
+++ b/src/util/locking/MemoryResourceLocker.ts
@@ -46,11 +46,7 @@ export class MemoryResourceLocker implements ResourceLocker, SingleThreaded {
   }
 
   /**
-   * The number of resource locks currently held by this locker.
-   *
-   * This is a pure, side-effect-free read of the in-memory lock bookkeeping: it never acquires or
-   * releases a lock and never mutates any state. It is exposed for observability (e.g. saturation
-   * metrics) so operators can see how many locks are active at any moment.
+   * Counts the number of active locks.
    */
   public getLockCount(): number {
     return Object.keys(this.unlockCallbacks).length;

--- a/src/util/locking/MemoryResourceLocker.ts
+++ b/src/util/locking/MemoryResourceLocker.ts
@@ -46,9 +46,13 @@ export class MemoryResourceLocker implements ResourceLocker, SingleThreaded {
   }
 
   /**
-   * Counts the number of active locks.
+   * The number of resource locks currently held by this locker.
+   *
+   * This is a pure, side-effect-free read of the in-memory lock bookkeeping: it never acquires or
+   * releases a lock and never mutates any state. It is exposed for observability (e.g. saturation
+   * metrics) so operators can see how many locks are active at any moment.
    */
-  private getLockCount(): number {
+  public getLockCount(): number {
     return Object.keys(this.unlockCallbacks).length;
   }
 }

--- a/test/unit/server/metrics/MetricsHandler.test.ts
+++ b/test/unit/server/metrics/MetricsHandler.test.ts
@@ -1,0 +1,63 @@
+import { MetricsHandler } from '../../../../src/server/metrics/MetricsHandler';
+import type { PrometheusMetrics } from '../../../../src/server/metrics/PrometheusMetrics';
+
+describe('A MetricsHandler', (): void => {
+  const contentType = 'text/plain; version=0.0.4; charset=utf-8';
+  let registry: { metrics: jest.Mock; contentType: string };
+  let metrics: jest.Mocked<PrometheusMetrics>;
+  let response: { writeHead: jest.Mock; end: jest.Mock };
+  let handler: MetricsHandler;
+
+  beforeEach((): void => {
+    registry = {
+      metrics: jest.fn().mockResolvedValue('# metrics body'),
+      contentType,
+    };
+    metrics = { registry } as any;
+
+    response = {
+      writeHead: jest.fn(),
+      end: jest.fn(),
+    };
+
+    handler = new MetricsHandler(metrics);
+  });
+
+  it('rejects non-GET requests.', async(): Promise<void> => {
+    const request = { method: 'POST', url: '/metrics' };
+    await expect(handler.canHandle({ request } as any)).rejects.toThrow('Only GET requests are supported');
+  });
+
+  it('rejects GET requests on a different path.', async(): Promise<void> => {
+    const request = { method: 'GET', url: '/other' };
+    await expect(handler.canHandle({ request } as any)).rejects.toThrow('Only /metrics is supported');
+  });
+
+  it('rejects GET requests without a URL.', async(): Promise<void> => {
+    const request = { method: 'GET' };
+    await expect(handler.canHandle({ request } as any)).rejects.toThrow('Only /metrics is supported');
+  });
+
+  it('accepts GET requests on the metrics path, ignoring the query string.', async(): Promise<void> => {
+    const request = { method: 'GET', url: '/metrics?foo=bar' };
+    await expect(handler.canHandle({ request } as any)).resolves.toBeUndefined();
+  });
+
+  it('serves the registry contents with the registry content type.', async(): Promise<void> => {
+    await handler.handle({ response } as any);
+
+    expect(registry.metrics).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenLastCalledWith(200, { 'content-type': contentType });
+    expect(response.end).toHaveBeenCalledTimes(1);
+    expect(response.end).toHaveBeenLastCalledWith('# metrics body');
+  });
+
+  it('exposes the metrics on a configurable path.', async(): Promise<void> => {
+    handler = new MetricsHandler(metrics, '/internal/metrics');
+    await expect(handler.canHandle({ request: { method: 'GET', url: '/metrics' }} as any)).rejects
+      .toThrow('Only /internal/metrics is supported');
+    await expect(handler.canHandle({ request: { method: 'GET', url: '/internal/metrics' }} as any)).resolves
+      .toBeUndefined();
+  });
+});

--- a/test/unit/server/metrics/MetricsSaturationCollector.test.ts
+++ b/test/unit/server/metrics/MetricsSaturationCollector.test.ts
@@ -1,0 +1,91 @@
+import { MetricsSaturationCollector } from '../../../../src/server/metrics/MetricsSaturationCollector';
+import { PrometheusMetrics } from '../../../../src/server/metrics/PrometheusMetrics';
+import type { StreamingHttpMap } from '../../../../src/server/notifications/StreamingHttpChannel2023/StreamingHttpMap';
+import type { WebSocketMap } from '../../../../src/server/notifications/WebSocketChannel2023/WebSocketMap';
+import type { MemoryResourceLocker } from '../../../../src/util/locking/MemoryResourceLocker';
+
+describe('A MetricsSaturationCollector', (): void => {
+  let metrics: PrometheusMetrics;
+
+  beforeEach((): void => {
+    metrics = new PrometheusMetrics();
+  });
+
+  afterEach((): void => {
+    metrics.registry.clear();
+  });
+
+  // Scraping the registry triggers each gauge's `collect` callback; return the matching metric.
+  async function getGauge(name: string): Promise<any> {
+    const json = await metrics.registry.getMetricsAsJSON();
+    return json.find((metric): boolean => metric.name === name);
+  }
+
+  it('registers both saturation gauges on the metrics registry.', (): void => {
+    // eslint-disable-next-line no-new
+    new MetricsSaturationCollector(metrics);
+    expect(metrics.registry.getSingleMetric('solid_resource_locks')).toBeDefined();
+    expect(metrics.registry.getSingleMetric('solid_notification_connections')).toBeDefined();
+  });
+
+  it('reports the current held-lock count when a locker is provided.', async(): Promise<void> => {
+    const locker = { getLockCount: jest.fn().mockReturnValue(3) } as unknown as jest.Mocked<MemoryResourceLocker>;
+    // eslint-disable-next-line no-new
+    new MetricsSaturationCollector(metrics, locker);
+
+    const gauge = await getGauge('solid_resource_locks');
+    expect(gauge?.type).toBe('gauge');
+    expect(gauge?.values).toContainEqual(expect.objectContaining({ value: 3, labels: {}}));
+    expect(locker.getLockCount).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads the lock count fresh on every scrape.', async(): Promise<void> => {
+    const getLockCount = jest.fn<number, []>().mockReturnValueOnce(1).mockReturnValueOnce(4);
+    const locker = { getLockCount } as unknown as MemoryResourceLocker;
+    // eslint-disable-next-line no-new
+    new MetricsSaturationCollector(metrics, locker);
+
+    expect((await getGauge('solid_resource_locks'))?.values).toContainEqual(expect.objectContaining({ value: 1 }));
+    expect((await getGauge('solid_resource_locks'))?.values).toContainEqual(expect.objectContaining({ value: 4 }));
+    expect(getLockCount).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports 0 held locks when no locker is provided.', async(): Promise<void> => {
+    // eslint-disable-next-line no-new
+    new MetricsSaturationCollector(metrics);
+
+    const gauge = await getGauge('solid_resource_locks');
+    expect(gauge?.values).toEqual([ expect.objectContaining({ value: 0, labels: {}}) ]);
+  });
+
+  it('reports active connections per channel type when both maps are provided.', async(): Promise<void> => {
+    const webSocketMap = { size: 2 } as unknown as WebSocketMap;
+    const streamingHttpMap = { size: 5 } as unknown as StreamingHttpMap;
+    // eslint-disable-next-line no-new
+    new MetricsSaturationCollector(metrics, undefined, webSocketMap, streamingHttpMap);
+
+    const gauge = await getGauge('solid_notification_connections');
+    expect(gauge?.type).toBe('gauge');
+    expect(gauge?.values).toContainEqual(expect.objectContaining({ value: 2, labels: { type: 'websocket' }}));
+    expect(gauge?.values).toContainEqual(expect.objectContaining({ value: 5, labels: { type: 'streaming' }}));
+  });
+
+  it('omits a channel type label when its map is not provided.', async(): Promise<void> => {
+    const webSocketMap = { size: 7 } as unknown as WebSocketMap;
+    // eslint-disable-next-line no-new
+    new MetricsSaturationCollector(metrics, undefined, webSocketMap);
+
+    const gauge = await getGauge('solid_notification_connections');
+    expect(gauge?.values).toEqual([ expect.objectContaining({ value: 7, labels: { type: 'websocket' }}) ]);
+  });
+
+  it('omits the connection gauge values entirely when no maps are provided.', async(): Promise<void> => {
+    // eslint-disable-next-line no-new
+    new MetricsSaturationCollector(metrics);
+
+    const gauge = await getGauge('solid_notification_connections');
+    expect(gauge?.values).toEqual([]);
+    await expect(metrics.registry.getSingleMetricAsString('solid_notification_connections'))
+      .resolves.not.toContain('solid_notification_connections{');
+  });
+});

--- a/test/unit/server/metrics/MetricsSaturationCollector.test.ts
+++ b/test/unit/server/metrics/MetricsSaturationCollector.test.ts
@@ -21,17 +21,20 @@ describe('A MetricsSaturationCollector', (): void => {
     return json.find((metric): boolean => metric.name === name);
   }
 
-  it('registers both saturation gauges on the metrics registry.', (): void => {
-    // eslint-disable-next-line no-new
-    new MetricsSaturationCollector(metrics);
+  it('only registers the gauges once it is initialized.', async(): Promise<void> => {
+    const collector = new MetricsSaturationCollector(metrics);
+    expect(metrics.registry.getSingleMetric('solid_resource_locks')).toBeUndefined();
+    expect(metrics.registry.getSingleMetric('solid_notification_connections')).toBeUndefined();
+
+    await collector.handle();
+
     expect(metrics.registry.getSingleMetric('solid_resource_locks')).toBeDefined();
     expect(metrics.registry.getSingleMetric('solid_notification_connections')).toBeDefined();
   });
 
   it('reports the current held-lock count when a locker is provided.', async(): Promise<void> => {
     const locker = { getLockCount: jest.fn().mockReturnValue(3) } as unknown as jest.Mocked<MemoryResourceLocker>;
-    // eslint-disable-next-line no-new
-    new MetricsSaturationCollector(metrics, locker);
+    await new MetricsSaturationCollector(metrics, locker).handle();
 
     const gauge = await getGauge('solid_resource_locks');
     expect(gauge?.type).toBe('gauge');
@@ -42,8 +45,7 @@ describe('A MetricsSaturationCollector', (): void => {
   it('reads the lock count fresh on every scrape.', async(): Promise<void> => {
     const getLockCount = jest.fn<number, []>().mockReturnValueOnce(1).mockReturnValueOnce(4);
     const locker = { getLockCount } as unknown as MemoryResourceLocker;
-    // eslint-disable-next-line no-new
-    new MetricsSaturationCollector(metrics, locker);
+    await new MetricsSaturationCollector(metrics, locker).handle();
 
     expect((await getGauge('solid_resource_locks'))?.values).toContainEqual(expect.objectContaining({ value: 1 }));
     expect((await getGauge('solid_resource_locks'))?.values).toContainEqual(expect.objectContaining({ value: 4 }));
@@ -51,8 +53,7 @@ describe('A MetricsSaturationCollector', (): void => {
   });
 
   it('reports 0 held locks when no locker is provided.', async(): Promise<void> => {
-    // eslint-disable-next-line no-new
-    new MetricsSaturationCollector(metrics);
+    await new MetricsSaturationCollector(metrics).handle();
 
     const gauge = await getGauge('solid_resource_locks');
     expect(gauge?.values).toEqual([ expect.objectContaining({ value: 0, labels: {}}) ]);
@@ -61,8 +62,7 @@ describe('A MetricsSaturationCollector', (): void => {
   it('reports active connections per channel type when both maps are provided.', async(): Promise<void> => {
     const webSocketMap = { size: 2 } as unknown as WebSocketMap;
     const streamingHttpMap = { size: 5 } as unknown as StreamingHttpMap;
-    // eslint-disable-next-line no-new
-    new MetricsSaturationCollector(metrics, undefined, webSocketMap, streamingHttpMap);
+    await new MetricsSaturationCollector(metrics, undefined, webSocketMap, streamingHttpMap).handle();
 
     const gauge = await getGauge('solid_notification_connections');
     expect(gauge?.type).toBe('gauge');
@@ -72,16 +72,14 @@ describe('A MetricsSaturationCollector', (): void => {
 
   it('omits a channel type label when its map is not provided.', async(): Promise<void> => {
     const webSocketMap = { size: 7 } as unknown as WebSocketMap;
-    // eslint-disable-next-line no-new
-    new MetricsSaturationCollector(metrics, undefined, webSocketMap);
+    await new MetricsSaturationCollector(metrics, undefined, webSocketMap).handle();
 
     const gauge = await getGauge('solid_notification_connections');
     expect(gauge?.values).toEqual([ expect.objectContaining({ value: 7, labels: { type: 'websocket' }}) ]);
   });
 
   it('omits the connection gauge values entirely when no maps are provided.', async(): Promise<void> => {
-    // eslint-disable-next-line no-new
-    new MetricsSaturationCollector(metrics);
+    await new MetricsSaturationCollector(metrics).handle();
 
     const gauge = await getGauge('solid_notification_connections');
     expect(gauge?.values).toEqual([]);

--- a/test/unit/server/metrics/MetricsSaturationCollector.test.ts
+++ b/test/unit/server/metrics/MetricsSaturationCollector.test.ts
@@ -15,7 +15,7 @@ describe('A MetricsSaturationCollector', (): void => {
     metrics.registry.clear();
   });
 
-  // Scraping the registry triggers each gauge's `collect` callback; return the matching metric.
+  // Scraping the registry triggers each gauge's `collect` callback.
   async function getGauge(name: string): Promise<any> {
     const json = await metrics.registry.getMetricsAsJSON();
     return json.find((metric): boolean => metric.name === name);

--- a/test/unit/server/metrics/MetricsServerConfigurator.test.ts
+++ b/test/unit/server/metrics/MetricsServerConfigurator.test.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from 'node:events';
+import type { Server } from 'node:http';
+import type { Logger } from '../../../../src/logging/Logger';
+import { getLoggerFor } from '../../../../src/logging/LogUtil';
+import { MetricsServerConfigurator } from '../../../../src/server/metrics/MetricsServerConfigurator';
+import type { PrometheusMetrics } from '../../../../src/server/metrics/PrometheusMetrics';
+
+jest.mock('../../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { error: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+
+describe('A MetricsServerConfigurator', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
+  let server: Server;
+  let request: any;
+  let response: any;
+  let stopTimer: jest.Mock;
+  let metrics: jest.Mocked<PrometheusMetrics>;
+  let configurator: MetricsServerConfigurator;
+
+  beforeEach(async(): Promise<void> => {
+    jest.clearAllMocks();
+
+    server = new EventEmitter() as any;
+
+    request = { method: 'GET', url: '/foo' };
+
+    response = Object.assign(new EventEmitter(), {
+      statusCode: 200,
+      write: jest.fn(),
+      writeHead: jest.fn(),
+      end: jest.fn(),
+      setHeader: jest.fn(),
+    });
+
+    stopTimer = jest.fn();
+    metrics = {
+      requestDuration: { startTimer: jest.fn().mockReturnValue(stopTimer) },
+      requestsTotal: { inc: jest.fn() },
+    } as any;
+
+    configurator = new MetricsServerConfigurator(metrics);
+    await configurator.handle(server);
+  });
+
+  it('starts a timer per request but only records once the response finishes.', (): void => {
+    server.emit('request', request, response);
+    expect(metrics.requestDuration.startTimer).toHaveBeenCalledTimes(1);
+    expect(metrics.requestsTotal.inc).toHaveBeenCalledTimes(0);
+
+    response.emit('finish');
+    expect(metrics.requestsTotal.inc).toHaveBeenCalledTimes(1);
+    expect(metrics.requestsTotal.inc).toHaveBeenLastCalledWith({ method: 'GET', code: 200 });
+    expect(stopTimer).toHaveBeenCalledTimes(1);
+    expect(stopTimer).toHaveBeenLastCalledWith({ method: 'GET', code: 200 });
+  });
+
+  it('never writes to the response.', (): void => {
+    server.emit('request', request, response);
+    response.emit('finish');
+    expect(response.write).toHaveBeenCalledTimes(0);
+    expect(response.writeHead).toHaveBeenCalledTimes(0);
+    expect(response.end).toHaveBeenCalledTimes(0);
+    expect(response.setHeader).toHaveBeenCalledTimes(0);
+  });
+
+  it('uses a placeholder label when the request method is undefined.', (): void => {
+    request.method = undefined;
+    server.emit('request', request, response);
+    response.emit('finish');
+    expect(metrics.requestsTotal.inc).toHaveBeenLastCalledWith({ method: 'UNKNOWN', code: 200 });
+  });
+
+  it('does not throw or break the request flow when recording fails.', (): void => {
+    metrics.requestsTotal.inc.mockImplementation((): never => {
+      throw new Error('boom');
+    });
+    server.emit('request', request, response);
+    expect((): boolean => response.emit('finish')).not.toThrow();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith(expect.stringContaining('Unable to record request metrics'));
+  });
+
+  it('does not throw when the timer cannot be started.', (): void => {
+    metrics.requestDuration.startTimer.mockImplementation((): never => {
+      throw new Error('no timer');
+    });
+    expect((): void => {
+      server.emit('request', request, response);
+    }).not.toThrow();
+    expect(metrics.requestsTotal.inc).toHaveBeenCalledTimes(0);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith(expect.stringContaining('Unable to instrument request for metrics'));
+  });
+});

--- a/test/unit/server/metrics/PrometheusMetrics.test.ts
+++ b/test/unit/server/metrics/PrometheusMetrics.test.ts
@@ -1,0 +1,48 @@
+import { PrometheusMetrics } from '../../../../src/server/metrics/PrometheusMetrics';
+
+describe('A PrometheusMetrics', (): void => {
+  let metrics: PrometheusMetrics;
+
+  beforeEach((): void => {
+    metrics = new PrometheusMetrics();
+  });
+
+  afterEach((): void => {
+    metrics.registry.clear();
+  });
+
+  it('creates a registry using the Prometheus content type.', (): void => {
+    expect(metrics.registry.contentType).toContain('text/plain');
+  });
+
+  it('collects the default process metrics on its registry.', async(): Promise<void> => {
+    // `process_start_time_seconds` is one of the metrics registered by `collectDefaultMetrics`.
+    expect(metrics.registry.getSingleMetric('process_start_time_seconds')).toBeDefined();
+    await expect(metrics.registry.metrics()).resolves.toContain('process_cpu_user_seconds_total');
+  });
+
+  it('creates an http_requests_total counter labelled by method and code.', async(): Promise<void> => {
+    expect(metrics.registry.getSingleMetric('http_requests_total')).toBeDefined();
+
+    metrics.requestsTotal.inc({ method: 'GET', code: 200 });
+
+    const json = await metrics.registry.getMetricsAsJSON();
+    const counter = json.find((metric): boolean => metric.name === 'http_requests_total');
+    expect(counter?.type).toBe('counter');
+    expect(counter?.values).toContainEqual(
+      expect.objectContaining({ value: 1, labels: { method: 'GET', code: 200 }}),
+    );
+  });
+
+  it('creates an http_request_duration_seconds histogram labelled by method and code.', async(): Promise<void> => {
+    expect(metrics.registry.getSingleMetric('http_request_duration_seconds')).toBeDefined();
+
+    metrics.requestDuration.observe({ method: 'POST', code: 500 }, 0.25);
+
+    const json = await metrics.registry.getMetricsAsJSON();
+    const histogram = json.find((metric): boolean => metric.name === 'http_request_duration_seconds');
+    expect(histogram?.type).toBe('histogram');
+    expect(histogram?.values.some((value): boolean =>
+      value.labels.method === 'POST' && value.labels.code === 500)).toBe(true);
+  });
+});

--- a/test/unit/util/locking/MemoryResourceLocker.test.ts
+++ b/test/unit/util/locking/MemoryResourceLocker.test.ts
@@ -14,6 +14,14 @@ describe('A MemoryResourceLocker', (): void => {
     await expect(locker.release(identifier)).resolves.toBeUndefined();
   });
 
+  it('reports the number of currently held locks.', async(): Promise<void> => {
+    expect(locker.getLockCount()).toBe(0);
+    await locker.acquire({ path: 'path1' });
+    expect(locker.getLockCount()).toBe(1);
+    await locker.acquire({ path: 'path2' });
+    expect(locker.getLockCount()).toBe(2);
+  });
+
   it('can lock a resource again after it was unlocked.', async(): Promise<void> => {
     await expect(locker.acquire(identifier)).resolves.toBeUndefined();
     await expect(locker.release(identifier)).resolves.toBeUndefined();


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

**Stacks on #62** (`feat/prometheus-metrics`, the opt-in `/metrics` endpoint) — review after #62.

#### 📁 Related issues

None yet — an issue must be opened on CommunitySolidServer/CommunitySolidServer before this is submitted upstream (the upstream template requires one).

#### ✍️ Description

Extends the opt-in `/metrics` endpoint from #62 with two runtime **saturation** gauges, so an operator can see resource pressure (how close the server is to exhausting a bounded runtime resource) alongside #62's throughput instruments:

- `solid_resource_locks` — resource locks currently held, from `MemoryResourceLocker.getLockCount()`. That counter already existed as a private method (used by the locker's own debug logs); it is promoted to public. It is a pure read of the in-memory bookkeeping — it never acquires, releases, or mutates anything.
- `solid_notification_connections{type}` — open notification connections, labelled `type="websocket"` / `type="streaming"`, from the existing `WebSocketMap` / `StreamingHttpMap` `size` accessors.

The new `MetricsSaturationCollector` is an `Initializer`, wired into the primary initializer chain, that registers both gauges on the #62 registry with a prom-client `collect()` callback. The sources are therefore read only when `/metrics` is scraped: nothing runs on the request or notification hot paths, and the scrape-time reads are side-effect-free (`Map.size` / an object-key count — no lock is ever taken). There is no benchmark to reproduce; the zero-overhead claim is structural, since the only new code outside start-up is the scrape callback.

Design notes:

- **Low cardinality**: the only label is the fixed channel `type` (two values). Nothing unbounded (resource URL, subscription id, remote address) is used as a label, which would explode the time-series database — the same reasoning as #62's request instruments.
- **Optional sources**: all three constructor sources are optional. With one absent, the lock gauge reports `0` and the connection gauge omits that label, so the collector also works in configurations without WebSocket/streaming notifications or with a non-memory locker. The shipped recipe (`config/util/metrics/default.json`) assumes the default stack and says which reference to remove otherwise; a fully config-agnostic wiring (per-source overlays) would be a follow-up.
- `MemoryResourceLocker` was previously an anonymous nested node in `config/util/resource-locker/memory.json`; it now carries the stable id `urn:solid-server:default:MemoryResourceLocker` so the collector can reference it. Purely an added label: same singleton, no behaviour change.
- The gauges observe single-threaded in-memory state (the sources are `SingleThreaded`), so they are only meaningful in a non-clustered setup — hence the registration via the primary initializer chain.

Verified by booting `-c config/default.json -c config/util/metrics/default.json`: `GET /metrics` reports `solid_resource_locks 0` and `solid_notification_connections{type="websocket"} 0` / `{type="streaming"} 0` on an idle server. Unit tests cover gauge registration, the present/absent branch of every source, and that each scrape reads the sources fresh.

Intended as **semver.minor** (backwards-compatible feature addition; stating it in prose since contributors cannot set labels). As a feature it should target the latest `versions/*` branch when submitted upstream, not `main`.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
