### PR TITLE
perf: Memoize the WebhookEmitter signing key import

### DIFF
--- a/src/server/notifications/WebhookChannel2023/WebhookEmitter.ts
+++ b/src/server/notifications/WebhookChannel2023/WebhookEmitter.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import fetch from 'cross-fetch';
 import { calculateJwkThumbprint, importJWK, SignJWT } from 'jose';
-import type { JwkGenerator } from '../../../identity/configuration/JwkGenerator';
+import type { KeyLike } from 'jose';
+import type { AlgJwk, JwkGenerator } from '../../../identity/configuration/JwkGenerator';
 import type { InteractionRoute } from '../../../identity/interaction/routing/InteractionRoute';
 import { getLoggerFor } from '../../../logging/LogUtil';
 import { NotImplementedHttpError } from '../../../util/errors/NotImplementedHttpError';
@@ -11,6 +12,22 @@ import type { NotificationEmitterInput } from '../NotificationEmitter';
 import { NotificationEmitter } from '../NotificationEmitter';
 import type { WebhookChannel2023 } from './WebhookChannel2023Type';
 import { isWebhook2023Channel } from './WebhookChannel2023Type';
+
+/**
+ * The cryptographic material needed to sign the DPoP token and proof of a webhook notification.
+ * All values are derived from the {@link JwkGenerator} keys, which never change,
+ * so they can be computed once and reused for every emission.
+ */
+interface WebhookSigningMaterial {
+  /** The signing algorithm, taken from the private JWK. */
+  alg: AlgJwk['alg'];
+  /** The public JWK, embedded in the DPoP proof header. */
+  publicKey: AlgJwk;
+  /** The imported private key used to sign the DPoP token and proof. */
+  privateKeyObject: KeyLike | Uint8Array;
+  /** The `sha256` thumbprint of the public JWK. */
+  thumbprint: string;
+}
 
 /**
  * Emits a notification representation using the WebhookChannel2023 specification.
@@ -31,12 +48,41 @@ export class WebhookEmitter extends NotificationEmitter {
   private readonly jwkGenerator: JwkGenerator;
   private readonly expiration: number;
 
+  /**
+   * Caches the imported signing key and its thumbprint after the first emission.
+   * The {@link JwkGenerator} keys never change, so this only needs to be computed once.
+   */
+  private signingMaterial?: WebhookSigningMaterial;
+
   public constructor(baseUrl: string, webIdRoute: InteractionRoute, jwkGenerator: JwkGenerator, expiration = 20) {
     super();
     this.issuer = trimTrailingSlashes(baseUrl);
     this.webId = webIdRoute.getPath();
     this.jwkGenerator = jwkGenerator;
     this.expiration = expiration * 60;
+  }
+
+  /**
+   * Imports the signing key and calculates its thumbprint, caching the result after the first call.
+   *
+   * The {@link JwkGenerator} contract guarantees its keys never change,
+   * so the (relatively expensive) `importJWK` and `calculateJwkThumbprint` calls
+   * only need to happen once instead of on every notification emission.
+   * The cached key is functionally identical to a freshly imported one,
+   * so the generated tokens, proofs and signatures are unchanged.
+   */
+  private async getSigningMaterial(): Promise<WebhookSigningMaterial> {
+    if (!this.signingMaterial) {
+      const privateKey = await this.jwkGenerator.getPrivateKey();
+      const publicKey = await this.jwkGenerator.getPublicKey();
+      this.signingMaterial = {
+        alg: privateKey.alg,
+        publicKey,
+        privateKeyObject: await importJWK(privateKey),
+        thumbprint: await calculateJwkThumbprint(publicKey, 'sha256'),
+      };
+    }
+    return this.signingMaterial;
   }
 
   public async canHandle({ channel }: NotificationEmitterInput): Promise<void> {
@@ -50,11 +96,7 @@ export class WebhookEmitter extends NotificationEmitter {
     const webhookChannel = channel as WebhookChannel2023;
     this.logger.debug(`Emitting Webhook notification with target ${webhookChannel.sendTo}`);
 
-    const privateKey = await this.jwkGenerator.getPrivateKey();
-    const publicKey = await this.jwkGenerator.getPublicKey();
-
-    const privateKeyObject = await importJWK(privateKey);
-    const keyThumbprint = await calculateJwkThumbprint(publicKey, 'sha256');
+    const { alg, publicKey, privateKeyObject, thumbprint: keyThumbprint } = await this.getSigningMaterial();
 
     // Make sure both header and proof have the same timestamp
     const time = Math.floor(Date.now() / 1000);
@@ -69,7 +111,7 @@ export class WebhookEmitter extends NotificationEmitter {
       cnf: {
         jkt: keyThumbprint,
       },
-    }).setProtectedHeader({ alg: privateKey.alg, kid: keyThumbprint })
+    }).setProtectedHeader({ alg, kid: keyThumbprint })
       .setIssuedAt(time)
       .setExpirationTime(time + this.expiration)
       .setAudience([ this.webId, 'solid' ])
@@ -81,7 +123,7 @@ export class WebhookEmitter extends NotificationEmitter {
     const dpopProof = await new SignJWT({
       htu: webhookChannel.sendTo,
       htm: 'POST',
-    }).setProtectedHeader({ alg: privateKey.alg, jwk: publicKey, typ: 'dpop+jwt' })
+    }).setProtectedHeader({ alg, jwk: publicKey, typ: 'dpop+jwt' })
       .setIssuedAt(time)
       .setJti(randomUUID())
       .sign(privateKeyObject);

--- a/src/server/notifications/WebhookChannel2023/WebhookEmitter.ts
+++ b/src/server/notifications/WebhookChannel2023/WebhookEmitter.ts
@@ -15,17 +15,11 @@ import { isWebhook2023Channel } from './WebhookChannel2023Type';
 
 /**
  * The cryptographic material needed to sign the DPoP token and proof of a webhook notification.
- * All values are derived from the {@link JwkGenerator} keys, which never change,
- * so they can be computed once and reused for every emission.
  */
 interface WebhookSigningMaterial {
-  /** The signing algorithm, taken from the private JWK. */
   alg: AlgJwk['alg'];
-  /** The public JWK, embedded in the DPoP proof header. */
   publicKey: AlgJwk;
-  /** The imported private key used to sign the DPoP token and proof. */
   privateKeyObject: KeyLike | Uint8Array;
-  /** The `sha256` thumbprint of the public JWK. */
   thumbprint: string;
 }
 
@@ -48,10 +42,6 @@ export class WebhookEmitter extends NotificationEmitter {
   private readonly jwkGenerator: JwkGenerator;
   private readonly expiration: number;
 
-  /**
-   * Caches the imported signing key and its thumbprint after the first emission.
-   * The {@link JwkGenerator} keys never change, so this only needs to be computed once.
-   */
   private signingMaterial?: WebhookSigningMaterial;
 
   public constructor(baseUrl: string, webIdRoute: InteractionRoute, jwkGenerator: JwkGenerator, expiration = 20) {
@@ -63,13 +53,8 @@ export class WebhookEmitter extends NotificationEmitter {
   }
 
   /**
-   * Imports the signing key and calculates its thumbprint, caching the result after the first call.
-   *
-   * The {@link JwkGenerator} contract guarantees its keys never change,
-   * so the (relatively expensive) `importJWK` and `calculateJwkThumbprint` calls
-   * only need to happen once instead of on every notification emission.
-   * The cached key is functionally identical to a freshly imported one,
-   * so the generated tokens, proofs and signatures are unchanged.
+   * Imports the signing key and calculates its thumbprint.
+   * The {@link JwkGenerator} keys never change, so the result is cached after the first call.
    */
   private async getSigningMaterial(): Promise<WebhookSigningMaterial> {
     if (!this.signingMaterial) {

--- a/test/unit/server/notifications/WebHookChannel2023/WebhookEmitter.test.ts
+++ b/test/unit/server/notifications/WebHookChannel2023/WebhookEmitter.test.ts
@@ -159,10 +159,8 @@ describe('A WebhookEmitter', (): void => {
     await expect(emitter.handle({ channel, representation })).resolves.toBeUndefined();
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    // The expensive key import and thumbprint calculation only happen for the first emission.
     expect(importSpy).toHaveBeenCalledTimes(1);
     expect(thumbprintSpy).toHaveBeenCalledTimes(1);
-    // The generator keys are also only read while populating the cache.
     expect(jwkGenerator.getPrivateKey).toHaveBeenCalledTimes(1);
     expect(jwkGenerator.getPublicKey).toHaveBeenCalledTimes(1);
 

--- a/test/unit/server/notifications/WebHookChannel2023/WebhookEmitter.test.ts
+++ b/test/unit/server/notifications/WebHookChannel2023/WebhookEmitter.test.ts
@@ -1,5 +1,6 @@
 import fetch from 'cross-fetch';
 import { calculateJwkThumbprint, exportJWK, generateKeyPair, importJWK, jwtVerify } from 'jose';
+import * as jose from 'jose';
 import { BasicRepresentation } from '../../../../../src/http/representation/BasicRepresentation';
 import type { Representation } from '../../../../../src/http/representation/Representation';
 import type { AlgJwk, JwkGenerator } from '../../../../../src/identity/configuration/JwkGenerator';
@@ -145,5 +146,57 @@ describe('A WebhookEmitter', (): void => {
     expect(logger.error).toHaveBeenLastCalledWith(
       `There was an issue emitting a Webhook notification with target ${channel.sendTo}: invalid request`,
     );
+  });
+
+  it('imports the signing key and calculates its thumbprint only once across emissions.', async(): Promise<void> => {
+    const importSpy = jest.spyOn(jose, 'importJWK');
+    const thumbprintSpy = jest.spyOn(jose, 'calculateJwkThumbprint');
+    fetchMock.mockClear();
+
+    await expect(emitter.handle({ channel, representation })).resolves.toBeUndefined();
+    // The data stream is consumed by the first emission, so a fresh representation is needed.
+    representation = new BasicRepresentation(JSON.stringify(notification), 'application/ld+json');
+    await expect(emitter.handle({ channel, representation })).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The expensive key import and thumbprint calculation only happen for the first emission.
+    expect(importSpy).toHaveBeenCalledTimes(1);
+    expect(thumbprintSpy).toHaveBeenCalledTimes(1);
+    // The generator keys are also only read while populating the cache.
+    expect(jwkGenerator.getPrivateKey).toHaveBeenCalledTimes(1);
+    expect(jwkGenerator.getPublicKey).toHaveBeenCalledTimes(1);
+
+    importSpy.mockRestore();
+    thumbprintSpy.mockRestore();
+  });
+
+  it('keeps signing correctly when reusing the cached key.', async(): Promise<void> => {
+    fetchMock.mockClear();
+
+    await expect(emitter.handle({ channel, representation })).resolves.toBeUndefined();
+    // The data stream is consumed by the first emission, so a fresh representation is needed.
+    representation = new BasicRepresentation(JSON.stringify(notification), 'application/ld+json');
+    await expect(emitter.handle({ channel, representation })).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Verify the second emission specifically, as it is signed with the cached key.
+    const { authorization, dpop } = fetchMock.mock.calls[1][1].headers;
+    expect(matchesAuthorizationScheme('DPoP', authorization)).toBe(true);
+    const encodedDpopToken = authorization.slice('DPoP '.length);
+
+    const publicObject = await importJWK(publicJwk);
+    const keyThumbprint = await calculateJwkThumbprint(publicJwk, 'sha256');
+
+    const decodedDpopToken = await jwtVerify(encodedDpopToken, publicObject, { issuer: trimTrailingSlashes(baseUrl) });
+    expect(decodedDpopToken.payload).toMatchObject({
+      webid: serverWebId,
+      cnf: { jkt: keyThumbprint },
+    });
+    expect(decodedDpopToken.protectedHeader).toMatchObject({ alg: 'ES256', kid: keyThumbprint });
+
+    const decodedDpopProof = await jwtVerify(dpop, publicObject);
+    expect(decodedDpopProof.payload).toMatchObject({ htu: channel.sendTo, htm: 'POST' });
+    expect(decodedDpopProof.protectedHeader).toMatchObject({ alg: 'ES256', typ: 'dpop+jwt', jwk: publicJwk });
   });
 });


### PR DESCRIPTION
> 🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue must be created before this is submitted to CommunitySolidServer (the PR template requires one).

#### ✍️ Description

`WebhookEmitter.handle()` re-imports the signing JWK (`importJWK`) and recomputes the public-key thumbprint (`calculateJwkThumbprint`) on every notification emission. The key comes from the injected `JwkGenerator`, whose interface contract guarantees its keys never change ("The functions always need to return the same value"), so this per-emission crypto work is redundant. This PR computes the derived signing material (imported private key, public JWK, `alg`, and the `sha256` thumbprint) lazily on the first emission and reuses it for every subsequent one.

This is behaviour-preserving — a pure memoization; nothing that is signed or emitted changes:

* The cached key is functionally identical to a freshly imported one — same key material, same `alg` — so signatures remain valid and verifiable by the same public key.
* The DPoP token and proof payloads/headers are the same construction as before; the per-emission `iat`/`exp`/`jti` values are still computed inside `handle()`.
* Only the *import* of the stable key is cached — never *what* is signed.

Deterministic op counts per notification emission — this is the reproducible evidence, asserted as `jest.spyOn` call counts by the new unit tests (`npm run jest -- test/unit/server/notifications/WebHookChannel2023/WebhookEmitter.test.ts`):

| Operation | Before | After |
| --- | --- | --- |
| `importJWK` | 1 per emission | 1 per emitter instance |
| `calculateJwkThumbprint` | 1 per emission | 1 per emitter instance |
| `JwkGenerator.getPrivateKey` / `getPublicKey` | 1 each per emission | 1 each per emitter instance |

An ad-hoc wall-clock measurement of the removed jose work was ~573 µs → ~366 µs per emission (roughly halving the per-notification crypto cost), but no reproducible benchmark command exists for that figure — the op-count table above is the evidence that reproduces.

The new unit tests also verify the second emission (the one signed with the cached key) still produces a valid, correctly structured DPoP token and proof, verified against the public key; 100% coverage on `WebhookEmitter.ts` is maintained.

This is an internal optimization with no interface or configuration-behaviour change, so it targets `main`. Intended semver level: **patch** (stated in prose, as contributors cannot set the semver labels).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
