### PR TITLE
docs: Document single-instance locker constraint and file-backend backup; warn under clustering

### DIFF
--- a/config/util/resource-locker/memory.json
+++ b/config/util/resource-locker/memory.json
@@ -8,7 +8,12 @@
       "locker": {
         "@type": "GreedyReadWriteLocker",
         "locker": {
-          "@type": "MemoryResourceLocker"
+          "@type": "MemoryResourceLocker",
+          "clusterManager": {
+            "comment": "Used to warn when in-memory locks are used with multiple workers, where they are unsafe.",
+            "@type": "ClusterManager",
+            "workers": { "@id": "urn:solid-server:default:variable:workers" }
+          }
         },
         "storage": { "@id": "urn:solid-server:default:LockStorage" }
       },

--- a/documentation/markdown/usage/backup-restore.md
+++ b/documentation/markdown/usage/backup-restore.md
@@ -1,0 +1,98 @@
+# Backup and restore (file backend)
+
+When the server runs with a file-based configuration
+(for example `config/file.json`, started with `-f /path/to/data`),
+all state is stored below the root file path (`--rootFilePath`/`-f`).
+This page describes what lives there, how to take a consistent backup, and how to restore it.
+
+This applies to the file backend. Servers using the in-memory backend (the default `config/default.json`)
+keep everything in memory and have nothing on disk to back up.
+
+## What is stored in the root file path
+
+The root file path contains two kinds of data:
+
+* **Pod and resource data.**
+  The resources users create are stored as files and directories that mirror their URLs,
+  next to their metadata (stored in companion files, by default with a `.meta` suffix).
+* **Server-internal state**, under the hidden `.internal/` directory.
+  This directory is deliberately hidden from the Solid interface and is *not* exposed over HTTP,
+  but it is essential and must be included in any backup. It contains, among others:
+
+    * `.internal/accounts/` – account records, including login/password data and
+      `.internal/accounts/credentials/` for [client credentials](client-credentials.md) tokens.
+    * `.internal/idp/keys/` – the OpenID Connect signing keys.
+    * `.internal/idp/adapter/` – OIDC registration/session state.
+    * `.internal/idp/tokens/` – issued OIDC tokens.
+    * `.internal/forgot-password/` – pending password-reset records.
+    * `.internal/notifications/` – notification channel state.
+    * `.internal/setup/` – setup/version markers used by data migrations.
+    * `.internal/locks/` – lock files, when the file-based locker is used.
+
+!!! danger "Back up the whole root file path, including `.internal`"
+    A backup of only the visible pod data is **not** restorable: without `.internal` you lose all accounts,
+    credentials and OIDC keys. Losing `.internal/idp/keys/` in particular invalidates every existing
+    token and session, forcing all clients to re-authenticate. Always copy the *entire* root file path.
+
+!!! note "Keep the base URL stable"
+    Resource identifiers are derived from the server's base URL (`--baseUrl`/`-b`).
+    Restore the data behind the same base URL it was created with; changing the base URL effectively
+    rehosts the data at different identifiers.
+
+## Taking a backup
+
+### Cold backup (recommended)
+
+The only way to guarantee a fully consistent snapshot is to make sure nothing is writing during the copy:
+
+1. Stop the server (allow it to shut down cleanly so finalizers run and locks are released).
+2. Copy the entire root file path, preserving permissions, symlinks and hidden files, e.g.:
+
+    ```shell
+    # server is stopped
+    tar czpf css-backup-$(date +%F).tar.gz -C /path/to/data .
+    # or
+    rsync -a --delete /path/to/data/ /path/to/backup/
+    ```
+
+3. Start the server again.
+
+### Online backup caveats
+
+If you cannot stop the server, be aware that a plain live copy of the directory is **not** guaranteed to be
+consistent: files (including account and OIDC state under `.internal`) may be copied mid-write,
+and a resource and its metadata companion file may be captured at different moments.
+
+* Prefer an **atomic file-system or volume snapshot** (LVM, ZFS, or a cloud block-storage snapshot)
+  so the whole tree is captured at a single point in time, then copy from the snapshot.
+* If you must use a live `rsync`/`cp`, treat the result as best-effort: run the copy, then run it again to
+  narrow the window, and expect that a small number of in-flight resources may be inconsistent.
+  This is acceptable for coarse disaster recovery but not for a guaranteed point-in-time restore.
+* The server's own resource locks do not make a directory copy consistent: they serialize the server's
+  writes but are not visible to an external copy tool, and the in-memory locker keeps no on-disk state at all.
+  See [Scaling, clustering and locking](scaling-and-locking.md) for the locker options.
+
+## Restoring a backup
+
+1. Stop the server if it is running. **Never restore into a running server**, as it will be writing to the
+   same files.
+2. Replace the root file path with the backup contents, preserving permissions and hidden files, e.g.:
+
+    ```shell
+    rsync -a --delete /path/to/backup/ /path/to/data/
+    ```
+
+3. Remove any stale lock files if a lock directory was captured while the server was running:
+
+    ```shell
+    rm -rf /path/to/data/.internal/locks
+    ```
+
+    The file locker also clears this directory on a clean start, but removing it avoids confusion after an
+    unclean copy.
+4. Make sure the restored files are owned by and readable/writable for the user that runs the server.
+5. Start the server with the **same** base URL and configuration as the backed-up instance.
+
+Because the restore includes `.internal/idp/keys/`, existing tokens and sessions remain valid after a
+restore to the same base URL. If those keys were lost or intentionally rotated, clients will need to
+re-authenticate.

--- a/documentation/markdown/usage/scaling-and-locking.md
+++ b/documentation/markdown/usage/scaling-and-locking.md
@@ -1,0 +1,85 @@
+# Scaling, clustering and locking
+
+The Community Solid Server serializes concurrent writes to the same resource with a *resource locker*.
+Which locker is safe to use depends on how you scale the server:
+in a single process, across multiple worker threads, or across multiple server instances.
+Choosing the wrong locker can silently corrupt data, so this page describes the trade-offs.
+
+## Ways of running the server
+
+There are two independent axes of scaling:
+
+* **Workers / clustering** (single machine, one storage backend):
+  the `--workers`/`-w` parameter runs the server in multithreaded mode using the
+  Node.js [`cluster`](https://nodejs.org/api/cluster.html) module.
+  See [Starting the server](starting-server.md) for the exact semantics of the values.
+  With more than one worker, several processes handle requests against the *same* backend.
+* **Multiple instances** (horizontal scaling):
+  running several independent server processes (for example several containers or Kubernetes replicas)
+  that all point at the *same* shared storage.
+
+Both cases mean that more than one process can write to the same resource at the same time,
+so the locker has to coordinate *across processes*, not just within one.
+
+## The in-memory locker is single-instance only
+
+The default configuration (`config/default.json`) and every configuration that imports
+`config/util/resource-locker/memory.json` use the `MemoryResourceLocker`.
+This locker keeps all of its locks in the memory of a *single* process.
+
+!!! danger "The in-memory locker is not shared across processes"
+    Because the locks only live in the memory of one process, a second worker or a second
+    server instance does not see them. Two processes can then acquire a "lock" on the same
+    resource at the same time and write to it simultaneously, which can corrupt that resource
+    and its metadata. The in-memory locker is therefore only correct for a **single process,
+    single instance** deployment.
+
+The default configuration also stores all data *in memory* (`config/storage/backend/memory.json`),
+so it cannot be scaled horizontally anyway; it is intended for development and quickly trying things out.
+The risk becomes relevant when the in-memory locker is combined with a **persistent backend**
+(a file or SPARQL backend) that *can* be shared between processes or instances.
+
+### What the server does to protect you
+
+* **Clustering is refused.**
+  The `MemoryResourceLocker` is marked as single-threaded. When the server is started with more than
+  one worker (`--workers` set to anything other than `1`) while a single-threaded component such as the
+  in-memory locker is configured, startup is aborted with an error rather than running in an unsafe state.
+* **A warning is logged.**
+  In addition, the `MemoryResourceLocker` logs a `warn`-level message at startup when it detects it is
+  being constructed in multithreaded/clustered mode, pointing you at a shared locker.
+  A normal single-instance, single-worker deployment sees no warning and no change in behaviour.
+
+!!! warning "Multiple instances cannot be detected automatically"
+    The checks above catch the multi-*worker* case within one process. They cannot detect that you
+    started several *separate* single-worker instances against the same shared storage
+    (for example several containers on a network file system). In that setup every instance passes
+    the single-threaded check individually, yet their in-memory locks are still not shared.
+    When you run more than one instance you **must** switch to a shared locker yourself.
+
+## Choosing a locker
+
+| Locker                                       | Safe for                                              | Notes                                                                                     |
+|----------------------------------------------|-------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| `config/util/resource-locker/memory.json`    | Single process, single instance                       | Default. Fastest, but locks are not shared across processes.                              |
+| `config/util/resource-locker/file.json`      | Multiple workers/instances on one shared file system  | Process- and thread-safe. Relies on the file system for locking (see caveat below).       |
+| `config/util/resource-locker/redis.json`     | Multiple instances across machines                    | Recommended for horizontal scaling. Requires a reachable Redis server.                    |
+
+To use a different locker, start from a configuration that imports the corresponding
+`config/util/resource-locker/*.json` file instead of the in-memory one, or override that import in your
+own configuration. See the [configuration documentation](https://communitysolidserver.github.io/configuration-generator/)
+and [`config/README.md`](https://github.com/CommunitySolidServer/CommunitySolidServer/blob/main/config/README.md)
+for how imports are composed.
+
+!!! note "File-system locking on network storage"
+    The file locker coordinates through lock files on disk. This is reliable on a local file system,
+    but locking guarantees on network file systems (NFS, SMB, some cloud volumes) are implementation
+    dependent and can be unreliable. For robust horizontal scaling across machines, prefer the Redis locker.
+
+## Summary
+
+* Keep the in-memory locker only for a single-process, single-instance deployment (this is the default).
+* For multiple workers on one host with a shared file system, use the file locker.
+* For multiple instances across machines, use the Redis locker.
+* Also make sure the storage backend itself is shared and consistent; see
+  [Backup and restore](backup-restore.md) for how the file backend stores its data.

--- a/documentation/markdown/usage/scaling-and-locking.md
+++ b/documentation/markdown/usage/scaling-and-locking.md
@@ -48,7 +48,7 @@ The risk becomes relevant when the in-memory locker is combined with a **persist
 * **A warning is logged.**
   In addition, the `MemoryResourceLocker` logs a `warn`-level message at startup when it detects it is
   being constructed in multithreaded/clustered mode, pointing you at a shared locker.
-  A normal single-instance, single-worker deployment sees no warning and no change in behaviour.
+  A single-instance, single-worker deployment sees no warning.
 
 !!! warning "Multiple instances cannot be detected automatically"
     The checks above catch the multi-*worker* case within one process. They cannot detect that you

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -104,7 +104,7 @@ docker run --rm -p 3000:3000 -it solidproject/community-server -c config/default
 # Or use your own configuration mapped to the right directory
 docker run --rm -v ~/solid-config:/config -p 3000:3000 -it solidproject/community-server -c /config/my-config.json
 # Or use environment variables to configure your css instance
-docker run --rm -v ~/Solid:/data -p 3000:3000 -it -e CSS_CONFIG=config/file-no-setup.json -e CSS_LOGGING_LEVEL=debug solidproject/community-server
+docker run --rm -v ~/Solid:/data -p 3000:3000 -it -e CSS_CONFIG=config/file.json -e CSS_LOGGING_LEVEL=debug solidproject/community-server
 ```
 
 ### Using a Helm Chart

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -82,6 +82,8 @@ nav:
       - Tests: features/test.md
   - Usage:
       - Starting the server: usage/starting-server.md
+      - Scaling, clustering and locking: usage/scaling-and-locking.md
+      - Backup and restore: usage/backup-restore.md
       - Example request: usage/example-requests.md
       - Metadata: usage/metadata.md
       - Identity provider:

--- a/src/util/locking/MemoryResourceLocker.ts
+++ b/src/util/locking/MemoryResourceLocker.ts
@@ -1,5 +1,6 @@
 import AsyncLock from 'async-lock';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
+import type { ClusterManager } from '../../init/cluster/ClusterManager';
 import type { SingleThreaded } from '../../init/cluster/SingleThreaded';
 import { getLoggerFor } from '../../logging/LogUtil';
 import { InternalServerError } from '../errors/InternalServerError';
@@ -10,6 +11,12 @@ import type { ResourceLocker } from './ResourceLocker';
  * Note that all locks are kept in memory until they are unlocked which could potentially result
  * in a memory leak if locks are never unlocked, so make sure this is covered with expiring locks for example,
  * and/or proper `finally` handles.
+ *
+ * As the name indicates, all locks are only kept in the memory of a single process.
+ * They are therefore not shared across workers or server instances,
+ * so this locker is only safe to use in a single-process, single-instance deployment.
+ * Use a shared locker (such as the Redis locker) when running with multiple workers,
+ * in clustered mode, or with multiple server instances on shared storage.
  */
 export class MemoryResourceLocker implements ResourceLocker, SingleThreaded {
   protected readonly logger = getLoggerFor(this);
@@ -17,9 +24,22 @@ export class MemoryResourceLocker implements ResourceLocker, SingleThreaded {
   private readonly locker: AsyncLock;
   private readonly unlockCallbacks: Record<string, () => void>;
 
-  public constructor() {
+  /**
+   * @param clusterManager - When provided, a warning is logged if the server is not running in
+   *                         singlethreaded mode, since in-memory locks are not shared across workers.
+   */
+  public constructor(clusterManager?: ClusterManager) {
     this.locker = new AsyncLock();
     this.unlockCallbacks = {};
+    if (clusterManager && !clusterManager.isSingleThreaded()) {
+      this.logger.warn(
+        'Using the in-memory MemoryResourceLocker while running with multiple workers or in clustered mode. ' +
+        'Locks are only stored in the memory of a single process, so they are not shared across workers or ' +
+        'server instances, and concurrent writes to the same resource can corrupt data. ' +
+        'Switch to a shared locker such as the Redis locker (config/util/resource-locker/redis.json) ' +
+        'for multi-worker or multi-instance deployments.',
+      );
+    }
   }
 
   public async acquire(identifier: ResourceIdentifier): Promise<void> {

--- a/src/util/locking/MemoryResourceLocker.ts
+++ b/src/util/locking/MemoryResourceLocker.ts
@@ -12,11 +12,8 @@ import type { ResourceLocker } from './ResourceLocker';
  * in a memory leak if locks are never unlocked, so make sure this is covered with expiring locks for example,
  * and/or proper `finally` handles.
  *
- * As the name indicates, all locks are only kept in the memory of a single process.
- * They are therefore not shared across workers or server instances,
- * so this locker is only safe to use in a single-process, single-instance deployment.
- * Use a shared locker (such as the Redis locker) when running with multiple workers,
- * in clustered mode, or with multiple server instances on shared storage.
+ * Locks are not shared between processes, so this locker can not be used
+ * when multiple server instances run on the same storage.
  */
 export class MemoryResourceLocker implements ResourceLocker, SingleThreaded {
   protected readonly logger = getLoggerFor(this);
@@ -25,8 +22,7 @@ export class MemoryResourceLocker implements ResourceLocker, SingleThreaded {
   private readonly unlockCallbacks: Record<string, () => void>;
 
   /**
-   * @param clusterManager - When provided, a warning is logged if the server is not running in
-   *                         singlethreaded mode, since in-memory locks are not shared across workers.
+   * @param clusterManager - Used to warn when the server is not running in singlethreaded mode.
    */
   public constructor(clusterManager?: ClusterManager) {
     this.locker = new AsyncLock();

--- a/test/unit/util/locking/MemoryResourceLocker.test.ts
+++ b/test/unit/util/locking/MemoryResourceLocker.test.ts
@@ -1,11 +1,16 @@
+import type { ClusterManager } from '../../../../src/init/cluster/ClusterManager';
+import * as LogUtil from '../../../../src/logging/LogUtil';
 import { InternalServerError } from '../../../../src/util/errors/InternalServerError';
 import { MemoryResourceLocker } from '../../../../src/util/locking/MemoryResourceLocker';
 
 describe('A MemoryResourceLocker', (): void => {
   let locker: MemoryResourceLocker;
   const identifier = { path: 'http://test.com/foo' };
+  let logger: { debug: jest.Mock; warn: jest.Mock };
 
   beforeEach(async(): Promise<void> => {
+    logger = { debug: jest.fn(), warn: jest.fn() };
+    jest.spyOn(LogUtil, 'getLoggerFor').mockReturnValue(logger as any);
     locker = new MemoryResourceLocker();
   });
 
@@ -67,5 +72,29 @@ describe('A MemoryResourceLocker', (): void => {
       return locker.release({ path: 'path1' });
     });
     expect(results).toEqual([ 2, 3, 1 ]);
+  });
+
+  it('does not warn when no ClusterManager is provided.', (): void => {
+    expect(new MemoryResourceLocker()).toBeDefined();
+    expect(logger.warn).toHaveBeenCalledTimes(0);
+  });
+
+  it('warns when constructed while running with multiple workers.', (): void => {
+    const clusterManager: jest.Mocked<ClusterManager> = {
+      isSingleThreaded: jest.fn().mockReturnValue(false),
+    } as any;
+    expect(new MemoryResourceLocker(clusterManager)).toBeDefined();
+    expect(clusterManager.isSingleThreaded).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenLastCalledWith(expect.stringContaining('MemoryResourceLocker'));
+  });
+
+  it('does not warn when constructed in singlethreaded mode.', (): void => {
+    const clusterManager: jest.Mocked<ClusterManager> = {
+      isSingleThreaded: jest.fn().mockReturnValue(true),
+    } as any;
+    expect(new MemoryResourceLocker(clusterManager)).toBeDefined();
+    expect(clusterManager.isSingleThreaded).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

None yet — the upstream template requires a related issue, so one needs to be created on CommunitySolidServer/CommunitySolidServer before this is submitted upstream.

#### ✍️ Description

Documents the operational constraints of the file backend and the in-memory locker, and adds a startup warning for the one unsafe case the server can detect.

**Scaling/locking docs + a warning under clustering.** The `MemoryResourceLocker` keeps its locks in the memory of a single process, so combining it with a persistent backend shared by several workers or server instances can silently corrupt data. The server already refuses to start a `SingleThreaded` component with more than one worker, but it cannot detect several independent single-worker instances pointed at the same storage. A new docs page, `documentation/markdown/usage/scaling-and-locking.md`, explains the two scaling axes (workers/clustering vs. multiple instances) and which locker fits each (`file` for multiple workers on one shared file system, `redis` for horizontal scaling). In addition, `MemoryResourceLocker` now accepts an optional `ClusterManager` and logs a `warn`-level message when constructed in multithreaded/clustered mode, pointing operators at a shared locker. The warning is purely additive: it never refuses to start, never changes locking behaviour, and single-worker single-instance deployments see no warning. In `config/util/resource-locker/memory.json` the parameter is wired via a locally built `ClusterManager` on the always-bound `urn:solid-server:default:variable:workers` variable, so it also resolves in partial-config integration tests without depending on the shared `ClusterManager` `@id`.

**Backup/restore docs for the file backend.** A new page, `documentation/markdown/usage/backup-restore.md`, documents what lives under `rootFilePath` (pod data plus the hidden `.internal/` state: accounts, client credentials, OIDC keys/adapter/tokens, forgot-password, notifications, setup markers, locks), how to take a consistent cold backup, why a live copy is not point-in-time consistent (prefer atomic FS/volume snapshots), and the restore procedure (stop the server, restore the whole tree, drop stale `.internal/locks`, keep the same base URL so the OIDC keys stay valid).

**Stale docs reference.** The Docker example in `documentation/markdown/usage/starting-server.md` still pointed at `config/file-no-setup.json`, which was removed together with setup in v6; it now uses the current equivalent, `config/file.json` (this was the only remaining occurrence in the repo). This is a small drive-by docs correction — it can be split into its own PR if preferred.

Both new pages are linked from the MkDocs nav under *Usage*. The warning's two branches (warn under clustering, silent when single-threaded) are covered by unit tests in `test/unit/util/locking/MemoryResourceLocker.test.ts`.

**Semver / branch target:** this is a **semver.minor** change (a backwards-compatible optional constructor parameter plus its config wiring; contributors cannot set the label). Per the contributing guidelines the upstream submission should therefore target the latest `versions/*` branch (currently `versions/next-major`) rather than `main`; this fork PR targets `main` for fork-side review only.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
