### PR TITLE
perf: Add a reusable promise cache abstraction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -545,6 +545,10 @@ export * from './storage/ResourceSet';
 export * from './storage/ResourceStore';
 export * from './storage/RoutingResourceStore';
 
+// Util/Caching
+export * from './util/caching/CachedDecorator';
+export * from './util/caching/PromiseCache';
+
 // Util/Errors
 export * from './util/errors/BadRequestHttpError';
 export * from './util/errors/ConflictHttpError';

--- a/src/util/caching/CachedDecorator.ts
+++ b/src/util/caching/CachedDecorator.ts
@@ -1,0 +1,73 @@
+import type { PromiseCacheStore } from './PromiseCache';
+import { PromiseCache } from './PromiseCache';
+
+/**
+ * Options for the {@link cached} method decorator.
+ *
+ * @typeParam TThis - Type of the instance the decorated method belongs to.
+ * @typeParam TArgs - Argument tuple of the decorated method.
+ */
+export interface CachedOptions<TThis, TArgs extends unknown[]> {
+  /**
+   * Derives the cache key from the arguments of the decorated method.
+   * Defaults to using the first argument as key.
+   */
+  readonly key?: (this: TThis, ...args: TArgs) => unknown;
+  /**
+   * Whether to back the per-instance cache with a `WeakMap` instead of a `Map`.
+   * A `WeakMap` keys entries on object identity and lets them be garbage collected once the key is unreachable,
+   * which requires the cache key to be an object and is the memory-safe choice for request-scoped keys.
+   * Defaults to `false`, using a `Map` that caches for the lifetime of the instance.
+   */
+  readonly weak?: boolean;
+  /**
+   * Whether an entry whose promise rejects is evicted so the call is retried next time.
+   * Defaults to `true`.
+   */
+  readonly evictOnError?: boolean;
+}
+
+/**
+ * Method decorator that memoizes an asynchronous method with a {@link PromiseCache},
+ * making the widely repeated "look up a cached promise, otherwise compute and cache it" pattern
+ * a single, minimally invasive annotation.
+ *
+ * Each instance gets its own cache, so instances never share cached results.
+ * The returned promise is cached (not just its resolved value),
+ * so concurrent calls with the same key deduplicate onto a single in-flight computation.
+ *
+ * By default the first argument is used as cache key and entries live for the lifetime of the instance;
+ * use {@link CachedOptions.key} to derive the key differently
+ * and {@link CachedOptions.weak} to instead key entries on object identity in a `WeakMap`.
+ *
+ * @param options - {@link CachedOptions} controlling the key, backing store, and error eviction.
+ *
+ * @returns A decorator applying the described caching to the method.
+ *
+ * @typeParam TThis - Type of the instance the decorated method belongs to.
+ * @typeParam TArgs - Argument tuple of the decorated method.
+ * @typeParam TValue - Value the decorated method's promise resolves to.
+ */
+export function cached<TThis extends object, TArgs extends unknown[], TValue>(
+  options: CachedOptions<TThis, TArgs> = {},
+): (target: (this: TThis, ...args: TArgs) => Promise<TValue>) => (this: TThis, ...args: TArgs) => Promise<TValue> {
+  // One cache per instance, keyed on the instance itself so instances never share results.
+  const caches = new WeakMap<TThis, PromiseCache<unknown, TValue>>();
+
+  return (target: (this: TThis, ...args: TArgs) => Promise<TValue>):
+  (this: TThis, ...args: TArgs) => Promise<TValue> =>
+    async function(this: TThis, ...args: TArgs): Promise<TValue> {
+      let cache = caches.get(this);
+      if (!cache) {
+        // A WeakMap only accepts object keys, which the caller opts into via `weak`;
+        // the cast mirrors that the key type is only known to be an object at that call site.
+        const store = options.weak ?
+          new WeakMap<object, Promise<TValue>>() as unknown as PromiseCacheStore<unknown, Promise<TValue>> :
+          new Map<unknown, Promise<TValue>>();
+        cache = new PromiseCache<unknown, TValue>(store, { evictOnError: options.evictOnError });
+        caches.set(this, cache);
+      }
+      const key = options.key ? options.key.apply(this, args) : args[0];
+      return cache.getOrCreate(key, async(): Promise<TValue> => target.apply(this, args));
+    };
+}

--- a/src/util/caching/PromiseCache.ts
+++ b/src/util/caching/PromiseCache.ts
@@ -1,0 +1,85 @@
+/**
+ * The subset of the `Map`/`WeakMap` API that a {@link PromiseCache} uses to store its entries.
+ * Both `Map` and `WeakMap` structurally satisfy this interface,
+ * which lets a cache be backed by either of them:
+ * a `Map` keeps its entries for as long as the cache exists (process-lifetime caching of a bounded key space),
+ * while a `WeakMap` keyed on object identity lets entries be garbage collected
+ * once their key object becomes unreachable, avoiding unbounded growth.
+ */
+export interface PromiseCacheStore<TKey, TValue> {
+  get: (key: TKey) => TValue | undefined;
+  set: (key: TKey, value: TValue) => unknown;
+  delete: (key: TKey) => unknown;
+}
+
+/**
+ * Options for a {@link PromiseCache}.
+ */
+export interface PromiseCacheOptions {
+  /**
+   * Whether an entry whose promise rejects is removed from the cache as soon as it rejects,
+   * so the failed computation is retried on the next call instead of being remembered.
+   * Defaults to `true`.
+   */
+  readonly evictOnError?: boolean;
+}
+
+/**
+ * A small, reusable cache for asynchronous, keyed computations.
+ *
+ * The *promise* returned by the factory is cached rather than its resolved value,
+ * so concurrent callers requesting the same key share a single in-flight computation and deduplicate,
+ * instead of each starting their own.
+ *
+ * The cache is backed by an injected {@link PromiseCacheStore}, allowing the caller to pick the lifetime:
+ * a `Map` (the default) caches for the lifetime of this object, which suits a bounded set of keys,
+ * whereas a `WeakMap` keyed on object identity lets entries be collected once their key is unreachable,
+ * which suits keys scoped to, for example, a single request.
+ *
+ * By default an entry whose promise rejects is evicted (see {@link PromiseCacheOptions.evictOnError}),
+ * so transient failures are retried rather than cached.
+ */
+export class PromiseCache<TKey, TValue> {
+  private readonly store: PromiseCacheStore<TKey, Promise<TValue>>;
+  private readonly evictOnError: boolean;
+
+  /**
+   * @param store - Backing store for the cached promises. Defaults to a new `Map`, which caches
+   *                entries for the lifetime of this object. Pass a `WeakMap` to instead key entries
+   *                on object identity and let them be garbage collected once the key is unreachable.
+   * @param options - Additional {@link PromiseCacheOptions}.
+   */
+  public constructor(
+    store: PromiseCacheStore<TKey, Promise<TValue>> = new Map<TKey, Promise<TValue>>(),
+    options: PromiseCacheOptions = {},
+  ) {
+    this.store = store;
+    this.evictOnError = options.evictOnError ?? true;
+  }
+
+  /**
+   * Returns the cached promise for the given key,
+   * or, on a cache miss, creates a new promise with the provided factory, caches it, and returns it.
+   *
+   * @param key - Key to look up.
+   * @param createPromise - Factory generating the promise on a cache miss. It receives the key.
+   *
+   * @returns The cached or newly created promise.
+   */
+  public async getOrCreate(key: TKey, createPromise: (key: TKey) => Promise<TValue>): Promise<TValue> {
+    const cached = this.store.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const promise = createPromise(key);
+    this.store.set(key, promise);
+    if (this.evictOnError) {
+      // Evict a rejected entry so the failed computation is retried on the next call.
+      promise.catch((): void => {
+        this.store.delete(key);
+      });
+    }
+    return promise;
+  }
+}

--- a/test/unit/util/caching/CachedDecorator.test.ts
+++ b/test/unit/util/caching/CachedDecorator.test.ts
@@ -1,0 +1,115 @@
+import { cached } from '../../../../src/util/caching/CachedDecorator';
+
+describe('The cached decorator', (): void => {
+  it('caches a method result per instance based on the first argument.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Counter {
+      private count = 0;
+
+      @cached()
+      public async get(key: string): Promise<number> {
+        spy(key);
+        const value = this.count;
+        this.count += 1;
+        return value;
+      }
+    }
+    const instance = new Counter();
+    await expect(instance.get('a')).resolves.toBe(0);
+    await expect(instance.get('a')).resolves.toBe(0);
+    await expect(instance.get('b')).resolves.toBe(1);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(1, 'a');
+    expect(spy).toHaveBeenNthCalledWith(2, 'b');
+  });
+
+  it('gives each instance its own cache.', async(): Promise<void> => {
+    class Counter {
+      private count = 0;
+
+      @cached()
+      public async get(): Promise<number> {
+        const value = this.count;
+        this.count += 1;
+        return value;
+      }
+    }
+    const first = new Counter();
+    const second = new Counter();
+    await expect(first.get()).resolves.toBe(0);
+    await expect(second.get()).resolves.toBe(0);
+    await expect(first.get()).resolves.toBe(0);
+  });
+
+  it('can key a WeakMap-backed cache on object identity.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Store {
+      private count = 0;
+
+      @cached({ weak: true })
+      public async get(key: object): Promise<number> {
+        spy(key);
+        const value = this.count;
+        this.count += 1;
+        return value;
+      }
+    }
+    const store = new Store();
+    const key1 = {};
+    const key2 = {};
+    await expect(store.get(key1)).resolves.toBe(0);
+    await expect(store.get(key1)).resolves.toBe(0);
+    await expect(store.get(key2)).resolves.toBe(1);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('supports deriving the cache key from all arguments.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Store {
+      @cached({ key: (a: string, b: string): string => `${a}:${b}` })
+      public async get(a: string, b: string): Promise<string> {
+        spy();
+        return `${a}${b}`;
+      }
+    }
+    const store = new Store();
+    await expect(store.get('a', 'b')).resolves.toBe('ab');
+    await expect(store.get('a', 'b')).resolves.toBe('ab');
+    await expect(store.get('a', 'c')).resolves.toBe('ac');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates concurrent calls onto a single computation.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Store {
+      @cached()
+      public async get(key: string): Promise<string> {
+        spy();
+        return key;
+      }
+    }
+    const store = new Store();
+    const [ first, second ] = await Promise.all([ store.get('a'), store.get('a') ]);
+    expect(first).toBe('a');
+    expect(second).toBe('a');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries the method after a rejection by default.', async(): Promise<void> => {
+    let calls = 0;
+    class Store {
+      @cached()
+      public async get(key: string): Promise<number> {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error(`fail-${key}`);
+        }
+        return 5;
+      }
+    }
+    const store = new Store();
+    await expect(store.get('a')).rejects.toThrow('fail-a');
+    await expect(store.get('a')).resolves.toBe(5);
+    expect(calls).toBe(2);
+  });
+});

--- a/test/unit/util/caching/PromiseCache.test.ts
+++ b/test/unit/util/caching/PromiseCache.test.ts
@@ -1,0 +1,80 @@
+import { PromiseCache } from '../../../../src/util/caching/PromiseCache';
+
+describe('A PromiseCache', (): void => {
+  it('computes and caches a value on a miss and reuses it on a hit.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    const factory = jest.fn(async(): Promise<number> => 1);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(1);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(1);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the key to the factory.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, string>();
+    const factory = jest.fn(async(key: string): Promise<string> => `v:${key}`);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe('v:a');
+    expect(factory).toHaveBeenLastCalledWith('a');
+  });
+
+  it('caches separate values for separate keys.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    let count = 0;
+    const factory = jest.fn(async(): Promise<number> => {
+      const value = count;
+      count += 1;
+      return value;
+    });
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(0);
+    await expect(cache.getOrCreate('b', factory)).resolves.toBe(1);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(0);
+  });
+
+  it('deduplicates concurrent calls for the same key onto a single computation.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    const factory = jest.fn(async(): Promise<number> => 42);
+    const [ first, second ] = await Promise.all([ cache.getOrCreate('a', factory), cache.getOrCreate('a', factory) ]);
+    expect(first).toBe(42);
+    expect(second).toBe(42);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports a WeakMap backing store keyed on object identity.', async(): Promise<void> => {
+    const cache = new PromiseCache<object, number>(new WeakMap());
+    const key1 = {};
+    const key2 = {};
+    let count = 0;
+    const factory = jest.fn(async(): Promise<number> => {
+      const value = count;
+      count += 1;
+      return value;
+    });
+    await expect(cache.getOrCreate(key1, factory)).resolves.toBe(0);
+    await expect(cache.getOrCreate(key1, factory)).resolves.toBe(0);
+    await expect(cache.getOrCreate(key2, factory)).resolves.toBe(1);
+  });
+
+  it('evicts an entry whose promise rejects so it is retried.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    let calls = 0;
+    const factory = jest.fn(async(): Promise<number> => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error('fail');
+      }
+      return 5;
+    });
+    await expect(cache.getOrCreate('a', factory)).rejects.toThrow('fail');
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(5);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a rejected entry cached when evictOnError is disabled.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>(new Map(), { evictOnError: false });
+    const factory = jest.fn(async(): Promise<number> => {
+      throw new Error('fail');
+    });
+    await expect(cache.getOrCreate('a', factory)).rejects.toThrow('fail');
+    await expect(cache.getOrCreate('a', factory)).rejects.toThrow('fail');
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue describing the shared-caching need must be created before this is submitted to CommunitySolidServer (the PR template requires one). On this fork, the abstraction was requested in the reviews of #24 and #31.

#### ✍️ Description

Several of this fork's performance PRs (#24, #31, and likewise #58/#59) each hand-roll the same caching logic: look up a cached promise, otherwise compute it and cache it. This PR adds one small reusable primitive under `src/util/caching/` so those call sites stop repeating it.

`PromiseCache<TKey, TValue>` caches the *promise* rather than the resolved value, so concurrent callers for the same key deduplicate onto a single in-flight computation instead of each starting their own. The backing store is injected (anything satisfying the `Map`/`WeakMap` subset in `PromiseCacheStore`) and determines the entry lifetime: a `Map` (the default) caches for the lifetime of the instance, which suits a bounded key space such as a fixed set of templates, while a `WeakMap` keyed on object identity lets entries be garbage collected once the key becomes unreachable, which suits request-scoped object keys (e.g. `ResourceIdentifier`s) and avoids unbounded growth. Entries whose promise rejects are evicted by default (`evictOnError`), so transient failures are retried rather than remembered.

`cached(...)` is a method decorator wrapping a `PromiseCache`, so adoption is a single annotation on the method. Each instance gets its own cache (a decorator would otherwise share state across all instances of the class); the key defaults to the first argument (overridable via `key`), and `weak: true` opts into a `WeakMap`. The `weak` path casts the `WeakMap` to the store interface: a `WeakMap` only accepts object keys, which callers opting into `weak` are required to supply.

Adoption on this fork (both PRs are rebased on top of this branch, so this should land first):

- #24 (`perf/template-caching`) backs the compiled-template cache with a `Map`-backed `PromiseCache`, since keys are template path/string primitives;
- #31 (`perf/acl-read-once`) memoizes the ACL walk and document read with `@cached({ weak: true })`.

On its own this PR is performance-neutral — it only adds the abstraction, so there is no reproducible benchmark command for it; the measured effects (deterministic op-count tables) belong to the adopting PRs above.

Both new files have 100% unit coverage (`PromiseCache`, `cached`): hit/miss, concurrent dedup, `Map` vs `WeakMap` backing, per-instance isolation, custom key derivation, and error eviction.

**Branch target and semver:** this is a backwards-compatible feature addition (new exported classes), so the upstream submission should target the latest `versions/*` branch (currently `versions/next-major`), not `main`. Intended semver level: **minor** — stated here in prose since contributors cannot set the semver labels.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
