### PR TITLE
feat: Add a heartbeat for WebSocket notification connections

### DIFF
--- a/config/http/notifications/websockets/http.json
+++ b/config/http/notifications/websockets/http.json
@@ -35,11 +35,11 @@
       "storage": { "@id": "urn:solid-server:default:SubscriptionStorage" }
     },
     {
-      "comment": "Makes sure the WebSocket2023Storer cleanup and heartbeat timers are stopped when the server stops.",
       "@id": "urn:solid-server:default:Finalizer",
       "@type": "ParallelHandler",
       "handlers": [
         {
+          "comment": "Makes sure the WebSocket2023Storer timers are stopped when the application stops.",
           "@type": "FinalizableHandler",
           "finalizable": { "@id": "urn:solid-server:default:WebSocket2023Storer" }
         }

--- a/config/http/notifications/websockets/http.json
+++ b/config/http/notifications/websockets/http.json
@@ -34,6 +34,17 @@
       "handler": { "@id": "urn:solid-server:default:WebSocket2023NotificationHandler" },
       "storage": { "@id": "urn:solid-server:default:SubscriptionStorage" }
     },
+    {
+      "comment": "Makes sure the WebSocket2023Storer cleanup and heartbeat timers are stopped when the server stops.",
+      "@id": "urn:solid-server:default:Finalizer",
+      "@type": "ParallelHandler",
+      "handlers": [
+        {
+          "@type": "FinalizableHandler",
+          "finalizable": { "@id": "urn:solid-server:default:WebSocket2023Storer" }
+        }
+      ]
+    },
 
     {
       "@id": "urn:solid-server:default:WebSocketHandler",

--- a/src/server/notifications/WebSocketChannel2023/WebSocket2023Storer.ts
+++ b/src/server/notifications/WebSocketChannel2023/WebSocket2023Storer.ts
@@ -16,17 +16,9 @@ import { WebSocket2023Handler } from './WebSocket2023Handler';
  * Defaults to 60 minutes.
  * Open WebSockets will not receive notifications if their channel expired.
  *
- * `heartbeatInterval` defines in seconds how often a WebSocket ping/pong heartbeat is sent
- * to every tracked WebSocket to detect and reap half-open (dead) connections.
- * A client killed by a NAT/idle timeout, a laptop going to sleep, or a network drop never sends a
- * `close` frame, so without a heartbeat such a socket would linger in the map forever.
- * The heartbeat pings every tracked socket; a socket that has not answered with a `pong`
- * since the previous cycle is assumed dead and gets `terminate()`d
- * (which also removes it from the map through the attached `close` listener).
- * Ping/pong are RFC 6455 control frames handled automatically by conformant WebSocket clients,
- * so a healthy client is never affected: it auto-pongs and is kept.
- * Defaults to `0`, which **disables** the heartbeat entirely, preserving the previous behaviour.
- * A value such as `30` (seconds) is recommended to enable dead-connection reaping.
+ * `heartbeatInterval` defines in seconds how often the stored WebSockets are pinged
+ * to detect and terminate half-open connections that no longer answer with a pong.
+ * Defaults to 0, which disables the heartbeat.
  */
 export class WebSocket2023Storer extends WebSocket2023Handler implements Finalizable {
   protected readonly logger = getLoggerFor(this);
@@ -58,7 +50,6 @@ export class WebSocket2023Storer extends WebSocket2023Handler implements Finaliz
     );
     this.cleanupTimer.unref();
 
-    // A `heartbeatInterval` of `0` (the default) disables the heartbeat, keeping the previous behaviour.
     if (heartbeatInterval > 0) {
       this.heartbeatTimer = setSafeInterval(
         this.logger,
@@ -73,7 +64,7 @@ export class WebSocket2023Storer extends WebSocket2023Handler implements Finaliz
   public async handle({ webSocket, channel }: WebSocket2023HandlerInput): Promise<void> {
     this.socketMap.add(channel.id, webSocket);
     if (this.heartbeatInterval > 0) {
-      // A newly opened socket starts out alive; conformant clients answer every ping with a `pong`.
+      // A new socket counts as alive until it misses a ping
       this.aliveSockets.add(webSocket);
       webSocket.on('pong', (): void => {
         this.aliveSockets.add(webSocket);
@@ -110,30 +101,24 @@ export class WebSocket2023Storer extends WebSocket2023Handler implements Finaliz
   }
 
   /**
-   * Ping every tracked WebSocket and reap the ones that did not answer the previous ping with a `pong`.
-   * A missed pong indicates a half-open (dead) connection, so it is `terminate()`d;
-   * the attached `close` listener then removes it from the `socketMap`.
+   * Ping every stored WebSocket and terminate those that did not answer the previous ping with a pong.
+   * Terminated sockets get removed from the map by their attached `close` listener.
    */
   private sendHeartbeat(): void {
     this.logger.debug('Sending WebSocket heartbeat pings');
-    // Snapshot the sockets first: `terminate()` schedules a `close` event that mutates the `socketMap`.
+    // Iterate over a snapshot as terminating a socket mutates the map through its `close` listener
     for (const socket of new Set(this.socketMap.values())) {
       if (this.aliveSockets.has(socket)) {
-        // Answered the previous ping (or was just opened): mark it pending again and ping.
+        // Removing the socket marks it as pending until its pong re-adds it
         this.aliveSockets.delete(socket);
         socket.ping();
       } else {
-        // No pong since the previous cycle: assume the connection is dead and reap it.
         socket.terminate();
       }
     }
     this.logger.debug('Finished sending WebSocket heartbeat pings');
   }
 
-  /**
-   * Stops the cleanup and heartbeat timers so they no longer keep the event loop alive
-   * or fire during/after a graceful shutdown.
-   */
   public async finalize(): Promise<void> {
     clearInterval(this.cleanupTimer);
     if (this.heartbeatTimer) {

--- a/src/server/notifications/WebSocketChannel2023/WebSocket2023Storer.ts
+++ b/src/server/notifications/WebSocketChannel2023/WebSocket2023Storer.ts
@@ -1,4 +1,5 @@
 import type { WebSocket } from 'ws';
+import type { Finalizable } from '../../../init/final/Finalizable';
 import { getLoggerFor } from '../../../logging/LogUtil';
 import type { SetMultiMap } from '../../../util/map/SetMultiMap';
 import { setSafeInterval } from '../../../util/TimerUtil';
@@ -14,35 +15,80 @@ import { WebSocket2023Handler } from './WebSocket2023Handler';
  * if their corresponding channel has expired.
  * Defaults to 60 minutes.
  * Open WebSockets will not receive notifications if their channel expired.
+ *
+ * `heartbeatInterval` defines in seconds how often a WebSocket ping/pong heartbeat is sent
+ * to every tracked WebSocket to detect and reap half-open (dead) connections.
+ * A client killed by a NAT/idle timeout, a laptop going to sleep, or a network drop never sends a
+ * `close` frame, so without a heartbeat such a socket would linger in the map forever.
+ * The heartbeat pings every tracked socket; a socket that has not answered with a `pong`
+ * since the previous cycle is assumed dead and gets `terminate()`d
+ * (which also removes it from the map through the attached `close` listener).
+ * Ping/pong are RFC 6455 control frames handled automatically by conformant WebSocket clients,
+ * so a healthy client is never affected: it auto-pongs and is kept.
+ * Defaults to `0`, which **disables** the heartbeat entirely, preserving the previous behaviour.
+ * A value such as `30` (seconds) is recommended to enable dead-connection reaping.
  */
-export class WebSocket2023Storer extends WebSocket2023Handler {
+export class WebSocket2023Storer extends WebSocket2023Handler implements Finalizable {
   protected readonly logger = getLoggerFor(this);
 
   private readonly storage: NotificationChannelStorage;
   private readonly socketMap: SetMultiMap<string, WebSocket>;
+  private readonly heartbeatInterval: number;
+  private readonly aliveSockets: Set<WebSocket>;
+  private readonly cleanupTimer: NodeJS.Timeout;
+  private readonly heartbeatTimer?: NodeJS.Timeout;
 
   public constructor(
     storage: NotificationChannelStorage,
     socketMap: SetMultiMap<string, WebSocket>,
     cleanupTimer = 60,
+    heartbeatInterval = 0,
   ) {
     super();
     this.socketMap = socketMap;
     this.storage = storage;
+    this.heartbeatInterval = heartbeatInterval;
+    this.aliveSockets = new Set<WebSocket>();
 
-    const timer = setSafeInterval(
+    this.cleanupTimer = setSafeInterval(
       this.logger,
       'Failed to remove closed WebSockets',
       this.closeExpiredSockets.bind(this),
       cleanupTimer * 60 * 1000,
     );
-    timer.unref();
+    this.cleanupTimer.unref();
+
+    // A `heartbeatInterval` of `0` (the default) disables the heartbeat, keeping the previous behaviour.
+    if (heartbeatInterval > 0) {
+      this.heartbeatTimer = setSafeInterval(
+        this.logger,
+        'Failed to send WebSocket heartbeat',
+        this.sendHeartbeat.bind(this),
+        heartbeatInterval * 1000,
+      );
+      this.heartbeatTimer.unref();
+    }
   }
 
   public async handle({ webSocket, channel }: WebSocket2023HandlerInput): Promise<void> {
     this.socketMap.add(channel.id, webSocket);
-    webSocket.on('error', (): boolean => this.socketMap.deleteEntry(channel.id, webSocket));
-    webSocket.on('close', (): boolean => this.socketMap.deleteEntry(channel.id, webSocket));
+    if (this.heartbeatInterval > 0) {
+      // A newly opened socket starts out alive; conformant clients answer every ping with a `pong`.
+      this.aliveSockets.add(webSocket);
+      webSocket.on('pong', (): void => {
+        this.aliveSockets.add(webSocket);
+      });
+    }
+    webSocket.on('error', (): void => this.removeSocket(channel.id, webSocket));
+    webSocket.on('close', (): void => this.removeSocket(channel.id, webSocket));
+  }
+
+  /**
+   * Removes a WebSocket from all tracking structures.
+   */
+  private removeSocket(id: string, webSocket: WebSocket): void {
+    this.aliveSockets.delete(webSocket);
+    this.socketMap.deleteEntry(id, webSocket);
   }
 
   /**
@@ -61,5 +107,37 @@ export class WebSocket2023Storer extends WebSocket2023Handler {
       }
     }
     this.logger.debug('Finished closing expired WebSockets');
+  }
+
+  /**
+   * Ping every tracked WebSocket and reap the ones that did not answer the previous ping with a `pong`.
+   * A missed pong indicates a half-open (dead) connection, so it is `terminate()`d;
+   * the attached `close` listener then removes it from the `socketMap`.
+   */
+  private sendHeartbeat(): void {
+    this.logger.debug('Sending WebSocket heartbeat pings');
+    // Snapshot the sockets first: `terminate()` schedules a `close` event that mutates the `socketMap`.
+    for (const socket of new Set(this.socketMap.values())) {
+      if (this.aliveSockets.has(socket)) {
+        // Answered the previous ping (or was just opened): mark it pending again and ping.
+        this.aliveSockets.delete(socket);
+        socket.ping();
+      } else {
+        // No pong since the previous cycle: assume the connection is dead and reap it.
+        socket.terminate();
+      }
+    }
+    this.logger.debug('Finished sending WebSocket heartbeat pings');
+  }
+
+  /**
+   * Stops the cleanup and heartbeat timers so they no longer keep the event loop alive
+   * or fire during/after a graceful shutdown.
+   */
+  public async finalize(): Promise<void> {
+    clearInterval(this.cleanupTimer);
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+    }
   }
 }

--- a/test/unit/server/notifications/WebSocketChannel2023/WebSocket2023Storer.test.ts
+++ b/test/unit/server/notifications/WebSocketChannel2023/WebSocket2023Storer.test.ts
@@ -102,12 +102,10 @@ describe('A WebSocket2023Storer', (): void => {
   describe('with the heartbeat disabled (the default)', (): void => {
     it('never pings or terminates tracked sockets.', async(): Promise<void> => {
       jest.useFakeTimers();
-      // The default `heartbeatInterval` of `0` disables the heartbeat.
       storer = new WebSocket2023Storer(storage, socketMap);
 
       await expect(storer.handle({ channel, webSocket })).resolves.toBeUndefined();
 
-      // Advance well past any interval; only the cleanup timer should ever fire.
       jest.advanceTimersByTime(60 * 60 * 1000);
       await flushPromises();
 
@@ -130,7 +128,6 @@ describe('A WebSocket2023Storer', (): void => {
   describe('with the heartbeat enabled', (): void => {
     beforeEach((): void => {
       jest.useFakeTimers();
-      // 60 min cleanup timer, 30 s heartbeat.
       storer = new WebSocket2023Storer(storage, socketMap, 60, 30);
     });
 
@@ -151,15 +148,12 @@ describe('A WebSocket2023Storer', (): void => {
     it('keeps sockets that answer with a pong.', async(): Promise<void> => {
       await expect(storer.handle({ channel, webSocket })).resolves.toBeUndefined();
 
-      // First cycle: socket is pinged.
       jest.advanceTimersByTime(30 * 1000);
       await flushPromises();
       expect(webSocket.ping).toHaveBeenCalledTimes(1);
 
-      // Healthy client answers with a pong.
       webSocket.emit('pong');
 
-      // Second cycle: socket is still alive, so it is pinged again and never terminated.
       jest.advanceTimersByTime(30 * 1000);
       await flushPromises();
       expect(webSocket.ping).toHaveBeenCalledTimes(2);
@@ -169,19 +163,17 @@ describe('A WebSocket2023Storer', (): void => {
     it('terminates sockets that miss a pong.', async(): Promise<void> => {
       await expect(storer.handle({ channel, webSocket })).resolves.toBeUndefined();
 
-      // First cycle: socket is pinged but does not pong.
       jest.advanceTimersByTime(30 * 1000);
       await flushPromises();
       expect(webSocket.ping).toHaveBeenCalledTimes(1);
       expect(webSocket.terminate).toHaveBeenCalledTimes(0);
 
-      // Second cycle: no pong was received, so the socket is terminated.
       jest.advanceTimersByTime(30 * 1000);
       await flushPromises();
       expect(webSocket.ping).toHaveBeenCalledTimes(1);
       expect(webSocket.terminate).toHaveBeenCalledTimes(1);
 
-      // A real terminate() emits `close`, which removes the socket from the map.
+      // The mocked `terminate` does not emit the `close` event a real socket would
       webSocket.emit('close');
       expect(socketMap.has(channel.id)).toBe(false);
     });
@@ -203,7 +195,7 @@ describe('A WebSocket2023Storer', (): void => {
 
       await expect(storer.finalize()).resolves.toBeUndefined();
 
-      // No timer fires after finalization: neither heartbeat nor cleanup runs.
+      // Neither the heartbeat nor the cleanup timer fires after finalization
       jest.advanceTimersByTime(60 * 60 * 1000);
       await flushPromises();
 

--- a/test/unit/server/notifications/WebSocketChannel2023/WebSocket2023Storer.test.ts
+++ b/test/unit/server/notifications/WebSocketChannel2023/WebSocket2023Storer.test.ts
@@ -24,10 +24,17 @@ describe('A WebSocket2023Storer', (): void => {
   let socketMap: SetMultiMap<string, WebSocket>;
   let storer: WebSocket2023Storer;
 
+  function createWebSocket(): jest.Mocked<WebSocket> {
+    const socket = new EventEmitter() as any;
+    socket.send = jest.fn();
+    socket.close = jest.fn();
+    socket.ping = jest.fn();
+    socket.terminate = jest.fn();
+    return socket;
+  }
+
   beforeEach(async(): Promise<void> => {
-    webSocket = new EventEmitter() as any;
-    webSocket.send = jest.fn();
-    webSocket.close = jest.fn();
+    webSocket = createWebSocket();
 
     storage = {
       get: jest.fn(),
@@ -64,12 +71,8 @@ describe('A WebSocket2023Storer', (): void => {
     // Need to create class after fake timers have been enabled
     storer = new WebSocket2023Storer(storage, socketMap);
 
-    const webSocket2: jest.Mocked<WebSocket> = new EventEmitter() as any;
-    webSocket2.send = jest.fn();
-    webSocket2.close = jest.fn();
-    const webSocketOther: jest.Mocked<WebSocket> = new EventEmitter() as any;
-    webSocketOther.send = jest.fn();
-    webSocketOther.close = jest.fn();
+    const webSocket2: jest.Mocked<WebSocket> = createWebSocket();
+    const webSocketOther: jest.Mocked<WebSocket> = createWebSocket();
     const channelOther: NotificationChannel = {
       ...channel,
       id: 'other',
@@ -94,5 +97,119 @@ describe('A WebSocket2023Storer', (): void => {
     expect(webSocketOther.close).toHaveBeenCalledTimes(0);
 
     jest.useRealTimers();
+  });
+
+  describe('with the heartbeat disabled (the default)', (): void => {
+    it('never pings or terminates tracked sockets.', async(): Promise<void> => {
+      jest.useFakeTimers();
+      // The default `heartbeatInterval` of `0` disables the heartbeat.
+      storer = new WebSocket2023Storer(storage, socketMap);
+
+      await expect(storer.handle({ channel, webSocket })).resolves.toBeUndefined();
+
+      // Advance well past any interval; only the cleanup timer should ever fire.
+      jest.advanceTimersByTime(60 * 60 * 1000);
+      await flushPromises();
+
+      expect(webSocket.ping).toHaveBeenCalledTimes(0);
+      expect(webSocket.terminate).toHaveBeenCalledTimes(0);
+
+      jest.useRealTimers();
+    });
+
+    it('does not attach a pong listener.', async(): Promise<void> => {
+      await expect(storer.handle({ channel, webSocket })).resolves.toBeUndefined();
+      expect(webSocket.listenerCount('pong')).toBe(0);
+    });
+
+    it('can be finalized without a heartbeat timer.', async(): Promise<void> => {
+      await expect(storer.finalize()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('with the heartbeat enabled', (): void => {
+    beforeEach((): void => {
+      jest.useFakeTimers();
+      // 60 min cleanup timer, 30 s heartbeat.
+      storer = new WebSocket2023Storer(storage, socketMap, 60, 30);
+    });
+
+    afterEach((): void => {
+      jest.useRealTimers();
+    });
+
+    it('pings every tracked socket.', async(): Promise<void> => {
+      await expect(storer.handle({ channel, webSocket })).resolves.toBeUndefined();
+
+      jest.advanceTimersByTime(30 * 1000);
+      await flushPromises();
+
+      expect(webSocket.ping).toHaveBeenCalledTimes(1);
+      expect(webSocket.terminate).toHaveBeenCalledTimes(0);
+    });
+
+    it('keeps sockets that answer with a pong.', async(): Promise<void> => {
+      await expect(storer.handle({ channel, webSocket })).resolves.toBeUndefined();
+
+      // First cycle: socket is pinged.
+      jest.advanceTimersByTime(30 * 1000);
+      await flushPromises();
+      expect(webSocket.ping).toHaveBeenCalledTimes(1);
+
+      // Healthy client answers with a pong.
+      webSocket.emit('pong');
+
+      // Second cycle: socket is still alive, so it is pinged again and never terminated.
+      jest.advanceTimersByTime(30 * 1000);
+      await flushPromises();
+      expect(webSocket.ping).toHaveBeenCalledTimes(2);
+      expect(webSocket.terminate).toHaveBeenCalledTimes(0);
+    });
+
+    it('terminates sockets that miss a pong.', async(): Promise<void> => {
+      await expect(storer.handle({ channel, webSocket })).resolves.toBeUndefined();
+
+      // First cycle: socket is pinged but does not pong.
+      jest.advanceTimersByTime(30 * 1000);
+      await flushPromises();
+      expect(webSocket.ping).toHaveBeenCalledTimes(1);
+      expect(webSocket.terminate).toHaveBeenCalledTimes(0);
+
+      // Second cycle: no pong was received, so the socket is terminated.
+      jest.advanceTimersByTime(30 * 1000);
+      await flushPromises();
+      expect(webSocket.ping).toHaveBeenCalledTimes(1);
+      expect(webSocket.terminate).toHaveBeenCalledTimes(1);
+
+      // A real terminate() emits `close`, which removes the socket from the map.
+      webSocket.emit('close');
+      expect(socketMap.has(channel.id)).toBe(false);
+    });
+
+    it('stops pinging once a socket has closed.', async(): Promise<void> => {
+      await expect(storer.handle({ channel, webSocket })).resolves.toBeUndefined();
+      webSocket.emit('close');
+      expect(socketMap.has(channel.id)).toBe(false);
+
+      jest.advanceTimersByTime(30 * 1000);
+      await flushPromises();
+
+      expect(webSocket.ping).toHaveBeenCalledTimes(0);
+      expect(webSocket.terminate).toHaveBeenCalledTimes(0);
+    });
+
+    it('clears the heartbeat timer when finalized.', async(): Promise<void> => {
+      await expect(storer.handle({ channel, webSocket })).resolves.toBeUndefined();
+
+      await expect(storer.finalize()).resolves.toBeUndefined();
+
+      // No timer fires after finalization: neither heartbeat nor cleanup runs.
+      jest.advanceTimersByTime(60 * 60 * 1000);
+      await flushPromises();
+
+      expect(webSocket.ping).toHaveBeenCalledTimes(0);
+      expect(webSocket.terminate).toHaveBeenCalledTimes(0);
+      expect(storage.get).toHaveBeenCalledTimes(0);
+    });
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an issue describing the half-open-connection leak needs to be opened on CommunitySolidServer before this is submitted upstream (the PR template requires one).

#### ✍️ Description

Sockets tracked in `WebSocketMap` are only removed by the `ws` `close`/`error` events. A half-open connection — a client dropped by a NAT idle timeout, a sleeping laptop, or a network failure — never fires either event, so its socket stays in the map forever: the map grows without bound, and every notification performs a doomed `send()` to each dead socket.

This adds an opt-in ping/pong heartbeat to `WebSocket2023Storer`. A new `heartbeatInterval` constructor parameter (in seconds) starts a timer that pings every stored socket; a socket that has not answered the previous ping with a pong is assumed dead and terminated, which removes it from the map through the already-attached `close` listener. Ping/pong are RFC 6455 control frames that conformant WebSocket clients answer automatically, so healthy clients are unaffected — only dead sockets are reaped. This was verified against a live client: it received the pings, auto-ponged, stayed open, and kept receiving notifications.

`heartbeatInterval` defaults to `0`, which disables the heartbeat; no shipped config sets it, so the default server behaves exactly as before. Enabling it (e.g. `"heartbeatInterval": 30` on `urn:solid-server:default:WebSocket2023Storer`) gives a worst-case dead-socket detection time of two intervals. Enabling it by default would be a behaviour change, so that decision is deliberately left to the maintainers.

`WebSocket2023Storer` now also implements `Finalizable` and clears both its cleanup and heartbeat timers in `finalize()`. It is registered with the default `Finalizer` in `config/http/notifications/websockets/http.json` (the same pattern as `RedisLocker` and `FileSystemResourceLocker`), so the timers are stopped on graceful shutdown.

The heartbeat lives in the storer because that is where the sockets are tracked; the upgrade path (`WebSocketServerConfigurator`) is untouched. New unit tests cover the disabled default (no pings sent, no pong listener attached), the ping/keep/terminate cycle, removal on close, and finalization with and without the heartbeat timer.

This is a backwards-compatible feature addition (a new optional constructor parameter), so the intended semver level is **minor** (stated in prose since contributors cannot set labels). As a feature it should target the latest `versions/*` branch (currently `versions/next-major`) when submitted upstream; it targets this fork's `main` only for the draft review.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
