### PR TITLE
🚧 DRAFT perf: Build HttpError metadata lazily

### DIFF
--- a/src/util/errors/HttpError.ts
+++ b/src/util/errors/HttpError.ts
@@ -58,8 +58,8 @@ export class HttpError<T extends number = number> extends Error implements HttpE
 
   /**
    * The metadata describing this error.
-   * Only built on first access, since errors are frequently used as control flow
-   * where the metadata is never read.
+   * Only built on first access when no metadata was supplied through the constructor,
+   * since errors are frequently used as control flow where the metadata is never read.
    */
   public get metadata(): RepresentationMetadata {
     if (!this.lazyMetadata) {

--- a/src/util/errors/HttpError.ts
+++ b/src/util/errors/HttpError.ts
@@ -26,13 +26,6 @@ export class HttpError<T extends number = number> extends Error implements HttpE
   public readonly cause?: unknown;
   public readonly errorCode: string;
 
-  /**
-   * Backing store for {@link HttpError.metadata}.
-   * `HttpError` instances are frequently created purely as control flow
-   * (e.g., `canHandle` declines during content negotiation and handler probing)
-   * and never have their metadata read, so building it is deferred to first access.
-   * It is only populated during construction when the caller provides `options.metadata`.
-   */
   private lazyMetadata?: RepresentationMetadata;
 
   /**
@@ -49,10 +42,7 @@ export class HttpError<T extends number = number> extends Error implements HttpE
     this.name = name;
     this.cause = options.cause;
     this.errorCode = options.errorCode ?? `H${statusCode}`;
-    // When the caller provides metadata we keep building it eagerly:
-    // the existing behaviour mutates that exact object during construction,
-    // so the provided object must already contain the generated triples afterwards.
-    // Otherwise the metadata is built lazily on first access (see the `metadata` getter).
+    // Metadata provided by the caller is populated immediately so it always contains the generated triples
     if (options.metadata) {
       this.lazyMetadata = options.metadata;
       this.generateMetadata();
@@ -60,8 +50,7 @@ export class HttpError<T extends number = number> extends Error implements HttpE
   }
 
   public static isInstance(error: unknown): error is HttpError {
-    // `errorCode` is a string on every `HttpError` instance and is checked instead of `metadata`
-    // so that a type check never forces the (otherwise lazy) metadata to be built.
+    // Checking `metadata` here would force the lazy metadata build
     return isError(error) &&
       typeof (error as HttpError).statusCode === 'number' &&
       typeof (error as HttpError).errorCode === 'string';
@@ -69,8 +58,8 @@ export class HttpError<T extends number = number> extends Error implements HttpE
 
   /**
    * The metadata describing this error.
-   * Built on first access if it was not provided through the constructor options,
-   * producing exactly the same triples as an eagerly built instance.
+   * Only built on first access, since errors are frequently used as control flow
+   * where the metadata is never read.
    */
   public get metadata(): RepresentationMetadata {
     if (!this.lazyMetadata) {

--- a/src/util/errors/HttpError.ts
+++ b/src/util/errors/HttpError.ts
@@ -25,7 +25,15 @@ export class HttpError<T extends number = number> extends Error implements HttpE
   public readonly statusCode: T;
   public readonly cause?: unknown;
   public readonly errorCode: string;
-  public readonly metadata: RepresentationMetadata;
+
+  /**
+   * Backing store for {@link HttpError.metadata}.
+   * `HttpError` instances are frequently created purely as control flow
+   * (e.g., `canHandle` declines during content negotiation and handler probing)
+   * and never have their metadata read, so building it is deferred to first access.
+   * It is only populated during construction when the caller provides `options.metadata`.
+   */
+  private lazyMetadata?: RepresentationMetadata;
 
   /**
    * Creates a new HTTP error. Subclasses should call this with their fixed status code.
@@ -41,14 +49,35 @@ export class HttpError<T extends number = number> extends Error implements HttpE
     this.name = name;
     this.cause = options.cause;
     this.errorCode = options.errorCode ?? `H${statusCode}`;
-    this.metadata = options.metadata ?? new RepresentationMetadata();
-    this.generateMetadata();
+    // When the caller provides metadata we keep building it eagerly:
+    // the existing behaviour mutates that exact object during construction,
+    // so the provided object must already contain the generated triples afterwards.
+    // Otherwise the metadata is built lazily on first access (see the `metadata` getter).
+    if (options.metadata) {
+      this.lazyMetadata = options.metadata;
+      this.generateMetadata();
+    }
   }
 
   public static isInstance(error: unknown): error is HttpError {
+    // `errorCode` is a string on every `HttpError` instance and is checked instead of `metadata`
+    // so that a type check never forces the (otherwise lazy) metadata to be built.
     return isError(error) &&
       typeof (error as HttpError).statusCode === 'number' &&
-      Boolean((error as HttpError).metadata);
+      typeof (error as HttpError).errorCode === 'string';
+  }
+
+  /**
+   * The metadata describing this error.
+   * Built on first access if it was not provided through the constructor options,
+   * producing exactly the same triples as an eagerly built instance.
+   */
+  public get metadata(): RepresentationMetadata {
+    if (!this.lazyMetadata) {
+      this.lazyMetadata = new RepresentationMetadata();
+      this.generateMetadata();
+    }
+    return this.lazyMetadata;
   }
 
   /**

--- a/test/unit/util/errors/HttpError.test.ts
+++ b/test/unit/util/errors/HttpError.test.ts
@@ -3,7 +3,7 @@ import { RepresentationMetadata } from '../../../../src/http/representation/Repr
 import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
 import { ConflictHttpError } from '../../../../src/util/errors/ConflictHttpError';
 import { ForbiddenHttpError } from '../../../../src/util/errors/ForbiddenHttpError';
-import { generateHttpErrorUri } from '../../../../src/util/errors/HttpError';
+import { generateHttpErrorUri, HttpError } from '../../../../src/util/errors/HttpError';
 import type { HttpErrorClass } from '../../../../src/util/errors/HttpError';
 import { InternalServerError } from '../../../../src/util/errors/InternalServerError';
 import { MethodNotAllowedHttpError } from '../../../../src/util/errors/MethodNotAllowedHttpError';
@@ -132,5 +132,54 @@ describe('HttpError', (): void => {
       expect(instance.metadata.get(HTTP.terms.statusCodeNumber)?.value).toBe('304');
       expect(instance.metadata.get(HH.terms.etag)?.value).toBe(eTag);
     });
+  });
+});
+
+describe('A HttpError', (): void => {
+  // Exposes the private lazy metadata cache so tests can assert it is not built prematurely.
+  type WithCache = { lazyMetadata?: RepresentationMetadata };
+
+  it('builds the provided metadata eagerly during construction.', (): void => {
+    const metadata = new RepresentationMetadata();
+    const error = new NotFoundHttpError('message', { metadata });
+    // The exact provided object is reused.
+    expect(error.metadata).toBe(metadata);
+    // It already contains the generated triples after construction, without accessing `.metadata`.
+    expect(metadata.get(SOLID_ERROR.terms.errorResponse)?.value).toBe(`${SOLID_ERROR.namespace}H404`);
+    expect(metadata.get(HTTP.terms.statusCodeNumber)?.value).toBe('404');
+  });
+
+  it('builds identical metadata lazily when none is provided.', (): void => {
+    const eager = new NotFoundHttpError('message', { metadata: new RepresentationMetadata() });
+    const lazy = new NotFoundHttpError('message');
+    // The lazily built metadata contains exactly the same triples as an eagerly built one.
+    expect(lazy.metadata.quads()).toBeRdfIsomorphic(eager.metadata.quads());
+    expect(lazy.metadata.get(SOLID_ERROR.terms.errorResponse)?.value).toBe(`${SOLID_ERROR.namespace}H404`);
+    expect(lazy.metadata.get(HTTP.terms.statusCodeNumber)?.value).toBe('404');
+  });
+
+  it('does not build the metadata store until it is accessed.', (): void => {
+    const error = new NotFoundHttpError();
+    // No metadata (and thus no backing N3 store) is created during construction.
+    expect((error as unknown as WithCache).lazyMetadata).toBeUndefined();
+    // The first access builds the store and caches the result.
+    const { metadata } = error;
+    expect(metadata).toBeInstanceOf(RepresentationMetadata);
+    expect((error as unknown as WithCache).lazyMetadata).toBe(metadata);
+    // Repeated access returns the same cached instance.
+    expect(error.metadata).toBe(metadata);
+  });
+
+  it('is recognised by `isInstance` without building the metadata store.', (): void => {
+    const error = new NotFoundHttpError();
+    expect(HttpError.isInstance(error)).toBe(true);
+    // The type check did not trigger a metadata build.
+    expect((error as unknown as WithCache).lazyMetadata).toBeUndefined();
+  });
+
+  it('is not recognised by `isInstance` for non-HttpError values.', (): void => {
+    expect(HttpError.isInstance('string')).toBe(false);
+    expect(HttpError.isInstance(new Error('bad'))).toBe(false);
+    expect(HttpError.isInstance({ name: 'e', message: 'm', stack: 's', statusCode: 404 })).toBe(false);
   });
 });

--- a/test/unit/util/errors/HttpError.test.ts
+++ b/test/unit/util/errors/HttpError.test.ts
@@ -142,9 +142,7 @@ describe('A HttpError', (): void => {
   it('builds the provided metadata eagerly during construction.', (): void => {
     const metadata = new RepresentationMetadata();
     const error = new NotFoundHttpError('message', { metadata });
-    // The exact provided object is reused.
     expect(error.metadata).toBe(metadata);
-    // It already contains the generated triples after construction, without accessing `.metadata`.
     expect(metadata.get(SOLID_ERROR.terms.errorResponse)?.value).toBe(`${SOLID_ERROR.namespace}H404`);
     expect(metadata.get(HTTP.terms.statusCodeNumber)?.value).toBe('404');
   });
@@ -152,7 +150,6 @@ describe('A HttpError', (): void => {
   it('builds identical metadata lazily when none is provided.', (): void => {
     const eager = new NotFoundHttpError('message', { metadata: new RepresentationMetadata() });
     const lazy = new NotFoundHttpError('message');
-    // The lazily built metadata contains exactly the same triples as an eagerly built one.
     expect(lazy.metadata.quads()).toBeRdfIsomorphic(eager.metadata.quads());
     expect(lazy.metadata.get(SOLID_ERROR.terms.errorResponse)?.value).toBe(`${SOLID_ERROR.namespace}H404`);
     expect(lazy.metadata.get(HTTP.terms.statusCodeNumber)?.value).toBe('404');
@@ -160,20 +157,16 @@ describe('A HttpError', (): void => {
 
   it('does not build the metadata store until it is accessed.', (): void => {
     const error = new NotFoundHttpError();
-    // No metadata (and thus no backing N3 store) is created during construction.
     expect((error as unknown as WithCache).lazyMetadata).toBeUndefined();
-    // The first access builds the store and caches the result.
     const { metadata } = error;
     expect(metadata).toBeInstanceOf(RepresentationMetadata);
     expect((error as unknown as WithCache).lazyMetadata).toBe(metadata);
-    // Repeated access returns the same cached instance.
     expect(error.metadata).toBe(metadata);
   });
 
   it('is recognised by `isInstance` without building the metadata store.', (): void => {
     const error = new NotFoundHttpError();
     expect(HttpError.isInstance(error)).toBe(true);
-    // The type check did not trigger a metadata build.
     expect((error as unknown as WithCache).lazyMetadata).toBeUndefined();
   });
 


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue must be created before this is submitted to CommunitySolidServer (the upstream PR template requires one).

#### ✍️ Description

CSS uses `HttpError` extensively as control flow: `canHandle` declines by throwing (`NotImplementedHttpError`, `NotFoundHttpError`, …) during content negotiation and handler probing. Profiling a booted server (file backend, WAC, DPoP; 10 concurrent workers, 6 scenario types) showed ~67 `HttpError` instances constructed per request, each eagerly building a `RepresentationMetadata` — a fresh N3 `Store`, a blank node, and 2 quads — that decline errors never read. This accounted for ~9.2% of runtime CPU.

This PR builds that metadata lazily, on first access of `.metadata`. Notes for reviewers:

- Errors that surface to a client (`ErrorToJsonConverter`, `ErrorToQuadConverter`, `ErrorToTemplateConverter`, the error metadata writers) read `.metadata` and get metadata containing exactly the same triples as before — a new test asserts the lazily built quads are RDF-isomorphic to eagerly built ones. Discarded decline errors no longer build anything.
- When the caller passes `options.metadata`, the metadata is still generated eagerly in the constructor: the previous behaviour mutated that exact object during construction, and callers can rely on it containing the generated triples afterwards, so that path is unchanged (`expect(error.metadata).toBe(metadata)` still holds).
- `HttpError.isInstance` previously duck-typed on `Boolean(error.metadata)`, which under a lazy getter would build the store on every type check — and `isInstance` runs on the hot decline path (e.g. `RoutingResourceStore`, `PatchingStore`). It now checks `typeof error.errorCode === 'string'`, which is always a string on a genuine `HttpError`, so the result is unchanged for real instances.

Considered and deliberately not included: skipping V8 stack capture for control-flow error classes. `NotFoundHttpError` is frequently a genuine client-facing error, and `error.stack` is copied into client-facing error responses and logs by the converters above, so zeroing stacks by status code would change observable behaviour. Scoping that safely to probing call sites only is a larger change, left as a follow-up.

**Benchmarks.** The reproducible evidence is the deterministic per-request op count: ~67 eager `RepresentationMetadata` builds (N3 `Store` + blank node + 2 quads each) per request before, 0 on the decline path after; client-facing errors build once, on first `.metadata` access. Wall-clock, from a paired alternating A/B load run against a booted server (same 6-scenario workload as the profile): 63 → 76 req/s (+21% end-to-end, uniform across scenario types, 0 errors). There is currently no upstream-runnable benchmark command — the load harness lives in this fork — so treat the wall-clock numbers as indicative and the op count as the reproducible part.

**Branch target and semver.** Intended semver level: **patch** — behaviour-preserving, no API additions, `.metadata` on access identical. However, `metadata` changes from a `readonly` property to a getter, which is visible to subclasses that redeclare or assign it, so per the contributing guide this should target the latest `versions/*` branch (`versions/next-major`) rather than `main` — retarget before upstream submission unless the maintainer judges it internal enough for `main`.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
