### PR TITLE
feat: Add aggregable notification delivery metrics

### DIFF
--- a/config/util/metrics/default.json
+++ b/config/util/metrics/default.json
@@ -5,7 +5,8 @@
       "comment": [
         "OPT-IN Prometheus metrics. This file is NOT imported by any shipped config: add it next to your main config, e.g. `community-solid-server -c config/file.json -c config/util/metrics/default.json`.",
         "SECURITY: the /metrics endpoint is UNAUTHENTICATED and exposes internal counters (request rates, latencies, process cpu/memory). Restrict it at your reverse proxy or firewall; never expose it to the public internet.",
-        "This recipe assumes the default handler waterfall (config/http/handler/default.json). If you use a different handler configuration, adjust the Override list below to match its handlers."
+        "This recipe assumes the default handler waterfall (config/http/handler/default.json). If you use a different handler configuration, adjust the Override list below to match its handlers.",
+        "It also assumes notification delivery is enabled (config/http/notifications/all.json, the default) so the WebhookEmitter and ListeningActivityHandler exist. If you use config/http/notifications/disabled.json, remove the two notification-delivery Override blocks below."
       ]
     },
     {
@@ -33,6 +34,24 @@
       "@type": "MetricsHandler",
       "metrics": { "@id": "urn:solid-server:metrics:PrometheusMetrics" },
       "path": "/metrics"
+    },
+    {
+      "comment": "Records webhook delivery outcomes on the css_notification_deliveries_total counter. Only adds the `metrics` parameter; all other WebhookEmitter parameters are preserved. Remove this block if webhook notifications are disabled.",
+      "@type": "Override",
+      "overrideInstance": { "@id": "urn:solid-server:default:WebhookEmitter" },
+      "overrideParameters": {
+        "@type": "WebhookEmitter",
+        "metrics": { "@id": "urn:solid-server:metrics:PrometheusMetrics" }
+      }
+    },
+    {
+      "comment": "Records per-channel delivery outcomes on the css_notification_deliveries_total counter. Only adds the `metrics` parameter; all other ListeningActivityHandler parameters are preserved. Remove this block if notifications are disabled.",
+      "@type": "Override",
+      "overrideInstance": { "@id": "urn:solid-server:default:ListeningActivityHandler" },
+      "overrideParameters": {
+        "@type": "ListeningActivityHandler",
+        "metrics": { "@id": "urn:solid-server:metrics:PrometheusMetrics" }
+      }
     },
     {
       "comment": "Places the metrics handler first in the waterfall so a scrape is answered immediately and never traverses the LDP stack.",

--- a/config/util/metrics/default.json
+++ b/config/util/metrics/default.json
@@ -36,7 +36,7 @@
       "path": "/metrics"
     },
     {
-      "comment": "Records webhook delivery outcomes on the css_notification_deliveries_total counter. Only adds the `metrics` parameter; all other WebhookEmitter parameters are preserved. Remove this block if webhook notifications are disabled.",
+      "comment": "Records webhook delivery outcomes on the css_notification_deliveries_total counter. Remove this block if webhook notifications are disabled.",
       "@type": "Override",
       "overrideInstance": { "@id": "urn:solid-server:default:WebhookEmitter" },
       "overrideParameters": {
@@ -45,7 +45,7 @@
       }
     },
     {
-      "comment": "Records per-channel delivery outcomes on the css_notification_deliveries_total counter. Only adds the `metrics` parameter; all other ListeningActivityHandler parameters are preserved. Remove this block if notifications are disabled.",
+      "comment": "Records per-channel delivery outcomes on the css_notification_deliveries_total counter. Remove this block if notifications are disabled.",
       "@type": "Override",
       "overrideInstance": { "@id": "urn:solid-server:default:ListeningActivityHandler" },
       "overrideParameters": {

--- a/config/util/metrics/default.json
+++ b/config/util/metrics/default.json
@@ -1,0 +1,56 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": [
+        "OPT-IN Prometheus metrics. This file is NOT imported by any shipped config: add it next to your main config, e.g. `community-solid-server -c config/file.json -c config/util/metrics/default.json`.",
+        "SECURITY: the /metrics endpoint is UNAUTHENTICATED and exposes internal counters (request rates, latencies, process cpu/memory). Restrict it at your reverse proxy or firewall; never expose it to the public internet.",
+        "This recipe assumes the default handler waterfall (config/http/handler/default.json). If you use a different handler configuration, adjust the Override list below to match its handlers."
+      ]
+    },
+    {
+      "comment": "Prometheus registry holding the default process metrics and the HTTP request instruments.",
+      "@id": "urn:solid-server:metrics:PrometheusMetrics",
+      "@type": "PrometheusMetrics"
+    },
+    {
+      "comment": "Observe-only configurator: records request rate/latency without ever writing to the response.",
+      "@id": "urn:solid-server:metrics:MetricsServerConfigurator",
+      "@type": "MetricsServerConfigurator",
+      "metrics": { "@id": "urn:solid-server:metrics:PrometheusMetrics" }
+    },
+    {
+      "comment": "Adds the observe-only metrics configurator to the existing (parallel) set of server configurators.",
+      "@id": "urn:solid-server:default:ServerConfigurator",
+      "@type": "ParallelHandler",
+      "handlers": [
+        { "@id": "urn:solid-server:metrics:MetricsServerConfigurator" }
+      ]
+    },
+    {
+      "comment": "Serves the Prometheus registry on GET /metrics.",
+      "@id": "urn:solid-server:metrics:MetricsHandler",
+      "@type": "MetricsHandler",
+      "metrics": { "@id": "urn:solid-server:metrics:PrometheusMetrics" },
+      "path": "/metrics"
+    },
+    {
+      "comment": "Places the metrics handler first in the waterfall so a scrape is answered immediately and never traverses the LDP stack.",
+      "@type": "Override",
+      "overrideInstance": { "@id": "urn:solid-server:default:BaseHttpHandler" },
+      "overrideParameters": {
+        "@type": "WaterfallHandler",
+        "handlers": [
+          { "@id": "urn:solid-server:metrics:MetricsHandler" },
+          { "@id": "urn:solid-server:default:StaticAssetHandler" },
+          { "@id": "urn:solid-server:default:OidcHandler" },
+          { "@id": "urn:solid-server:default:NotificationHttpHandler" },
+          { "@id": "urn:solid-server:default:StorageDescriptionHandler" },
+          { "@id": "urn:solid-server:default:AuthResourceHttpHandler" },
+          { "@id": "urn:solid-server:default:IdentityProviderHandler" },
+          { "@id": "urn:solid-server:default:LdpHandler" }
+        ]
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "n3": "^1.17.1",
         "nodemailer": "^9.0.1",
         "oidc-provider": "^8.4.0",
+        "prom-client": "^15.1.3",
         "proper-lockfile": "^4.1.2",
         "pump": "^3.0.0",
         "punycode": "^2.3.0",
@@ -5446,6 +5447,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -7605,6 +7615,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -14501,6 +14517,19 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-polyfill": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
@@ -16098,6 +16127,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {
@@ -21579,6 +21617,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
+    },
     "@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -23160,6 +23203,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "brace-expansion": {
       "version": "1.1.14",
@@ -28163,6 +28211,15 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "requires": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise-polyfill": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
@@ -29412,6 +29469,14 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.3.tgz",
       "integrity": "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==",
       "dev": true
+    },
+    "tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "requires": {
+        "bintrees": "1.0.2"
+      }
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "n3": "^1.17.1",
     "nodemailer": "^9.0.1",
     "oidc-provider": "^8.4.0",
+    "prom-client": "^15.1.3",
     "proper-lockfile": "^4.1.2",
     "pump": "^3.0.0",
     "punycode": "^2.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -380,6 +380,11 @@ export * from './server/middleware/HeaderHandler';
 export * from './server/middleware/StaticAssetHandler';
 export * from './server/middleware/WebSocketAdvertiser';
 
+// Server/Metrics
+export * from './server/metrics/MetricsHandler';
+export * from './server/metrics/MetricsServerConfigurator';
+export * from './server/metrics/PrometheusMetrics';
+
 // Server/Notifications/Generate
 export * from './server/notifications/generate/ActivityNotificationGenerator';
 export * from './server/notifications/generate/AddRemoveNotificationGenerator';

--- a/src/server/metrics/MetricsHandler.ts
+++ b/src/server/metrics/MetricsHandler.ts
@@ -1,0 +1,48 @@
+import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import type { HttpHandlerInput } from '../HttpHandler';
+import { HttpHandler } from '../HttpHandler';
+import type { PrometheusMetrics } from './PrometheusMetrics';
+
+/**
+ * An {@link HttpHandler} that exposes the collected Prometheus metrics on a fixed path (default `/metrics`).
+ *
+ * Only `GET` requests on the configured path are handled;
+ * any other request is rejected with a {@link NotImplementedHttpError} so it continues down the waterfall.
+ *
+ * The response is UNAUTHENTICATED and exposes internal counters:
+ * make sure this endpoint is restricted at the reverse proxy or firewall when the server is publicly reachable.
+ */
+export class MetricsHandler extends HttpHandler {
+  private readonly metrics: PrometheusMetrics;
+  private readonly path: string;
+
+  /**
+   * @param metrics - The {@link PrometheusMetrics} exposing the registry to serialize.
+   * @param path - The path on which the metrics are exposed. Defaults to `/metrics`.
+   */
+  public constructor(metrics: PrometheusMetrics, path = '/metrics') {
+    super();
+    this.metrics = metrics;
+    this.path = path;
+  }
+
+  public async canHandle({ request }: HttpHandlerInput): Promise<void> {
+    if (request.method !== 'GET') {
+      throw new NotImplementedHttpError('Only GET requests are supported');
+    }
+    // Strip a potential query string before comparing to the configured path.
+    if (request.url?.split('?')[0] !== this.path) {
+      throw new NotImplementedHttpError(`Only ${this.path} is supported`);
+    }
+  }
+
+  public async handle({ response }: HttpHandlerInput): Promise<void> {
+    const { registry } = this.metrics;
+    const body = await registry.metrics();
+    response.writeHead(200, {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'content-type': registry.contentType,
+    });
+    response.end(body);
+  }
+}

--- a/src/server/metrics/MetricsServerConfigurator.ts
+++ b/src/server/metrics/MetricsServerConfigurator.ts
@@ -1,0 +1,52 @@
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
+import { getLoggerFor } from '../../logging/LogUtil';
+import { createErrorMessage } from '../../util/errors/ErrorUtil';
+import { ServerConfigurator } from '../ServerConfigurator';
+import type { PrometheusMetrics } from './PrometheusMetrics';
+
+/**
+ * A {@link ServerConfigurator} that attaches an observe-only listener to the `request` event of a
+ * {@link Server} to record Prometheus metrics.
+ *
+ * The listener runs alongside the main request listener without interfering with it:
+ * it never writes to the response, never consumes the request body,
+ * and never throws into the request flow.
+ * Any error while instrumenting or recording is caught and logged so that a metrics failure
+ * can never break request handling.
+ *
+ * On every request a timer is started; when the response emits `finish` the duration is observed and
+ * the request counter is incremented with the request method and the response status code.
+ */
+export class MetricsServerConfigurator extends ServerConfigurator {
+  protected readonly logger = getLoggerFor(this);
+
+  private readonly metrics: PrometheusMetrics;
+
+  /**
+   * @param metrics - The {@link PrometheusMetrics} holding the registry and request instruments.
+   */
+  public constructor(metrics: PrometheusMetrics) {
+    super();
+    this.metrics = metrics;
+  }
+
+  public async handle(server: Server): Promise<void> {
+    server.on('request', (request: IncomingMessage, response: ServerResponse): void => {
+      try {
+        // Start timing before the request is handled; the returned function observes the duration.
+        const stopTimer = this.metrics.requestDuration.startTimer();
+        response.on('finish', (): void => {
+          try {
+            const labels = { method: request.method ?? 'UNKNOWN', code: response.statusCode };
+            this.metrics.requestsTotal.inc(labels);
+            stopTimer(labels);
+          } catch (error: unknown) {
+            this.logger.error(`Unable to record request metrics: ${createErrorMessage(error)}`);
+          }
+        });
+      } catch (error: unknown) {
+        this.logger.error(`Unable to instrument request for metrics: ${createErrorMessage(error)}`);
+      }
+    });
+  }
+}

--- a/src/server/metrics/PrometheusMetrics.ts
+++ b/src/server/metrics/PrometheusMetrics.ts
@@ -12,9 +12,8 @@ import { collectDefaultMetrics, Counter, Histogram, Registry } from 'prom-client
  * The request target/path is deliberately *not* used as a label:
  * the unbounded number of resource URLs would cause a cardinality explosion in the time-series database.
  *
- * For the same reason the notification delivery instrument is only labelled by the channel `type` and the
- * delivery `outcome` (`success` or `failure`): the target URL, channel id or remote address are deliberately
- * *not* used as labels, as those are unbounded (and attacker-influenced) and would explode the time-series database.
+ * For the same reason the notification delivery counter is only labelled by the channel `type`
+ * and the delivery `outcome`, never by the unbounded target URL or channel id.
  */
 export class PrometheusMetrics {
   public readonly registry: Registry;
@@ -43,9 +42,7 @@ export class PrometheusMetrics {
 
     this.notificationDeliveriesTotal = new Counter({
       name: 'css_notification_deliveries_total',
-      help:
-        'Total number of notification delivery attempts, labelled by channel type and delivery outcome ' +
-        '(success or failure). Target URL and channel id are deliberately not labelled to bound cardinality.',
+      help: 'Total number of notification delivery attempts, labelled by channel type and delivery outcome.',
       labelNames: [ 'type', 'outcome' ],
       registers: [ this.registry ],
     });

--- a/src/server/metrics/PrometheusMetrics.ts
+++ b/src/server/metrics/PrometheusMetrics.ts
@@ -11,11 +11,16 @@ import { collectDefaultMetrics, Counter, Histogram, Registry } from 'prom-client
  * request `method` and the response status `code`.
  * The request target/path is deliberately *not* used as a label:
  * the unbounded number of resource URLs would cause a cardinality explosion in the time-series database.
+ *
+ * For the same reason the notification delivery instrument is only labelled by the channel `type` and the
+ * delivery `outcome` (`success` or `failure`): the target URL, channel id or remote address are deliberately
+ * *not* used as labels, as those are unbounded (and attacker-influenced) and would explode the time-series database.
  */
 export class PrometheusMetrics {
   public readonly registry: Registry;
   public readonly requestsTotal: Counter<'code' | 'method'>;
   public readonly requestDuration: Histogram<'code' | 'method'>;
+  public readonly notificationDeliveriesTotal: Counter<'outcome' | 'type'>;
 
   public constructor() {
     this.registry = new Registry();
@@ -33,6 +38,15 @@ export class PrometheusMetrics {
       name: 'http_request_duration_seconds',
       help: 'Duration of HTTP requests in seconds, labelled by request method and response status code.',
       labelNames: [ 'method', 'code' ],
+      registers: [ this.registry ],
+    });
+
+    this.notificationDeliveriesTotal = new Counter({
+      name: 'css_notification_deliveries_total',
+      help:
+        'Total number of notification delivery attempts, labelled by channel type and delivery outcome ' +
+        '(success or failure). Target URL and channel id are deliberately not labelled to bound cardinality.',
+      labelNames: [ 'type', 'outcome' ],
       registers: [ this.registry ],
     });
   }

--- a/src/server/metrics/PrometheusMetrics.ts
+++ b/src/server/metrics/PrometheusMetrics.ts
@@ -1,0 +1,39 @@
+import { collectDefaultMetrics, Counter, Histogram, Registry } from 'prom-client';
+
+/**
+ * Creates and owns a Prometheus {@link Registry} together with the instruments used to observe
+ * incoming HTTP requests.
+ *
+ * Default process metrics (CPU, memory, event loop lag, garbage collection, ...) are collected on the
+ * same registry through `collectDefaultMetrics`.
+ *
+ * The request instruments are intentionally kept low-cardinality: they are only labelled by the
+ * request `method` and the response status `code`.
+ * The request target/path is deliberately *not* used as a label:
+ * the unbounded number of resource URLs would cause a cardinality explosion in the time-series database.
+ */
+export class PrometheusMetrics {
+  public readonly registry: Registry;
+  public readonly requestsTotal: Counter<'code' | 'method'>;
+  public readonly requestDuration: Histogram<'code' | 'method'>;
+
+  public constructor() {
+    this.registry = new Registry();
+    // Collect the default Node.js/process metrics (cpu, memory, event loop lag, gc, ...) on this registry.
+    collectDefaultMetrics({ register: this.registry });
+
+    this.requestsTotal = new Counter({
+      name: 'http_requests_total',
+      help: 'Total number of HTTP requests, labelled by request method and response status code.',
+      labelNames: [ 'method', 'code' ],
+      registers: [ this.registry ],
+    });
+
+    this.requestDuration = new Histogram({
+      name: 'http_request_duration_seconds',
+      help: 'Duration of HTTP requests in seconds, labelled by request method and response status code.',
+      labelNames: [ 'method', 'code' ],
+      registers: [ this.registry ],
+    });
+  }
+}

--- a/src/server/notifications/ListeningActivityHandler.ts
+++ b/src/server/notifications/ListeningActivityHandler.ts
@@ -19,8 +19,8 @@ import type { NotificationHandler } from './NotificationHandler';
  * No class takes this one as input, so to make sure Components.js instantiates it,
  * it needs to be added somewhere where its presence has no impact, such as the list of initializers.
  *
- * When a {@link PrometheusMetrics} instance is provided, every delivery attempt increments its
- * `css_notification_deliveries_total` counter with the channel `type` and the delivery `outcome`.
+ * When a {@link PrometheusMetrics} instance is provided,
+ * every delivery attempt increments its `css_notification_deliveries_total` counter.
  */
 export class ListeningActivityHandler extends StaticHandler {
   protected readonly logger = getLoggerFor(this);
@@ -29,12 +29,6 @@ export class ListeningActivityHandler extends StaticHandler {
   private readonly handler: NotificationHandler;
   private readonly metrics?: PrometheusMetrics;
 
-  /**
-   * @param storage - Storage containing the notification channels.
-   * @param emitter - Emitter of the activities the channels are listening to.
-   * @param handler - Handler to call for every matching notification channel.
-   * @param metrics - Optional {@link PrometheusMetrics} used to record delivery outcomes. Default is none.
-   */
   public constructor(
     storage: NotificationChannelStorage,
     emitter: ActivityEmitter,
@@ -90,8 +84,7 @@ export class ListeningActivityHandler extends StaticHandler {
         })
         .catch((error: unknown): void => {
           this.metrics?.notificationDeliveriesTotal.inc({ type: channel.type, outcome: 'failure' });
-          // Demoted from `error` to `debug`: the aggregate failure rate is now captured by the metric above,
-          // and the per-channel identifier is unaggregable noise at info level.
+          // The counter above tracks the failure rate; the per-channel details are only useful when debugging.
           this.logger.debug(`Error trying to handle notification for ${id}: ${createErrorMessage(error)}`);
         });
     }

--- a/src/server/notifications/ListeningActivityHandler.ts
+++ b/src/server/notifications/ListeningActivityHandler.ts
@@ -4,6 +4,7 @@ import { getLoggerFor } from '../../logging/LogUtil';
 import { createErrorMessage } from '../../util/errors/ErrorUtil';
 import { StaticHandler } from '../../util/handlers/StaticHandler';
 import type { AS, VocabularyTerm } from '../../util/Vocabularies';
+import type { PrometheusMetrics } from '../metrics/PrometheusMetrics';
 import type { ActivityEmitter } from './ActivityEmitter';
 import type { NotificationChannelStorage } from './NotificationChannelStorage';
 import type { NotificationHandler } from './NotificationHandler';
@@ -17,17 +18,33 @@ import type { NotificationHandler } from './NotificationHandler';
  * Extends {@link StaticHandler} so it can be more easily injected into a Components.js configuration.
  * No class takes this one as input, so to make sure Components.js instantiates it,
  * it needs to be added somewhere where its presence has no impact, such as the list of initializers.
+ *
+ * When a {@link PrometheusMetrics} instance is provided, every delivery attempt increments its
+ * `css_notification_deliveries_total` counter with the channel `type` and the delivery `outcome`.
  */
 export class ListeningActivityHandler extends StaticHandler {
   protected readonly logger = getLoggerFor(this);
 
   private readonly storage: NotificationChannelStorage;
   private readonly handler: NotificationHandler;
+  private readonly metrics?: PrometheusMetrics;
 
-  public constructor(storage: NotificationChannelStorage, emitter: ActivityEmitter, handler: NotificationHandler) {
+  /**
+   * @param storage - Storage containing the notification channels.
+   * @param emitter - Emitter of the activities the channels are listening to.
+   * @param handler - Handler to call for every matching notification channel.
+   * @param metrics - Optional {@link PrometheusMetrics} used to record delivery outcomes. Default is none.
+   */
+  public constructor(
+    storage: NotificationChannelStorage,
+    emitter: ActivityEmitter,
+    handler: NotificationHandler,
+    metrics?: PrometheusMetrics,
+  ) {
     super();
     this.storage = storage;
     this.handler = handler;
+    this.metrics = metrics;
 
     emitter.on('changed', (topic, activity, metadata): void => {
       this.emit(topic, activity, metadata).catch((error: unknown): void => {
@@ -64,6 +81,7 @@ export class ListeningActivityHandler extends StaticHandler {
       // Prevent failed notification from blocking other notifications.
       this.handler.handleSafe({ channel, activity, topic, metadata })
         .then(async(): Promise<void> => {
+          this.metrics?.notificationDeliveriesTotal.inc({ type: channel.type, outcome: 'success' });
           // Update the `lastEmit` value if the channel has a rate limit
           if (channel.rate) {
             channel.lastEmit = Date.now();
@@ -71,7 +89,10 @@ export class ListeningActivityHandler extends StaticHandler {
           }
         })
         .catch((error: unknown): void => {
-          this.logger.error(`Error trying to handle notification for ${id}: ${createErrorMessage(error)}`);
+          this.metrics?.notificationDeliveriesTotal.inc({ type: channel.type, outcome: 'failure' });
+          // Demoted from `error` to `debug`: the aggregate failure rate is now captured by the metric above,
+          // and the per-channel identifier is unaggregable noise at info level.
+          this.logger.debug(`Error trying to handle notification for ${id}: ${createErrorMessage(error)}`);
         });
     }
   }

--- a/src/server/notifications/WebhookChannel2023/WebhookEmitter.ts
+++ b/src/server/notifications/WebhookChannel2023/WebhookEmitter.ts
@@ -24,8 +24,8 @@ import { isWebhook2023Channel } from './WebhookChannel2023Type';
  * The `expiration` input parameter is how long the generated token should be valid in minutes.
  * Default is 20.
  *
- * When a {@link PrometheusMetrics} instance is provided, every delivery attempt increments its
- * `css_notification_deliveries_total` counter with the channel `type` and the delivery `outcome`.
+ * When a {@link PrometheusMetrics} instance is provided,
+ * every delivery attempt increments its `css_notification_deliveries_total` counter.
  */
 export class WebhookEmitter extends NotificationEmitter {
   protected readonly logger = getLoggerFor(this);
@@ -36,13 +36,6 @@ export class WebhookEmitter extends NotificationEmitter {
   private readonly expiration: number;
   private readonly metrics?: PrometheusMetrics;
 
-  /**
-   * @param baseUrl - The base URL of the server.
-   * @param webIdRoute - The route to the WebID used to sign the notification requests.
-   * @param jwkGenerator - Generates the key pair used to sign the notification requests.
-   * @param expiration - How long the generated token should be valid, in minutes. Default is 20.
-   * @param metrics - Optional {@link PrometheusMetrics} used to record delivery outcomes. Default is none.
-   */
   public constructor(
     baseUrl: string,
     webIdRoute: InteractionRoute,
@@ -118,8 +111,7 @@ export class WebhookEmitter extends NotificationEmitter {
     });
     if (response.status >= 400) {
       this.metrics?.notificationDeliveriesTotal.inc({ type: webhookChannel.type, outcome: 'failure' });
-      // Demoted from `error` to `debug`: the aggregate failure rate is now captured by the metric above,
-      // and the target URL and response body are attacker-influenced, so they must not be logged at info level.
+      // The target URL and response body are attacker-influenced, so they are only logged at debug level.
       this.logger.debug(`There was an issue emitting a Webhook notification with target ${webhookChannel.sendTo}: ${
         await response.text()}`);
     } else {

--- a/src/server/notifications/WebhookChannel2023/WebhookEmitter.ts
+++ b/src/server/notifications/WebhookChannel2023/WebhookEmitter.ts
@@ -7,6 +7,7 @@ import { getLoggerFor } from '../../../logging/LogUtil';
 import { NotImplementedHttpError } from '../../../util/errors/NotImplementedHttpError';
 import { trimTrailingSlashes } from '../../../util/PathUtil';
 import { readableToString } from '../../../util/StreamUtil';
+import type { PrometheusMetrics } from '../../metrics/PrometheusMetrics';
 import type { NotificationEmitterInput } from '../NotificationEmitter';
 import { NotificationEmitter } from '../NotificationEmitter';
 import type { WebhookChannel2023 } from './WebhookChannel2023Type';
@@ -22,6 +23,9 @@ import { isWebhook2023Channel } from './WebhookChannel2023Type';
  *
  * The `expiration` input parameter is how long the generated token should be valid in minutes.
  * Default is 20.
+ *
+ * When a {@link PrometheusMetrics} instance is provided, every delivery attempt increments its
+ * `css_notification_deliveries_total` counter with the channel `type` and the delivery `outcome`.
  */
 export class WebhookEmitter extends NotificationEmitter {
   protected readonly logger = getLoggerFor(this);
@@ -30,13 +34,28 @@ export class WebhookEmitter extends NotificationEmitter {
   private readonly webId: string;
   private readonly jwkGenerator: JwkGenerator;
   private readonly expiration: number;
+  private readonly metrics?: PrometheusMetrics;
 
-  public constructor(baseUrl: string, webIdRoute: InteractionRoute, jwkGenerator: JwkGenerator, expiration = 20) {
+  /**
+   * @param baseUrl - The base URL of the server.
+   * @param webIdRoute - The route to the WebID used to sign the notification requests.
+   * @param jwkGenerator - Generates the key pair used to sign the notification requests.
+   * @param expiration - How long the generated token should be valid, in minutes. Default is 20.
+   * @param metrics - Optional {@link PrometheusMetrics} used to record delivery outcomes. Default is none.
+   */
+  public constructor(
+    baseUrl: string,
+    webIdRoute: InteractionRoute,
+    jwkGenerator: JwkGenerator,
+    expiration = 20,
+    metrics?: PrometheusMetrics,
+  ) {
     super();
     this.issuer = trimTrailingSlashes(baseUrl);
     this.webId = webIdRoute.getPath();
     this.jwkGenerator = jwkGenerator;
     this.expiration = expiration * 60;
+    this.metrics = metrics;
   }
 
   public async canHandle({ channel }: NotificationEmitterInput): Promise<void> {
@@ -98,8 +117,13 @@ export class WebhookEmitter extends NotificationEmitter {
       body: await readableToString(representation.data),
     });
     if (response.status >= 400) {
-      this.logger.error(`There was an issue emitting a Webhook notification with target ${webhookChannel.sendTo}: ${
+      this.metrics?.notificationDeliveriesTotal.inc({ type: webhookChannel.type, outcome: 'failure' });
+      // Demoted from `error` to `debug`: the aggregate failure rate is now captured by the metric above,
+      // and the target URL and response body are attacker-influenced, so they must not be logged at info level.
+      this.logger.debug(`There was an issue emitting a Webhook notification with target ${webhookChannel.sendTo}: ${
         await response.text()}`);
+    } else {
+      this.metrics?.notificationDeliveriesTotal.inc({ type: webhookChannel.type, outcome: 'success' });
     }
   }
 }

--- a/test/unit/server/metrics/MetricsHandler.test.ts
+++ b/test/unit/server/metrics/MetricsHandler.test.ts
@@ -1,0 +1,63 @@
+import { MetricsHandler } from '../../../../src/server/metrics/MetricsHandler';
+import type { PrometheusMetrics } from '../../../../src/server/metrics/PrometheusMetrics';
+
+describe('A MetricsHandler', (): void => {
+  const contentType = 'text/plain; version=0.0.4; charset=utf-8';
+  let registry: { metrics: jest.Mock; contentType: string };
+  let metrics: jest.Mocked<PrometheusMetrics>;
+  let response: { writeHead: jest.Mock; end: jest.Mock };
+  let handler: MetricsHandler;
+
+  beforeEach((): void => {
+    registry = {
+      metrics: jest.fn().mockResolvedValue('# metrics body'),
+      contentType,
+    };
+    metrics = { registry } as any;
+
+    response = {
+      writeHead: jest.fn(),
+      end: jest.fn(),
+    };
+
+    handler = new MetricsHandler(metrics);
+  });
+
+  it('rejects non-GET requests.', async(): Promise<void> => {
+    const request = { method: 'POST', url: '/metrics' };
+    await expect(handler.canHandle({ request } as any)).rejects.toThrow('Only GET requests are supported');
+  });
+
+  it('rejects GET requests on a different path.', async(): Promise<void> => {
+    const request = { method: 'GET', url: '/other' };
+    await expect(handler.canHandle({ request } as any)).rejects.toThrow('Only /metrics is supported');
+  });
+
+  it('rejects GET requests without a URL.', async(): Promise<void> => {
+    const request = { method: 'GET' };
+    await expect(handler.canHandle({ request } as any)).rejects.toThrow('Only /metrics is supported');
+  });
+
+  it('accepts GET requests on the metrics path, ignoring the query string.', async(): Promise<void> => {
+    const request = { method: 'GET', url: '/metrics?foo=bar' };
+    await expect(handler.canHandle({ request } as any)).resolves.toBeUndefined();
+  });
+
+  it('serves the registry contents with the registry content type.', async(): Promise<void> => {
+    await handler.handle({ response } as any);
+
+    expect(registry.metrics).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenCalledTimes(1);
+    expect(response.writeHead).toHaveBeenLastCalledWith(200, { 'content-type': contentType });
+    expect(response.end).toHaveBeenCalledTimes(1);
+    expect(response.end).toHaveBeenLastCalledWith('# metrics body');
+  });
+
+  it('exposes the metrics on a configurable path.', async(): Promise<void> => {
+    handler = new MetricsHandler(metrics, '/internal/metrics');
+    await expect(handler.canHandle({ request: { method: 'GET', url: '/metrics' }} as any)).rejects
+      .toThrow('Only /internal/metrics is supported');
+    await expect(handler.canHandle({ request: { method: 'GET', url: '/internal/metrics' }} as any)).resolves
+      .toBeUndefined();
+  });
+});

--- a/test/unit/server/metrics/MetricsServerConfigurator.test.ts
+++ b/test/unit/server/metrics/MetricsServerConfigurator.test.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from 'node:events';
+import type { Server } from 'node:http';
+import type { Logger } from '../../../../src/logging/Logger';
+import { getLoggerFor } from '../../../../src/logging/LogUtil';
+import { MetricsServerConfigurator } from '../../../../src/server/metrics/MetricsServerConfigurator';
+import type { PrometheusMetrics } from '../../../../src/server/metrics/PrometheusMetrics';
+
+jest.mock('../../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { error: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+
+describe('A MetricsServerConfigurator', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
+  let server: Server;
+  let request: any;
+  let response: any;
+  let stopTimer: jest.Mock;
+  let metrics: jest.Mocked<PrometheusMetrics>;
+  let configurator: MetricsServerConfigurator;
+
+  beforeEach(async(): Promise<void> => {
+    jest.clearAllMocks();
+
+    server = new EventEmitter() as any;
+
+    request = { method: 'GET', url: '/foo' };
+
+    response = Object.assign(new EventEmitter(), {
+      statusCode: 200,
+      write: jest.fn(),
+      writeHead: jest.fn(),
+      end: jest.fn(),
+      setHeader: jest.fn(),
+    });
+
+    stopTimer = jest.fn();
+    metrics = {
+      requestDuration: { startTimer: jest.fn().mockReturnValue(stopTimer) },
+      requestsTotal: { inc: jest.fn() },
+    } as any;
+
+    configurator = new MetricsServerConfigurator(metrics);
+    await configurator.handle(server);
+  });
+
+  it('starts a timer per request but only records once the response finishes.', (): void => {
+    server.emit('request', request, response);
+    expect(metrics.requestDuration.startTimer).toHaveBeenCalledTimes(1);
+    expect(metrics.requestsTotal.inc).toHaveBeenCalledTimes(0);
+
+    response.emit('finish');
+    expect(metrics.requestsTotal.inc).toHaveBeenCalledTimes(1);
+    expect(metrics.requestsTotal.inc).toHaveBeenLastCalledWith({ method: 'GET', code: 200 });
+    expect(stopTimer).toHaveBeenCalledTimes(1);
+    expect(stopTimer).toHaveBeenLastCalledWith({ method: 'GET', code: 200 });
+  });
+
+  it('never writes to the response.', (): void => {
+    server.emit('request', request, response);
+    response.emit('finish');
+    expect(response.write).toHaveBeenCalledTimes(0);
+    expect(response.writeHead).toHaveBeenCalledTimes(0);
+    expect(response.end).toHaveBeenCalledTimes(0);
+    expect(response.setHeader).toHaveBeenCalledTimes(0);
+  });
+
+  it('uses a placeholder label when the request method is undefined.', (): void => {
+    request.method = undefined;
+    server.emit('request', request, response);
+    response.emit('finish');
+    expect(metrics.requestsTotal.inc).toHaveBeenLastCalledWith({ method: 'UNKNOWN', code: 200 });
+  });
+
+  it('does not throw or break the request flow when recording fails.', (): void => {
+    metrics.requestsTotal.inc.mockImplementation((): never => {
+      throw new Error('boom');
+    });
+    server.emit('request', request, response);
+    expect((): boolean => response.emit('finish')).not.toThrow();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith(expect.stringContaining('Unable to record request metrics'));
+  });
+
+  it('does not throw when the timer cannot be started.', (): void => {
+    metrics.requestDuration.startTimer.mockImplementation((): never => {
+      throw new Error('no timer');
+    });
+    expect((): void => {
+      server.emit('request', request, response);
+    }).not.toThrow();
+    expect(metrics.requestsTotal.inc).toHaveBeenCalledTimes(0);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith(expect.stringContaining('Unable to instrument request for metrics'));
+  });
+});

--- a/test/unit/server/metrics/PrometheusMetrics.test.ts
+++ b/test/unit/server/metrics/PrometheusMetrics.test.ts
@@ -1,0 +1,48 @@
+import { PrometheusMetrics } from '../../../../src/server/metrics/PrometheusMetrics';
+
+describe('A PrometheusMetrics', (): void => {
+  let metrics: PrometheusMetrics;
+
+  beforeEach((): void => {
+    metrics = new PrometheusMetrics();
+  });
+
+  afterEach((): void => {
+    metrics.registry.clear();
+  });
+
+  it('creates a registry using the Prometheus content type.', (): void => {
+    expect(metrics.registry.contentType).toContain('text/plain');
+  });
+
+  it('collects the default process metrics on its registry.', async(): Promise<void> => {
+    // `process_start_time_seconds` is one of the metrics registered by `collectDefaultMetrics`.
+    expect(metrics.registry.getSingleMetric('process_start_time_seconds')).toBeDefined();
+    await expect(metrics.registry.metrics()).resolves.toContain('process_cpu_user_seconds_total');
+  });
+
+  it('creates an http_requests_total counter labelled by method and code.', async(): Promise<void> => {
+    expect(metrics.registry.getSingleMetric('http_requests_total')).toBeDefined();
+
+    metrics.requestsTotal.inc({ method: 'GET', code: 200 });
+
+    const json = await metrics.registry.getMetricsAsJSON();
+    const counter = json.find((metric): boolean => metric.name === 'http_requests_total');
+    expect(counter?.type).toBe('counter');
+    expect(counter?.values).toContainEqual(
+      expect.objectContaining({ value: 1, labels: { method: 'GET', code: 200 }}),
+    );
+  });
+
+  it('creates an http_request_duration_seconds histogram labelled by method and code.', async(): Promise<void> => {
+    expect(metrics.registry.getSingleMetric('http_request_duration_seconds')).toBeDefined();
+
+    metrics.requestDuration.observe({ method: 'POST', code: 500 }, 0.25);
+
+    const json = await metrics.registry.getMetricsAsJSON();
+    const histogram = json.find((metric): boolean => metric.name === 'http_request_duration_seconds');
+    expect(histogram?.type).toBe('histogram');
+    expect(histogram?.values.some((value): boolean =>
+      value.labels.method === 'POST' && value.labels.code === 500)).toBe(true);
+  });
+});

--- a/test/unit/server/metrics/PrometheusMetrics.test.ts
+++ b/test/unit/server/metrics/PrometheusMetrics.test.ts
@@ -45,4 +45,17 @@ describe('A PrometheusMetrics', (): void => {
     expect(histogram?.values.some((value): boolean =>
       value.labels.method === 'POST' && value.labels.code === 500)).toBe(true);
   });
+
+  it('creates a css_notification_deliveries_total counter labelled by type and outcome.', async(): Promise<void> => {
+    expect(metrics.registry.getSingleMetric('css_notification_deliveries_total')).toBeDefined();
+
+    metrics.notificationDeliveriesTotal.inc({ type: 'WebhookChannel2023', outcome: 'failure' });
+
+    const json = await metrics.registry.getMetricsAsJSON();
+    const counter = json.find((metric): boolean => metric.name === 'css_notification_deliveries_total');
+    expect(counter?.type).toBe('counter');
+    expect(counter?.values).toContainEqual(
+      expect.objectContaining({ value: 1, labels: { type: 'WebhookChannel2023', outcome: 'failure' }}),
+    );
+  });
 });

--- a/test/unit/server/notifications/ListeningActivityHandler.test.ts
+++ b/test/unit/server/notifications/ListeningActivityHandler.test.ts
@@ -14,7 +14,7 @@ import { AS } from '../../../../src/util/Vocabularies';
 import { flushPromises } from '../../../util/Util';
 
 jest.mock('../../../../src/logging/LogUtil', (): any => {
-  const logger: Logger = { error: jest.fn() } as any;
+  const logger: Logger = { error: jest.fn(), debug: jest.fn() } as any;
   return { getLoggerFor: (): Logger => logger };
 });
 
@@ -27,6 +27,7 @@ describe('A ListeningActivityHandler', (): void => {
   let storage: jest.Mocked<NotificationChannelStorage>;
   let emitter: ActivityEmitter;
   let notificationHandler: jest.Mocked<NotificationHandler>;
+  let metrics: { notificationDeliveriesTotal: { inc: jest.Mock }};
 
   beforeEach(async(): Promise<void> => {
     jest.clearAllMocks();
@@ -48,8 +49,10 @@ describe('A ListeningActivityHandler', (): void => {
       handleSafe: jest.fn().mockResolvedValue(undefined),
     } as any;
 
+    metrics = { notificationDeliveriesTotal: { inc: jest.fn() }};
+
     // eslint-disable-next-line no-new
-    new ListeningActivityHandler(storage, emitter, notificationHandler);
+    new ListeningActivityHandler(storage, emitter, notificationHandler, metrics as any);
   });
 
   it('calls the NotificationHandler if there is an event.', async(): Promise<void> => {
@@ -104,7 +107,17 @@ describe('A ListeningActivityHandler', (): void => {
     expect(logger.error).toHaveBeenCalledTimes(0);
   });
 
-  it('does not stop if one channel causes an error.', async(): Promise<void> => {
+  it('records a successful delivery on the metrics counter.', async(): Promise<void> => {
+    emitter.emit('changed', topic, activity, metadata);
+
+    await flushPromises();
+
+    expect(metrics.notificationDeliveriesTotal.inc).toHaveBeenCalledTimes(1);
+    expect(metrics.notificationDeliveriesTotal.inc)
+      .toHaveBeenLastCalledWith({ type: channel.type, outcome: 'success' });
+  });
+
+  it('does not stop and records a failure if one channel errors.', async(): Promise<void> => {
     storage.getAll.mockResolvedValue([ channel.id, channel.id ]);
     notificationHandler.handleSafe.mockRejectedValueOnce(new Error('bad input'));
 
@@ -113,8 +126,28 @@ describe('A ListeningActivityHandler', (): void => {
     await flushPromises();
 
     expect(notificationHandler.handleSafe).toHaveBeenCalledTimes(2);
-    expect(logger.error).toHaveBeenCalledTimes(1);
-    expect(logger.error).toHaveBeenLastCalledWith(`Error trying to handle notification for ${channel.id}: bad input`);
+    expect(logger.error).toHaveBeenCalledTimes(0);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenLastCalledWith(`Error trying to handle notification for ${channel.id}: bad input`);
+    expect(metrics.notificationDeliveriesTotal.inc).toHaveBeenCalledTimes(2);
+    expect(metrics.notificationDeliveriesTotal.inc).toHaveBeenCalledWith({ type: channel.type, outcome: 'failure' });
+    expect(metrics.notificationDeliveriesTotal.inc).toHaveBeenCalledWith({ type: channel.type, outcome: 'success' });
+  });
+
+  it('works without a PrometheusMetrics instance.', async(): Promise<void> => {
+    const otherEmitter = new EventEmitter() as any;
+    storage.getAll.mockResolvedValue([ channel.id, channel.id ]);
+    notificationHandler.handleSafe.mockRejectedValueOnce(new Error('bad input'));
+    // eslint-disable-next-line no-new
+    new ListeningActivityHandler(storage, otherEmitter, notificationHandler);
+
+    otherEmitter.emit('changed', topic, activity, metadata);
+
+    await flushPromises();
+
+    expect(notificationHandler.handleSafe).toHaveBeenCalledTimes(2);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(metrics.notificationDeliveriesTotal.inc).toHaveBeenCalledTimes(0);
   });
 
   it('logs an error if something goes wrong handling the event.', async(): Promise<void> => {

--- a/test/unit/server/notifications/WebHookChannel2023/WebhookEmitter.test.ts
+++ b/test/unit/server/notifications/WebHookChannel2023/WebhookEmitter.test.ts
@@ -52,6 +52,7 @@ describe('A WebhookEmitter', (): void => {
   let privateJwk: AlgJwk;
   let publicJwk: AlgJwk;
   let jwkGenerator: jest.Mocked<JwkGenerator>;
+  let metrics: { notificationDeliveriesTotal: { inc: jest.Mock }};
   let emitter: WebhookEmitter;
 
   beforeEach(async(): Promise<void> => {
@@ -70,7 +71,9 @@ describe('A WebhookEmitter', (): void => {
       getPublicKey: jest.fn().mockResolvedValue(publicJwk),
     };
 
-    emitter = new WebhookEmitter(baseUrl, webIdRoute, jwkGenerator);
+    metrics = { notificationDeliveriesTotal: { inc: jest.fn() }};
+
+    emitter = new WebhookEmitter(baseUrl, webIdRoute, jwkGenerator, 20, metrics as any);
   });
 
   it('errors if the channel type is wrong.', async(): Promise<void> => {
@@ -134,16 +137,39 @@ describe('A WebhookEmitter', (): void => {
     jest.useRealTimers();
   });
 
-  it('logs an error if the fetch request receives an invalid status code.', async(): Promise<void> => {
+  it('records a successful delivery on the metrics counter.', async(): Promise<void> => {
+    await expect(emitter.handle({ channel, representation })).resolves.toBeUndefined();
+
+    expect(metrics.notificationDeliveriesTotal.inc).toHaveBeenCalledTimes(1);
+    expect(metrics.notificationDeliveriesTotal.inc)
+      .toHaveBeenLastCalledWith({ type: channel.type, outcome: 'success' });
+  });
+
+  it('logs at debug and records a failure on an invalid status code.', async(): Promise<void> => {
     const logger = getLoggerFor('mock');
     representation = new BasicRepresentation(JSON.stringify(notification), {});
 
     fetchMock.mockResolvedValue({ status: 400, text: async(): Promise<string> => 'invalid request' });
     await expect(emitter.handle({ channel, representation })).resolves.toBeUndefined();
 
-    expect(logger.error).toHaveBeenCalledTimes(1);
-    expect(logger.error).toHaveBeenLastCalledWith(
+    expect(logger.error).toHaveBeenCalledTimes(0);
+    expect(logger.debug).toHaveBeenLastCalledWith(
       `There was an issue emitting a Webhook notification with target ${channel.sendTo}: invalid request`,
     );
+    expect(metrics.notificationDeliveriesTotal.inc).toHaveBeenCalledTimes(1);
+    expect(metrics.notificationDeliveriesTotal.inc)
+      .toHaveBeenLastCalledWith({ type: channel.type, outcome: 'failure' });
+  });
+
+  it('works without a PrometheusMetrics instance.', async(): Promise<void> => {
+    emitter = new WebhookEmitter(baseUrl, webIdRoute, jwkGenerator);
+
+    await expect(emitter.handle({ channel, representation })).resolves.toBeUndefined();
+
+    const failRepresentation = new BasicRepresentation(JSON.stringify(notification), 'application/ld+json');
+    fetchMock.mockResolvedValue({ status: 400, text: async(): Promise<string> => 'invalid request' });
+    await expect(emitter.handle({ channel, representation: failRepresentation })).resolves.toBeUndefined();
+
+    expect(metrics.notificationDeliveriesTotal.inc).toHaveBeenCalledTimes(0);
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

> **Stacks on #62** (`feat/prometheus-metrics`, the opt-in `/metrics` endpoint and `PrometheusMetrics` registry). This branch is based on that one, so review/merge it first; the diff here is only the notification-delivery metric on top of it.

#### 📁 Related issues

None yet — before this is submitted upstream, an issue describing the problem below must be opened on CommunitySolidServer (the upstream PR template requires one).

#### ✍️ Description

Notification delivery failures are currently only observable as per-channel `error` log lines that interpolate attacker-controlled content: `WebhookEmitter` logs the channel's target URL and the remote response body for every `>= 400` webhook response, and `ListeningActivityHandler` logs every per-channel handler failure with the channel id. These lines cannot be aggregated into a delivery-failure *rate* to alert on, and they are a log-forging/log-injection vector, since the URL and response body are controlled by whoever created the channel.

This PR makes the failure rate observable as a metric and demotes the noisy lines:

1. A new `css_notification_deliveries_total{type, outcome}` counter on the `PrometheusMetrics` registry from #62. `type` is the notification channel type IRI; `outcome` is `success` or `failure`. The target URL, channel id, and remote address are deliberately never used as labels: they are unbounded and attacker-influenced, so labelling on them would explode the time-series database and re-introduce the forging vector — the same reasoning as #62 labelling `http_requests_total` by `method`/`code` only, never the request path.
1. Both delivery outcome points increment it: `ListeningActivityHandler` when the per-channel handler pipeline resolves or rejects (covers all channel types end-to-end), and `WebhookEmitter` on the webhook HTTP outcome (`< 400` / `>= 400`) — that HTTP outcome never propagates as an error, so it is invisible to the handler-level increment, hence both points.
1. The two per-channel failure logs move from `error` to `debug`: the aggregate rate now lives in the metric, while the detailed, attacker-influenced line stays available for local troubleshooting. The systemic top-level `Something went wrong emitting notifications` log stays at `error`.

Both components take an **optional** `PrometheusMetrics` constructor argument (default `undefined`; the increments no-op via optional chaining), so behaviour without the opt-in metrics config is unchanged. `config/util/metrics/default.json` injects it through two `Override` blocks that add only the `metrics` parameter and leave all other constructor parameters untouched (standard Components.js `Override` semantics). Those blocks assume notification delivery is enabled (the default); since an `Override` errors when its target is absent, the config comments tell users of `config/http/notifications/disabled.json` to remove them.

Delivery semantics are byte-identical: no change to retries, error propagation, ordering, or whether/how a notification is delivered. Unit tests cover the increments and exact labels on success and failure paths, the demoted log level, and the no-metrics branch; the touched files retain 100% coverage. A boot smoke test with `-c config/default.json -c config/util/metrics/default.json` served `GET /metrics` with the counter's `# HELP`/`# TYPE` lines registered (labelled series appear on the first delivery attempt, as expected for a labelled counter).

**Intended upstream target and semver.** This is a feature (a new metric, optional constructor arguments on two classes, a config change), so upstream it should target the latest `versions/*` branch (`versions/next-major`), not `main` — it sits on this fork's `main`-based #62 stack only for review convenience. Intended semver level: **minor** (backwards-compatible addition; contributors cannot set the semver labels).

Note: #78 (`MetricsSaturationCollector`) also edits `config/util/metrics/default.json`; if both land, expect a trivial, non-semantic merge in that file's `@graph` list. No source-level overlap.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
