### PR TITLE
feat: Bound N3 patch WHERE evaluation to prevent join blow-up

### DIFF
--- a/config/storage/middleware/stores/patching.json
+++ b/config/storage/middleware/stores/patching.json
@@ -86,8 +86,8 @@
       "@type": "WaterfallHandler",
       "handlers": [
         {
+          "comment": "Caps the intermediate bindings allowed when solving the solid:where conditions of a patch.",
           "@type": "N3Patcher",
-          "comment": "maxConditionBindings caps the intermediate bindings allowed when solving the solid:where conditions of a patch.",
           "maxConditionBindings": 1000000
         },
         { "@type": "SparqlUpdatePatcher" }

--- a/config/storage/middleware/stores/patching.json
+++ b/config/storage/middleware/stores/patching.json
@@ -87,7 +87,7 @@
       "handlers": [
         {
           "@type": "N3Patcher",
-          "comment": "maxConditionBindings caps the intermediate bindings the solid:where conditions may produce, bounding the nested-loop join to prevent a combinatorial DoS. Far above any realistic patch.",
+          "comment": "maxConditionBindings caps the intermediate bindings allowed when solving the solid:where conditions of a patch.",
           "maxConditionBindings": 1000000
         },
         { "@type": "SparqlUpdatePatcher" }

--- a/config/storage/middleware/stores/patching.json
+++ b/config/storage/middleware/stores/patching.json
@@ -85,7 +85,11 @@
       "@id": "urn:solid-server:default:PatchHandler_RDF",
       "@type": "WaterfallHandler",
       "handlers": [
-        { "@type": "N3Patcher" },
+        {
+          "@type": "N3Patcher",
+          "comment": "maxConditionBindings caps the intermediate bindings the solid:where conditions may produce, bounding the nested-loop join to prevent a combinatorial DoS. Far above any realistic patch.",
+          "maxConditionBindings": 1000000
+        },
         { "@type": "SparqlUpdatePatcher" }
       ]
     }

--- a/src/storage/patch/N3Patcher.ts
+++ b/src/storage/patch/N3Patcher.ts
@@ -24,11 +24,8 @@ export class N3Patcher extends RepresentationPatcher<RdfDatasetRepresentation> {
   private readonly maxConditionBindings: number;
 
   /**
-   * @param maxConditionBindings - Maximum number of intermediate solution bindings the `solid:where` conditions may
-   * produce before the patch is rejected. This bounds the nested-loop join used to evaluate the conditions, preventing
-   * a crafted WHERE with many unconstrained triple patterns from causing a combinatorial CPU/memory blow-up.
-   * Defaults to 1,000,000, which is far above any realistic patch: a valid N3 Patch WHERE must resolve to exactly one
-   * variable mapping, so its intermediate bindings are bounded by the resource size in practice.
+   * @param maxConditionBindings - Maximum number of intermediate bindings allowed when solving
+   * the `solid:where` conditions. Patches exceeding this limit are rejected. Defaults to 1,000,000.
    */
   public constructor(maxConditionBindings?: number) {
     super();

--- a/src/storage/patch/N3Patcher.ts
+++ b/src/storage/patch/N3Patcher.ts
@@ -20,8 +20,19 @@ import { RepresentationPatcher } from './RepresentationPatcher';
  */
 export class N3Patcher extends RepresentationPatcher<RdfDatasetRepresentation> {
   protected readonly logger = getLoggerFor(this);
-  public constructor() {
+
+  private readonly maxConditionBindings: number;
+
+  /**
+   * @param maxConditionBindings - Maximum number of intermediate solution bindings the `solid:where` conditions may
+   * produce before the patch is rejected. This bounds the nested-loop join used to evaluate the conditions, preventing
+   * a crafted WHERE with many unconstrained triple patterns from causing a combinatorial CPU/memory blow-up.
+   * Defaults to 1,000,000, which is far above any realistic patch: a valid N3 Patch WHERE must resolve to exactly one
+   * variable mapping, so its intermediate bindings are bounded by the resource size in practice.
+   */
+  public constructor(maxConditionBindings?: number) {
     super();
+    this.maxConditionBindings = maxConditionBindings ?? 1_000_000;
   }
 
   public async canHandle({ patch }: RepresentationPatcherInput<RdfDatasetRepresentation>): Promise<void> {
@@ -102,7 +113,7 @@ export class N3Patcher extends RepresentationPatcher<RdfDatasetRepresentation> {
     if (conditions.length > 0) {
       // Solid, §5.3.1: "If ?conditions is non-empty, find all (possibly empty) variable mappings
       // such that all of the resulting triples occur in the dataset."
-      const bindings: Record<string, Term>[] = solveBgp(conditions, source);
+      const bindings: Record<string, Term>[] = solveBgp(conditions, source, this.maxConditionBindings);
 
       // Solid, §5.3.1: "If no such mapping exists, or if multiple mappings exist,
       // the server MUST respond with a 409 status code."

--- a/src/util/QuadUtil.ts
+++ b/src/util/QuadUtil.ts
@@ -3,6 +3,7 @@ import type { NamedNode, Quad, Term } from '@rdfjs/types';
 import arrayifyStream from 'arrayify-stream';
 import type { ParserOptions, Store } from 'n3';
 import { StreamParser, StreamWriter } from 'n3';
+import { BadRequestHttpError } from './errors/BadRequestHttpError';
 import type { Guarded } from './GuardedStream';
 import { guardedStreamFrom, pipeSafely } from './StreamUtil';
 import { toNamedTerm } from './TermUtil';
@@ -90,15 +91,27 @@ export type SimpleBinding = Record<string, Term>;
 /**
  * Finds the matching bindings in the given data set for the given BGP query.
  *
+ * BGPs are solved with a nested-loop join, so the number of intermediate solution bindings can grow
+ * combinatorially (up to `data.size ^ bgp.length`) for a query whose patterns share few or no variables.
+ * `maxBindings` bounds this work: as soon as the running set of intermediate bindings for a pattern exceeds
+ * the limit, evaluation is aborted with a {@link BadRequestHttpError} instead of exhausting CPU and memory.
+ * The default is `Number.POSITIVE_INFINITY`, keeping the original unbounded behaviour for direct callers.
+ *
  * @param bgp - BGP to solve
  * @param data - Dataset to query.
+ * @param maxBindings - Maximum number of intermediate solution bindings allowed before aborting. Defaults to no limit.
  */
-export function solveBgp(bgp: Quad[], data: Store): SimpleBinding[] {
+export function solveBgp(bgp: Quad[], data: Store, maxBindings = Number.POSITIVE_INFINITY): SimpleBinding[] {
   let result: SimpleBinding[] = [{}];
   for (const pattern of bgp) {
     const newResult: SimpleBinding[] = [];
     for (const binding of result) {
       newResult.push(...getAppliedBindings(pattern, binding, data));
+      if (newResult.length > maxBindings) {
+        throw new BadRequestHttpError(
+          `The patch conditions produced more than the allowed ${maxBindings} intermediate bindings.`,
+        );
+      }
     }
     result = newResult;
   }

--- a/src/util/QuadUtil.ts
+++ b/src/util/QuadUtil.ts
@@ -90,16 +90,15 @@ export type SimpleBinding = Record<string, Term>;
 
 /**
  * Finds the matching bindings in the given data set for the given BGP query.
- *
- * BGPs are solved with a nested-loop join, so the number of intermediate solution bindings can grow
- * combinatorially (up to `data.size ^ bgp.length`) for a query whose patterns share few or no variables.
- * `maxBindings` bounds this work: as soon as the running set of intermediate bindings for a pattern exceeds
- * the limit, evaluation is aborted with a {@link BadRequestHttpError} instead of exhausting CPU and memory.
- * The default is `Number.POSITIVE_INFINITY`, keeping the original unbounded behaviour for direct callers.
+ * Patterns are solved with a nested-loop join,
+ * so patterns sharing few or no variables can grow the intermediate bindings combinatorially.
  *
  * @param bgp - BGP to solve
  * @param data - Dataset to query.
- * @param maxBindings - Maximum number of intermediate solution bindings allowed before aborting. Defaults to no limit.
+ * @param maxBindings - Maximum number of intermediate bindings allowed. Defaults to no limit.
+ *
+ * @throws BadRequestHttpError
+ * Thrown if the number of intermediate bindings exceeds `maxBindings`.
  */
 export function solveBgp(bgp: Quad[], data: Store, maxBindings = Number.POSITIVE_INFINITY): SimpleBinding[] {
   let result: SimpleBinding[] = [{}];

--- a/test/unit/storage/patch/N3Patcher.test.ts
+++ b/test/unit/storage/patch/N3Patcher.test.ts
@@ -6,6 +6,7 @@ import type { RdfDatasetRepresentation } from '../../../../src/http/representati
 import type { SparqlUpdatePatch } from '../../../../src/http/representation/SparqlUpdatePatch';
 import { N3Patcher } from '../../../../src/storage/patch/N3Patcher';
 import type { RepresentationPatcherInput } from '../../../../src/storage/patch/RepresentationPatcher';
+import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
 import { ConflictHttpError } from '../../../../src/util/errors/ConflictHttpError';
 import { InternalServerError } from '../../../../src/util/errors/InternalServerError';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
@@ -142,6 +143,49 @@ describe('An N3Patcher', (): void => {
     const result = await patcher.handle(input);
     expect(result.dataset).toBeRdfIsomorphic([
       quad(namedNode('ex:s0'), namedNode('ex:p0'), namedNode('ex:o0')),
+    ]);
+  });
+
+  it('rejects a patch whose conditions exceed the configured binding limit.', async(): Promise<void> => {
+    const boundedPatcher = new N3Patcher(2);
+    patch.conditions = [
+      quad(variable('v'), namedNode('ex:p0'), namedNode('ex:x')),
+      quad(variable('v'), namedNode('ex:tag'), namedNode('ex:target')),
+    ];
+    patch.deletes = [ quad(variable('v'), namedNode('ex:tag'), namedNode('ex:target')) ];
+    input.representation?.dataset.addQuads([
+      quad(namedNode('ex:s0'), namedNode('ex:p0'), namedNode('ex:x')),
+      quad(namedNode('ex:s1'), namedNode('ex:p0'), namedNode('ex:x')),
+      quad(namedNode('ex:s2'), namedNode('ex:p0'), namedNode('ex:x')),
+      quad(namedNode('ex:s1'), namedNode('ex:tag'), namedNode('ex:target')),
+    ]);
+    const prom = boundedPatcher.handle(input);
+    await expect(prom).rejects.toThrow(BadRequestHttpError);
+    await expect(prom).rejects.toThrow(
+      'The patch conditions produced more than the allowed 2 intermediate bindings.',
+    );
+  });
+
+  it('honors a custom binding limit that leaves room for the intermediate bindings.', async(): Promise<void> => {
+    const boundedPatcher = new N3Patcher(10);
+    patch.conditions = [
+      quad(variable('v'), namedNode('ex:p0'), namedNode('ex:x')),
+      quad(variable('v'), namedNode('ex:tag'), namedNode('ex:target')),
+    ];
+    patch.deletes = [ quad(variable('v'), namedNode('ex:tag'), namedNode('ex:target')) ];
+    patch.inserts = [ quad(variable('v'), namedNode('ex:done'), namedNode('ex:yes')) ];
+    input.representation?.dataset.addQuads([
+      quad(namedNode('ex:s0'), namedNode('ex:p0'), namedNode('ex:x')),
+      quad(namedNode('ex:s1'), namedNode('ex:p0'), namedNode('ex:x')),
+      quad(namedNode('ex:s2'), namedNode('ex:p0'), namedNode('ex:x')),
+      quad(namedNode('ex:s1'), namedNode('ex:tag'), namedNode('ex:target')),
+    ]);
+    const result = await boundedPatcher.handle(input);
+    expect(result.dataset).toBeRdfIsomorphic([
+      quad(namedNode('ex:s0'), namedNode('ex:p0'), namedNode('ex:x')),
+      quad(namedNode('ex:s1'), namedNode('ex:p0'), namedNode('ex:x')),
+      quad(namedNode('ex:s2'), namedNode('ex:p0'), namedNode('ex:x')),
+      quad(namedNode('ex:s1'), namedNode('ex:done'), namedNode('ex:yes')),
     ]);
   });
 

--- a/test/unit/util/QuadUtil.test.ts
+++ b/test/unit/util/QuadUtil.test.ts
@@ -1,5 +1,6 @@
 import 'jest-rdf';
 import { DataFactory, Store } from 'n3';
+import { BadRequestHttpError } from '../../../src/util/errors/BadRequestHttpError';
 import { parseQuads, serializeQuads, solveBgp, termToInt, uniqueQuads } from '../../../src/util/QuadUtil';
 import { guardedStreamFrom, readableToString } from '../../../src/util/StreamUtil';
 import variable = DataFactory.variable;
@@ -91,6 +92,20 @@ describe('QuadUtil', (): void => {
         v2: namedNode('ex:o2'),
         v3: namedNode('ex:p2'),
       });
+    });
+
+    it('throws a BadRequestHttpError when the intermediate bindings exceed the maximum.', async(): Promise<void> => {
+      const bgp = [
+        quad(variable('v'), namedNode('ex:p0'), namedNode('ex:o0')),
+      ];
+      const data = new Store([
+        quad(namedNode('ex:s0'), namedNode('ex:p0'), namedNode('ex:o0')),
+        quad(namedNode('ex:s1'), namedNode('ex:p0'), namedNode('ex:o0')),
+      ]);
+      expect((): unknown => solveBgp(bgp, data, 1)).toThrow(BadRequestHttpError);
+      expect((): unknown => solveBgp(bgp, data, 1)).toThrow(
+        'The patch conditions produced more than the allowed 1 intermediate bindings.',
+      );
     });
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — an upstream issue describing the unbounded `solid:where` evaluation must be created on CommunitySolidServer/CommunitySolidServer before this is submitted there (the upstream template requires one).

#### ✍️ Description

N3 Patch (`text/n3`) requests carry a `solid:where` clause whose Basic Graph Pattern is evaluated against the target resource's graph by `solveBgp` (`src/util/QuadUtil.ts`), a nested-loop join that had no bound on the number of intermediate solution bindings. A WHERE of N mutually-unconstrained patterns (`?s1 ?p1 ?o1. ?s2 ?p2 ?o2. …`) makes each pattern match the entire graph, so the intermediate result grows as `graphSize ^ N` — deterministically: a resource of just 20 triples with 8 such patterns yields 20⁸ ≈ 2.6 × 10¹⁰ partial bindings, exhausting CPU and memory. That is an authenticated DoS on the LDP write path. (No wall-clock benchmark command exists for this; the growth formula above and the added regression tests are the reproducible evidence.)

This PR caps the number of intermediate bindings:

- `solveBgp` gains an optional `maxBindings` argument (default `Number.POSITIVE_INFINITY`, so direct callers keep the previous unbounded behaviour). The check runs inside the join loop, so evaluation aborts with a `400 BadRequestHttpError` *before* the combinatorial set is materialised.
- `N3Patcher` gains an optional `maxConditionBindings` constructor parameter (default `1_000_000`), passed into `solveBgp` and set explicitly on the default instance in `config/storage/middleware/stores/patching.json`.

A cap on intermediate bindings — rather than a wall-clock timeout or a pattern-count limit — maps directly onto how the join does its work, so it is exact and effectively free to enforce.

**Why the default cannot reject a legitimate patch:** Solid §5.3.1 requires an N3 Patch WHERE to resolve to exactly one variable mapping (`N3Patcher` already returns `409` for zero or multiple final matches), so a legitimate patch's intermediate bindings are bounded in practice by the target resource's triple count — realistically thousands, at most tens of thousands for an unusually large single resource. One million leaves well over 10× headroom, so no patch a real Solid client sends is affected. The `409` semantics for zero/multiple matches are untouched, and non-condition patches never reach the bound.

**Verification:** `npm run build` (componentsjs-generator emits the new optional `maxConditionBindings` parameter), `npm run lint` at 0 warnings, and the full unit suite under the 100% `src/` coverage gate all green (358 suites / 2373 tests; `N3Patcher.ts` and `QuadUtil.ts` each at 100% branches/functions/lines/statements). Unit tests added: `solveBgp` throws when the intermediate bindings exceed the maximum; a patch exceeding a configured limit is rejected; a limit with headroom still applies the patch. A boot smoke of `config/default.json` plus a full `PUT`/`PATCH` (`text/n3` with a `solid:where`)/`GET` round-trip against an allow-all config confirmed a normal WHERE still resolves and applies under the default bound.

**Branch target and semver:** this adds a new configuration parameter, so it is **semver.minor**; per the contributing guidelines it should target the latest `versions/*` branch (currently `versions/next-major`) when submitted upstream — it targets `main` here only because that is the fork's default branch.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
