### PR TITLE
feat: Add high-throughput production config preset

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -130,20 +130,13 @@ This way the server can be used to identify those WebIDs during an OIDC interact
 
 ## production-throughput.json
 
-An opt-in, high-throughput variant of `file.json` for single-process deployments.
-It keeps everything that makes `file.json` a persistent, WAC-authorized Solid server,
-and differs in only two additive ways, each with a trade-off:
+A variant of `file.json` for single-process deployments that need higher throughput.
+Locks are stored in memory instead of on disk,
+which removes the lock file system calls and the lock polling that the file-based locker performs on every request.
+Because those locks are only visible within a single process,
+this configuration can not be used with multiple workers,
+and no other process should write to the same data directory.
+For such deployments, use the file-based or Redis-based resource locker instead.
 
-- **In-memory resource locking** (`util/resource-locker/memory.json` instead of the file-based locker).
-  This removes the per-request lock-file syscalls and on-disk lock polling that the default file locker performs.
-  Because the locks live in this process' memory, the configuration is **single-process**:
-  do not run it with `--workers > 1` and do not point a second process at the same data directory.
-  Your data on disk stays durable; only the locks are no longer shared.
-  For multi-worker or multi-instance setups, keep `util/resource-locker/file.json`,
-  or switch to `util/resource-locker/redis.json` with a shared Redis.
-- **CORS preflight caching** (`Access-Control-Max-Age: 3600`).
-  Browsers may reuse a CORS preflight (`OPTIONS`) result for one hour instead of sending one per request,
-  which reduces preflight round-trips for browser-based Solid apps.
-  This only affects how long a browser caches the preflight; no response body or authorization decision changes.
-
-Use it with `-c config/production-throughput.json`.
+It also sets the `Access-Control-Max-Age` header,
+so browsers can cache CORS preflight results for an hour instead of sending a new preflight for every request.

--- a/config/README.md
+++ b/config/README.md
@@ -127,3 +127,23 @@ A configuration that sets up the server to only function as an Identity Provider
 It does not support creating pods or storing data on the server,
 the only available options are creating accounts and linking them to WebIDs.
 This way the server can be used to identify those WebIDs during an OIDC interaction.
+
+## production-throughput.json
+
+An opt-in, high-throughput variant of `file.json` for single-process deployments.
+It keeps everything that makes `file.json` a persistent, WAC-authorized Solid server,
+and differs in only two additive ways, each with a trade-off:
+
+- **In-memory resource locking** (`util/resource-locker/memory.json` instead of the file-based locker).
+  This removes the per-request lock-file syscalls and on-disk lock polling that the default file locker performs.
+  Because the locks live in this process' memory, the configuration is **single-process**:
+  do not run it with `--workers > 1` and do not point a second process at the same data directory.
+  Your data on disk stays durable; only the locks are no longer shared.
+  For multi-worker or multi-instance setups, keep `util/resource-locker/file.json`,
+  or switch to `util/resource-locker/redis.json` with a shared Redis.
+- **CORS preflight caching** (`Access-Control-Max-Age: 3600`).
+  Browsers may reuse a CORS preflight (`OPTIONS`) result for one hour instead of sending one per request,
+  which reduces preflight round-trips for browser-based Solid apps.
+  This only affects how long a browser caches the preflight; no response body or authorization decision changes.
+
+Use it with `-c config/production-throughput.json`.

--- a/config/production-throughput.json
+++ b/config/production-throughput.json
@@ -1,0 +1,55 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "import": [
+    "css:config/app/init/static-root.json",
+    "css:config/app/main/default.json",
+    "css:config/app/variables/default.json",
+    "css:config/http/handler/default.json",
+    "css:config/http/middleware/default.json",
+    "css:config/http/notifications/all.json",
+    "css:config/http/server-factory/http.json",
+    "css:config/http/static/default.json",
+    "css:config/identity/access/public.json",
+    "css:config/identity/email/default.json",
+    "css:config/identity/handler/default.json",
+    "css:config/identity/oidc/default.json",
+    "css:config/identity/ownership/token.json",
+    "css:config/identity/pod/static.json",
+    "css:config/ldp/authentication/dpop-bearer.json",
+    "css:config/ldp/authorization/webacl.json",
+    "css:config/ldp/handler/default.json",
+    "css:config/ldp/metadata-parser/default.json",
+    "css:config/ldp/metadata-writer/default.json",
+    "css:config/ldp/modes/default.json",
+    "css:config/storage/backend/file.json",
+    "css:config/storage/key-value/resource-store.json",
+    "css:config/storage/location/pod.json",
+    "css:config/storage/middleware/default.json",
+    "css:config/util/auxiliary/acl.json",
+    "css:config/util/identifiers/suffix.json",
+    "css:config/util/index/default.json",
+    "css:config/util/logging/winston.json",
+    "css:config/util/representation-conversion/default.json",
+    "css:config/util/resource-locker/memory.json",
+    "css:config/util/variables/default.json"
+  ],
+  "@graph": [
+    {
+      "comment": [
+        "OPT-IN high-throughput variant of file.json: same file-backed Solid server (data persists on disk, WAC authorization, accounts and pods), tuned for single-process throughput.",
+        "It differs from file.json in exactly two, additive ways:",
+        "1. In-memory resource locking (config/util/resource-locker/memory.json) instead of the file-based locker. This removes per-request lock-file syscalls and the on-disk lock polling. TRADE-OFF: locks live in this process's memory only, so this configuration is SINGLE-PROCESS. Do NOT run it with --workers > 1 and do NOT let a second process write to the same data directory. Data on disk stays durable; only the locks are non-shared. For multi-worker or multi-instance deployments keep resource-locker/file.json, or use resource-locker/redis.json with a shared Redis.",
+        "2. CORS preflight caching: Access-Control-Max-Age is set on OPTIONS responses so browsers can reuse a preflight for one hour, cutting preflight round-trips for browser-based Solid apps. This only affects how long a browser caches the preflight; it changes no actual response body or authorization decision."
+      ]
+    },
+    {
+      "comment": "Let browsers cache the CORS preflight (OPTIONS) result for 1 hour (3600 s) instead of re-sending a preflight per request.",
+      "@type": "Override",
+      "overrideInstance": { "@id": "urn:solid-server:default:Middleware_Cors" },
+      "overrideParameters": {
+        "@type": "CorsHandler",
+        "options_maxAge": 3600
+      }
+    }
+  ]
+}

--- a/config/production-throughput.json
+++ b/config/production-throughput.json
@@ -36,14 +36,12 @@
   "@graph": [
     {
       "comment": [
-        "OPT-IN high-throughput variant of file.json: same file-backed Solid server (data persists on disk, WAC authorization, accounts and pods), tuned for single-process throughput.",
-        "It differs from file.json in exactly two, additive ways:",
-        "1. In-memory resource locking (config/util/resource-locker/memory.json) instead of the file-based locker. This removes per-request lock-file syscalls and the on-disk lock polling. TRADE-OFF: locks live in this process's memory only, so this configuration is SINGLE-PROCESS. Do NOT run it with --workers > 1 and do NOT let a second process write to the same data directory. Data on disk stays durable; only the locks are non-shared. For multi-worker or multi-instance deployments keep resource-locker/file.json, or use resource-locker/redis.json with a shared Redis.",
-        "2. CORS preflight caching: Access-Control-Max-Age is set on OPTIONS responses so browsers can reuse a preflight for one hour, cutting preflight round-trips for browser-based Solid apps. This only affects how long a browser caches the preflight; it changes no actual response body or authorization decision."
+        "A Solid server that stores its resources on disk and uses WAC for authorization, tuned for single-process throughput.",
+        "Locks are stored in memory, so this configuration does not support multiple workers or a second server process on the same data directory."
       ]
     },
     {
-      "comment": "Let browsers cache the CORS preflight (OPTIONS) result for 1 hour (3600 s) instead of re-sending a preflight per request.",
+      "comment": "Lets browsers cache CORS preflight responses instead of sending a new preflight for every request.",
       "@type": "Override",
       "overrideInstance": { "@id": "urn:solid-server:default:Middleware_Cors" },
       "overrideParameters": {


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue needs to be created before this is submitted to CommunitySolidServer (the upstream PR template requires one).

#### ✍️ Description

Adds `config/production-throughput.json`, a preset that composes two throughput options the server already ships but no packaged config enables, plus a `config/README.md` section documenting it. Purely additive: no `src/` changes, no new components, and every existing config (including the shared `resource-locker/*.json` and `cors.json`) is byte-identical.

The preset is `file.json` with two differences:

1. **In-memory resource locking** — imports `util/resource-locker/memory.json` instead of the file-based locker. The file locker pays `mkdir`/`stat`/`rmdir` lock-cycle syscalls per request plus on-disk polling by waiting requests, even when nothing is contended. The trade-off is that locks live in one process's memory, so the preset is strictly single-process: no `--workers > 1`, and no second process on the same data directory. Data on disk stays fully durable — only the locks stop being shared. The README section points multi-worker/multi-instance deployments at the file or Redis lockers instead. This file-backend + memory-locker composition is already exercised by `test/integration/config/quota-global.json`, so it is a supported wiring, not a novel one.
2. **CORS preflight caching** — a Components.js `Override` on `urn:solid-server:default:Middleware_Cors` sets `options_maxAge: 3600`, emitting `Access-Control-Max-Age: 3600` so browsers may reuse a preflight for an hour instead of re-sending one before almost every non-simple request. Using an `Override`, rather than editing the shared `cors.json`, leaves every other config's preflight behaviour untouched. 3600 s is within all browser caps (Chromium ≈ 2 h, Firefox ≈ 24 h), and only preflight caching changes — no response body and no authorization decision.

**Benchmarks.** The composed preset has not been benchmarked as a unit, and this PR ships no reproducible benchmark command. The locker lever was measured in this fork's earlier instrumented A/B on `config/file.json`: fs ops per request dropped PUT ≈ 48 → 33 and GET ≈ 26 → 20, and idle disk churn under a lock wedge (one slow reader + abandoned writers) went from ≈ 1,200 sustained fs ops/s to 0. The CORS lever removes the per-request preflight round-trip for browser apps (≈ one preflight per hour per method/route instead of one per request); it has no server-side number to report.

**Verification.** A gated boot of the built server with this config (port 3456) reached `Listening to server at http://localhost:3456/` with no errors or warnings; `GET /` → `200 OK`; an `OPTIONS` preflight → `204` with `Access-Control-Max-Age: 3600` and all other CORS headers intact, confirming the `Override` merged with (rather than replaced) the existing instance. `eslint` and `markdownlint-cli2` are clean. `test/deploy/validate-configs.sh` was not run locally (it globally installs/uninstalls the packaged server, unsuitable on this shared box) — CI's `test:deploy` should boot-validate the new config before this is marked ready.

**Branch target + semver.** This is a backwards-compatible feature addition: intended level **semver.minor** (stated in prose since contributors cannot set labels). Per the contributing guide it should target the latest `versions/*` branch (currently `versions/next-major`) when submitted upstream, not `main` — it sits on `main` here only for review on the fork.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
