### PR TITLE
fix: Clear moderate @comunica/expression-evaluator advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4238,6 +4238,19 @@
         "node": "14 || >=16.14"
       }
     },
+    "node_modules/@comunica/expression-evaluator/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@comunica/logger-pretty": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-2.8.2.tgz",
@@ -16702,6 +16715,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -20590,13 +20604,18 @@
         "relative-to-absolute-iri": "^1.0.6",
         "spark-md5": "^3.0.1",
         "sparqlalgebrajs": "^4.2.0",
-        "uuid": "^9.0.0"
+        "uuid": "^11.1.1"
       },
       "dependencies": {
         "lru-cache": {
           "version": "10.0.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
           "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g=="
+        },
+        "uuid": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
         }
       }
     },
@@ -29803,7 +29822,8 @@
     "uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,11 @@
     "typedoc": "^0.26.4",
     "typescript": "^5.5.3"
   },
+  "overrides": {
+    "@comunica/expression-evaluator": {
+      "uuid": "^11.1.1"
+    }
+  },
   "husky": {
     "hooks": {
       "pre-commit": "npm run build && npm run lint && npm run test:unit && npm run test:integration",


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — this is staged on the fork; an issue must be created on CommunitySolidServer/CommunitySolidServer before upstream submission (the PR template requires one).

#### ✍️ Description

`npm audit` reports a chain of moderate advisories across the `@comunica/query-sparql@2.9.0` subtree. They all roll up to one real advisory: [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (uuid: missing buffer bounds check in `v3`/`v5`/`v6` when `buf` is provided; patched in uuid 11.1.1). `@comunica/expression-evaluator@2.9.0` pins `uuid ^9.0.0`, so audit escalates the flag through every package that depends on it.

The fix is a scoped `package.json` override that bumps only expression-evaluator's `uuid` to the patched line, plus the regenerated lockfile:

```json
"overrides": {
  "@comunica/expression-evaluator": {
    "uuid": "^11.1.1"
  }
}
```

No Comunica package version changes (`@comunica/query-sparql` stays `2.9.0`). This is contract-safe because expression-evaluator only ever calls `uuid.v4()` (SPARQL `UUID()`/`STRUUID()` and the `BNODE()` fallback label): `v4()`'s signature and 36-char RFC 4122 output format are identical across uuid 9 → 11, uuid 11.1.1 supports CommonJS `require` via its `exports` map, and it declares no `engines` restriction affecting Node 18. The advisory's vulnerable path (`v3`/`v5`/`v6` with an output buffer) is never exercised here, so this is audit hygiene / defense in depth rather than a live vulnerability.

Alternatives considered:

- **Bumping `@comunica/query-sparql`**: the only fix npm offers is `query-sparql@5.2.4`, a 2.x → 5.x major bump — too large a behavior change on the SPARQL / N3-Patch / SPARQL-Update path for a security-hygiene fix.
- **A global `uuid` override**: would also rewrite the dev-only `@inrupt/solid-client-authn-*` packages' `uuid`, widening the blast radius for no benefit. The scoped override leaves those at `uuid@9.0.1`.

Validation (reproducible from a fresh `npm ci` on this branch):

- `npm ls uuid`: `@comunica/expression-evaluator@2.9.0 → uuid@11.1.1 (overridden)`; all Comunica versions unchanged.
- `npm audit --omit=dev`: 9 moderate → 1 moderate (total 10 → 2); the full `npm audit` drops 22 → 15. The remaining findings (`js-yaml` in the markdownlint dev chain, `koa`) are unrelated and out of scope for this PR.
- `npm run build` and `npm run lint` are clean; the full unit suite passes with the 100% coverage gate.
- The Comunica-touching suites — `test/unit/storage/patch/SparqlUpdatePatcher.test.ts`, `test/unit/storage/patch/N3Patcher.test.ts`, `test/integration/N3Patch.test.ts` — all pass. `test/integration/SparqlStorage.test.ts` is a pre-existing `describeIf('docker')` skip, unaffected.

This is a backwards-compatible dependency patch fix, so it targets `main`; the intended semver level is **patch** (stated in prose — contributors cannot set the semver labels).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
