### PR TITLE
perf: Stop StaticThrowHandler from pinning the Components.js config graph

### DIFF
--- a/src/util/handlers/StaticThrowHandler.ts
+++ b/src/util/handlers/StaticThrowHandler.ts
@@ -5,16 +5,22 @@ import { AsyncHandler } from './AsyncHandler';
  * Utility handler that can handle all input and always throws an instance of the given error.
  */
 export class StaticThrowHandler extends AsyncHandler<unknown, never> {
-  protected readonly error: HttpError;
+  protected readonly errorClass: HttpErrorClass;
 
   public constructor(error: HttpError) {
     super();
-    this.error = error;
+    // Only the error's class is retained, never the provided instance.
+    // `handle` always throws a fresh instance, so the instance itself is unused after construction.
+    // Retaining it would also retain its lazily-formatted V8 stack trace; as this handler is
+    // instantiated by Components.js, that stack captures the configuration-construction call frames
+    // and would keep the entire parsed configuration object graph alive for the server's lifetime.
+    this.errorClass = error.constructor as HttpErrorClass;
   }
 
   public async handle(): Promise<never> {
     // We are creating a new instance of the error instead of rethrowing the error,
     // as reusing the same error can cause problem as the metadata is then also reused.
-    throw new (this.error.constructor as HttpErrorClass)();
+    // eslint-disable-next-line new-cap
+    throw new this.errorClass();
   }
 }

--- a/src/util/handlers/StaticThrowHandler.ts
+++ b/src/util/handlers/StaticThrowHandler.ts
@@ -9,11 +9,8 @@ export class StaticThrowHandler extends AsyncHandler<unknown, never> {
 
   public constructor(error: HttpError) {
     super();
-    // Only the error's class is retained, never the provided instance.
-    // `handle` always throws a fresh instance, so the instance itself is unused after construction.
-    // Retaining it would also retain its lazily-formatted V8 stack trace; as this handler is
-    // instantiated by Components.js, that stack captures the configuration-construction call frames
-    // and would keep the entire parsed configuration object graph alive for the server's lifetime.
+    // Keeping the instance would retain its captured stack trace,
+    // which pins the entire Components.js configuration graph that constructed this handler.
     this.errorClass = error.constructor as HttpErrorClass;
   }
 


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready.)

#### 📁 Related issues

None yet — an issue describing the retained-configuration-graph observation needs to be opened on CommunitySolidServer before this is submitted upstream (the PR template requires one).

#### ✍️ Description

`StaticThrowHandler` keeps the `HttpError` instance it is configured with, but only ever uses its class: `handle()` throws `new (this.error.constructor)()` so that error metadata is never shared between responses. The stored instance is unused after construction — and it is expensive to keep. `HttpError` extends `Error`, so the instance captured a stack trace when it was built, and V8 retains the structured stack frames (including each frame's receivers and closures) until `.stack` is first formatted, which never happens here. Since these handlers are instantiated by Components.js, the captured frames belong to the config-construction machinery and reference its `RdfObjectLoader` — pinning the entire parsed configuration graph for the lifetime of the process. The default config wires up 4 `StaticThrowHandler`s, so a default server always retains at least one such stack.

This PR stores the error's class instead of the instance, letting the instance — and everything its stack pins — be garbage-collected after boot. Behaviour is unchanged: the class captured once in the constructor is the same class `handle()` previously recomputed from the instance on every call, so every thrown error is a fresh instance exactly as before (covered by the existing "creates a new instance every time" unit test). The one signature change is the `protected` field rename `error` → `errorClass`; nothing in this repository subclasses `StaticThrowHandler`.

Measured by wrapping `ComponentsManager.build` in a `WeakRef` probe and reading post-GC `process.memoryUsage()` after booting `config/default.json`. The probe script is not part of this PR, so there is no in-repo command to reproduce it; heap sizes were taken on a shared box and are indicative — the collectability row is the deterministic evidence:

| | before | after |
| --- | --- | --- |
| object-loader `Resource` graph reachable after boot + GC | yes (18,287 objects) | collected |
| post-GC `heapUsed` after boot | 82.4 MB | 55.6 MB |
| post-GC `heapUsed` after a small LDP workload | 81.7 MB | 54.9 MB |

RSS barely moves (it is dominated by heap capacity V8 keeps from the boot-time JSON-LD high-water mark); the gain is ~27 MB of live retained heap, which is what matters for GC pressure and container memory limits. The workload exercised both configured `StaticThrowHandler` paths (405 and 415 responses, unchanged).

This draft targets the fork's `main` for review. Upstream it should target `versions/next-major`, since removing the `protected error` field changes the class surface for subclasses of `StaticThrowHandler` — intended semver level: **major**.
