### PR TITLE
perf: Seek byte ranges in the file backend via a metadata-first conversion decision

### DIFF
--- a/config/storage/backend/file.json
+++ b/config/storage/backend/file.json
@@ -11,7 +11,8 @@
       "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },
       "auxiliaryStrategy": { "@id": "urn:solid-server:default:AuxiliaryStrategy" },
       "accessor": { "@id": "urn:solid-server:default:FileDataAccessor" },
-      "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" }
+      "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" },
+      "optimizeRange": true
     }
   ]
 }

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -74,6 +74,12 @@ import namedNode = DataFactory.namedNode;
  *
  * Work has been done to minimize the number of required calls to the DataAccessor,
  * but the main disadvantage is that sometimes multiple calls are required where a specific store might only need one.
+ *
+ * The `optimizeRange` parameter can be used to push explicit, satisfiable byte ranges
+ * down to the accessor, so it can seek to the requested window instead of streaming the full resource.
+ * This only happens when no content conversion is needed,
+ * and should only be enabled for accessors that support the `range` argument of `getData`,
+ * such as a {@link FileDataAccessor}.
  */
 export class DataAccessorBasedStore implements ResourceStore {
   protected readonly logger = getLoggerFor(this);
@@ -84,21 +90,6 @@ export class DataAccessorBasedStore implements ResourceStore {
   private readonly metadataStrategy: AuxiliaryStrategy;
   private readonly optimizeRange: boolean;
 
-  /**
-   * @param accessor - The accessor used to read/write the data.
-   * @param identifierStrategy - The strategy used to handle identifiers.
-   * @param auxiliaryStrategy - The strategy used to handle auxiliary resources.
-   * @param metadataStrategy - The strategy used to handle metadata resources.
-   * @param optimizeRange - Whether to push satisfiable byte ranges down to `accessor.getData`
-   *   instead of always reading the full stream and slicing it higher up.
-   *   This is only safe when (a) the configured `accessor` honours the `range` argument of `getData`
-   *   (e.g. {@link FileDataAccessor}), and (b) the outgoing conversion applied above this store is a
-   *   pure content-negotiation converter (it returns the stored representation unchanged whenever the
-   *   stored content-type already satisfies the request preferences, as the default `ChainedConverter`
-   *   does). When enabled, a range is only ever pushed down for cases where this store can prove from
-   *   metadata alone that no conversion will happen; every other case falls back to the full read.
-   *   Defaults to `false`, keeping the original behaviour.
-   */
   public constructor(
     accessor: DataAccessor,
     identifierStrategy: IdentifierStrategy,
@@ -182,12 +173,9 @@ export class DataAccessorBasedStore implements ResourceStore {
     if (isContainer || isMetadata) {
       representation = new BasicRepresentation(data, metadata, INTERNAL_QUADS);
     } else {
-      // If we can prove from metadata alone that no conversion will happen for this request,
-      // and a satisfiable byte range was requested, read only that window from the accessor.
-      // In every other case we read the full stream and let the higher slicing store handle the range,
-      // keeping the response byte-identical.
       const range = this.getSeekRange(preferences, metadata);
       if (range) {
+        // Writing the unit/start/end metadata indicates the range was already applied to the stream
         metadata.set(SOLID_HTTP.terms.unit, 'bytes');
         metadata.set(SOLID_HTTP.terms.start, toLiteral(range.start, XSD.terms.integer));
         metadata.set(SOLID_HTTP.terms.end, toLiteral(range.end, XSD.terms.integer));
@@ -201,22 +189,11 @@ export class DataAccessorBasedStore implements ResourceStore {
   }
 
   /**
-   * Determines whether the given request can be served by pushing a byte range down to the accessor
-   * instead of reading the full stream and slicing it in a higher store (e.g. `BinarySliceResourceStore`).
-   *
-   * Returns the resolved, satisfiable inclusive byte range to request, or `undefined` to fall back
-   * to the full read. It only returns a range when ALL of the following hold, guaranteeing the response
-   * stays byte-identical to the full-read + slice path:
-   *  - Range optimization is enabled for this store (`optimizeRange`).
-   *  - The preferences contain a single `bytes` range with an explicit, non-negative `start` and `end`.
-   *    (Open-ended and suffix ranges are left to the slicing store, so its `defaultSliceSize` and
-   *    suffix handling remain the single source of truth.)
-   *  - No content conversion will happen: the stored content-type already satisfies the request at the
-   *    maximal requested weight, which is exactly the condition under which a `ChainedConverter` returns
-   *    the representation unchanged. `application/json` is excluded because a converter
-   *    (`DynamicJsonToTemplateConverter`) can transform matching JSON ahead of that decision.
-   *  - The range is satisfiable given the known size (`start < end < size`). Unsatisfiable ranges are
-   *    left to the slicing store so it produces the exact same `416` behaviour as before.
+   * Determines whether the requested range can be read directly from the accessor,
+   * instead of slicing the full stream in a store such as the {@link BinarySliceResourceStore}.
+   * Only returns a range for a single explicit satisfiable `bytes` range
+   * where the stored content-type fully matches the preferences,
+   * which is exactly the case in which a {@link ChainedConverter} returns the representation unchanged.
    */
   private getSeekRange(
     preferences: RepresentationPreferences | undefined,
@@ -230,12 +207,12 @@ export class DataAccessorBasedStore implements ResourceStore {
       return;
     }
     const { start, end } = range.parts[0];
-    // Only explicit `start-end` ranges (both defined, non-negative) are handled here.
+    // Open-ended and suffix ranges are left to the slicing store
     if (typeof start !== 'number' || typeof end !== 'number' || start < 0) {
       return;
     }
 
-    // The stored content-type must already satisfy the request without conversion.
+    // JSON is excluded since a converter can transform it even when the content-type matches the preferences
     const { contentType } = metadata;
     if (typeof contentType !== 'string' || contentType === APPLICATION_JSON) {
       return;
@@ -247,16 +224,14 @@ export class DataAccessorBasedStore implements ResourceStore {
       maxWeight = Math.max(...Object.values(cleaned));
       weight = getTypeWeight(contentType, cleaned);
     } catch {
-      // `getTypeWeight` throws on an unexpected media type; fall back to the full read.
+      // Fall back to the full read on unexpected media types, which make `getTypeWeight` throw
       return;
     }
-    // Identical to the `ChainedConverter` "no conversion needed" decision:
-    // the stored type is (one of) the best match(es) for the preferences.
     if (weight <= 0 || weight < maxWeight) {
       return;
     }
 
-    // Only push down satisfiable ranges; unsatisfiable ones fall back so the slicing store throws 416.
+    // Unsatisfiable ranges are left to the slicing store, which generates the 416 response
     const size = termToInt(metadata.get(POSIX.terms.size));
     if (typeof size !== 'number' || start >= end || end >= size) {
       return;

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -7,9 +7,10 @@ import { BasicRepresentation } from '../http/representation/BasicRepresentation'
 import type { Patch } from '../http/representation/Patch';
 import type { Representation } from '../http/representation/Representation';
 import { RepresentationMetadata } from '../http/representation/RepresentationMetadata';
+import type { RepresentationPreferences } from '../http/representation/RepresentationPreferences';
 import type { ResourceIdentifier } from '../http/representation/ResourceIdentifier';
 import { getLoggerFor } from '../logging/LogUtil';
-import { INTERNAL_QUADS } from '../util/ContentTypes';
+import { APPLICATION_JSON, INTERNAL_QUADS } from '../util/ContentTypes';
 import { BadRequestHttpError } from '../util/errors/BadRequestHttpError';
 import { ConflictHttpError } from '../util/errors/ConflictHttpError';
 import { createErrorMessage } from '../util/errors/ErrorUtil';
@@ -28,7 +29,9 @@ import {
   toCanonicalUriPath,
   trimTrailingSlashes,
 } from '../util/PathUtil';
+import { termToInt } from '../util/QuadUtil';
 import { addResourceMetadata, updateModifiedDate } from '../util/ResourceUtil';
+import { toLiteral } from '../util/TermUtil';
 import {
   AS,
   CONTENT_TYPE_TERM,
@@ -43,8 +46,9 @@ import {
   SOLID_META,
   XSD,
 } from '../util/Vocabularies';
-import type { DataAccessor } from './accessors/DataAccessor';
+import type { DataAccessor, RangeOptions } from './accessors/DataAccessor';
 import type { Conditions } from './conditions/Conditions';
+import { cleanPreferences, getTypeWeight } from './conversion/ConversionUtil';
 import type { ChangeMap, ResourceStore } from './ResourceStore';
 import namedNode = DataFactory.namedNode;
 
@@ -78,17 +82,35 @@ export class DataAccessorBasedStore implements ResourceStore {
   private readonly identifierStrategy: IdentifierStrategy;
   private readonly auxiliaryStrategy: AuxiliaryStrategy;
   private readonly metadataStrategy: AuxiliaryStrategy;
+  private readonly optimizeRange: boolean;
 
+  /**
+   * @param accessor - The accessor used to read/write the data.
+   * @param identifierStrategy - The strategy used to handle identifiers.
+   * @param auxiliaryStrategy - The strategy used to handle auxiliary resources.
+   * @param metadataStrategy - The strategy used to handle metadata resources.
+   * @param optimizeRange - Whether to push satisfiable byte ranges down to `accessor.getData`
+   *   instead of always reading the full stream and slicing it higher up.
+   *   This is only safe when (a) the configured `accessor` honours the `range` argument of `getData`
+   *   (e.g. {@link FileDataAccessor}), and (b) the outgoing conversion applied above this store is a
+   *   pure content-negotiation converter (it returns the stored representation unchanged whenever the
+   *   stored content-type already satisfies the request preferences, as the default `ChainedConverter`
+   *   does). When enabled, a range is only ever pushed down for cases where this store can prove from
+   *   metadata alone that no conversion will happen; every other case falls back to the full read.
+   *   Defaults to `false`, keeping the original behaviour.
+   */
   public constructor(
     accessor: DataAccessor,
     identifierStrategy: IdentifierStrategy,
     auxiliaryStrategy: AuxiliaryStrategy,
     metadataStrategy: AuxiliaryStrategy,
+    optimizeRange = false,
   ) {
     this.accessor = accessor;
     this.identifierStrategy = identifierStrategy;
     this.auxiliaryStrategy = auxiliaryStrategy;
     this.metadataStrategy = metadataStrategy;
+    this.optimizeRange = optimizeRange;
   }
 
   public async hasResource(identifier: ResourceIdentifier): Promise<boolean> {
@@ -107,7 +129,10 @@ export class DataAccessorBasedStore implements ResourceStore {
     }
   }
 
-  public async getRepresentation(identifier: ResourceIdentifier): Promise<Representation> {
+  public async getRepresentation(
+    identifier: ResourceIdentifier,
+    preferences?: RepresentationPreferences,
+  ): Promise<Representation> {
     this.validateIdentifier(identifier);
     let isMetadata = false;
 
@@ -157,10 +182,86 @@ export class DataAccessorBasedStore implements ResourceStore {
     if (isContainer || isMetadata) {
       representation = new BasicRepresentation(data, metadata, INTERNAL_QUADS);
     } else {
-      representation = new BasicRepresentation(await this.accessor.getData(identifier), metadata);
+      // If we can prove from metadata alone that no conversion will happen for this request,
+      // and a satisfiable byte range was requested, read only that window from the accessor.
+      // In every other case we read the full stream and let the higher slicing store handle the range,
+      // keeping the response byte-identical.
+      const range = this.getSeekRange(preferences, metadata);
+      if (range) {
+        metadata.set(SOLID_HTTP.terms.unit, 'bytes');
+        metadata.set(SOLID_HTTP.terms.start, toLiteral(range.start, XSD.terms.integer));
+        metadata.set(SOLID_HTTP.terms.end, toLiteral(range.end, XSD.terms.integer));
+        representation = new BasicRepresentation(await this.accessor.getData(identifier, range), metadata);
+      } else {
+        representation = new BasicRepresentation(await this.accessor.getData(identifier), metadata);
+      }
     }
 
     return representation;
+  }
+
+  /**
+   * Determines whether the given request can be served by pushing a byte range down to the accessor
+   * instead of reading the full stream and slicing it in a higher store (e.g. `BinarySliceResourceStore`).
+   *
+   * Returns the resolved, satisfiable inclusive byte range to request, or `undefined` to fall back
+   * to the full read. It only returns a range when ALL of the following hold, guaranteeing the response
+   * stays byte-identical to the full-read + slice path:
+   *  - Range optimization is enabled for this store (`optimizeRange`).
+   *  - The preferences contain a single `bytes` range with an explicit, non-negative `start` and `end`.
+   *    (Open-ended and suffix ranges are left to the slicing store, so its `defaultSliceSize` and
+   *    suffix handling remain the single source of truth.)
+   *  - No content conversion will happen: the stored content-type already satisfies the request at the
+   *    maximal requested weight, which is exactly the condition under which a `ChainedConverter` returns
+   *    the representation unchanged. `application/json` is excluded because a converter
+   *    (`DynamicJsonToTemplateConverter`) can transform matching JSON ahead of that decision.
+   *  - The range is satisfiable given the known size (`start < end < size`). Unsatisfiable ranges are
+   *    left to the slicing store so it produces the exact same `416` behaviour as before.
+   */
+  private getSeekRange(
+    preferences: RepresentationPreferences | undefined,
+    metadata: RepresentationMetadata,
+  ): RangeOptions | undefined {
+    if (!this.optimizeRange) {
+      return;
+    }
+    const range = preferences?.range;
+    if (!range || range.unit !== 'bytes' || range.parts.length !== 1) {
+      return;
+    }
+    const { start, end } = range.parts[0];
+    // Only explicit `start-end` ranges (both defined, non-negative) are handled here.
+    if (typeof start !== 'number' || typeof end !== 'number' || start < 0) {
+      return;
+    }
+
+    // The stored content-type must already satisfy the request without conversion.
+    const { contentType } = metadata;
+    if (typeof contentType !== 'string' || contentType === APPLICATION_JSON) {
+      return;
+    }
+    let weight: number;
+    let maxWeight: number;
+    try {
+      const cleaned = cleanPreferences(preferences?.type);
+      maxWeight = Math.max(...Object.values(cleaned));
+      weight = getTypeWeight(contentType, cleaned);
+    } catch {
+      // `getTypeWeight` throws on an unexpected media type; fall back to the full read.
+      return;
+    }
+    // Identical to the `ChainedConverter` "no conversion needed" decision:
+    // the stored type is (one of) the best match(es) for the preferences.
+    if (weight <= 0 || weight < maxWeight) {
+      return;
+    }
+
+    // Only push down satisfiable ranges; unsatisfiable ones fall back so the slicing store throws 416.
+    const size = termToInt(metadata.get(POSIX.terms.size));
+    if (typeof size !== 'number' || start >= end || end >= size) {
+      return;
+    }
+    return { start, end };
   }
 
   public async addResource(container: ResourceIdentifier, representation: Representation, conditions?: Conditions):

--- a/src/storage/accessors/DataAccessor.ts
+++ b/src/storage/accessors/DataAccessor.ts
@@ -5,12 +5,10 @@ import type { ResourceIdentifier } from '../../http/representation/ResourceIdent
 import type { Guarded } from '../../util/GuardedStream';
 
 /**
- * A resolved, absolute byte range that can be requested from a {@link DataAccessor}.
+ * A resolved byte range that can be requested from a {@link DataAccessor}.
  * Both `start` and `end` are inclusive offsets, matching the semantics of
  * `fs.createReadStream(path, { start, end })` and of the HTTP `Range` header.
- *
- * The values are always fully resolved (non-negative, `start <= end`, `end < size`):
- * any relative/suffix/unsatisfiable range handling is done by the caller,
+ * Resolving relative, suffix, or unsatisfiable ranges is the responsibility of the caller,
  * so implementations only ever receive a concrete, satisfiable window.
  */
 export interface RangeOptions {
@@ -48,16 +46,12 @@ export interface DataAccessor {
    * Returns a data stream stored for the given identifier.
    * It can be assumed that the incoming identifier will always correspond to a document.
    *
-   * The optional `range` parameter is an additive, backwards-compatible hint:
-   * when provided, an implementation *may* return only the requested inclusive byte window
-   * (e.g. by seeking in the underlying storage) instead of the full stream.
-   * Implementations that support this MUST return exactly the bytes `[range.start, range.end]`.
-   * Implementations that do not support ranged reads MUST ignore the parameter
-   * and return the full stream; the caller then keeps its existing slicing behaviour,
-   * so ignoring the range never changes the response.
+   * The optional `range` asks for only the given inclusive byte window of the data,
+   * which implementations can provide more efficiently by seeking in the underlying storage.
+   * Implementations that do not support ranged reads can ignore it and return the full stream.
    *
    * @param identifier - Identifier for which the data is requested.
-   * @param range - Optional resolved byte range to return instead of the full stream.
+   * @param range - Optional byte range to return instead of the full stream.
    */
   getData: (identifier: ResourceIdentifier, range?: RangeOptions) => Promise<Guarded<Readable>>;
 

--- a/src/storage/accessors/DataAccessor.ts
+++ b/src/storage/accessors/DataAccessor.ts
@@ -5,6 +5,26 @@ import type { ResourceIdentifier } from '../../http/representation/ResourceIdent
 import type { Guarded } from '../../util/GuardedStream';
 
 /**
+ * A resolved, absolute byte range that can be requested from a {@link DataAccessor}.
+ * Both `start` and `end` are inclusive offsets, matching the semantics of
+ * `fs.createReadStream(path, { start, end })` and of the HTTP `Range` header.
+ *
+ * The values are always fully resolved (non-negative, `start <= end`, `end < size`):
+ * any relative/suffix/unsatisfiable range handling is done by the caller,
+ * so implementations only ever receive a concrete, satisfiable window.
+ */
+export interface RangeOptions {
+  /**
+   * The first byte offset to return (inclusive).
+   */
+  start: number;
+  /**
+   * The last byte offset to return (inclusive).
+   */
+  end: number;
+}
+
+/**
  * A DataAccessor is the building block closest to the actual data storage.
  * It should not worry about most Solid logic, most of that will be handled before it is called.
  * There are a few things it still needs to do, and it is very important every implementation does this:
@@ -28,9 +48,18 @@ export interface DataAccessor {
    * Returns a data stream stored for the given identifier.
    * It can be assumed that the incoming identifier will always correspond to a document.
    *
+   * The optional `range` parameter is an additive, backwards-compatible hint:
+   * when provided, an implementation *may* return only the requested inclusive byte window
+   * (e.g. by seeking in the underlying storage) instead of the full stream.
+   * Implementations that support this MUST return exactly the bytes `[range.start, range.end]`.
+   * Implementations that do not support ranged reads MUST ignore the parameter
+   * and return the full stream; the caller then keeps its existing slicing behaviour,
+   * so ignoring the range never changes the response.
+   *
    * @param identifier - Identifier for which the data is requested.
+   * @param range - Optional resolved byte range to return instead of the full stream.
    */
-  getData: (identifier: ResourceIdentifier) => Promise<Guarded<Readable>>;
+  getData: (identifier: ResourceIdentifier, range?: RangeOptions) => Promise<Guarded<Readable>>;
 
   /**
    * Returns the metadata corresponding to the identifier.

--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -17,7 +17,7 @@ import { addResourceMetadata, updateModifiedDate } from '../../util/ResourceUtil
 import { toLiteral, toNamedTerm } from '../../util/TermUtil';
 import { CONTENT_TYPE_TERM, DC, IANA, LDP, POSIX, RDF, SOLID_META, XSD } from '../../util/Vocabularies';
 import type { FileIdentifierMapper, ResourceLink } from '../mapping/FileIdentifierMapper';
-import type { DataAccessor } from './DataAccessor';
+import type { DataAccessor, RangeOptions } from './DataAccessor';
 
 /**
  * DataAccessor that uses the file system to store documents as files and containers as folders.
@@ -43,12 +43,21 @@ export class FileDataAccessor implements DataAccessor {
   /**
    * Will return data stream directly to the file corresponding to the resource.
    * Will throw NotFoundHttpError if the input is a container.
+   *
+   * When a `range` is provided, only that inclusive byte window is read from the file
+   * by seeking with `createReadStream(path, { start, end })`,
+   * avoiding reading (and discarding) the bytes before `start`.
+   * The caller is responsible for only passing satisfiable ranges
+   * and for setting the corresponding response metadata.
    */
-  public async getData(identifier: ResourceIdentifier): Promise<Guarded<Readable>> {
+  public async getData(identifier: ResourceIdentifier, range?: RangeOptions): Promise<Guarded<Readable>> {
     const link = await this.resourceMapper.mapUrlToFilePath(identifier, false);
     const stats = await this.getStats(link.filePath);
 
     if (stats.isFile()) {
+      if (range) {
+        return guardStream(createReadStream(link.filePath, { start: range.start, end: range.end }));
+      }
       return guardStream(createReadStream(link.filePath));
     }
 

--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -43,12 +43,6 @@ export class FileDataAccessor implements DataAccessor {
   /**
    * Will return data stream directly to the file corresponding to the resource.
    * Will throw NotFoundHttpError if the input is a container.
-   *
-   * When a `range` is provided, only that inclusive byte window is read from the file
-   * by seeking with `createReadStream(path, { start, end })`,
-   * avoiding reading (and discarding) the bytes before `start`.
-   * The caller is responsible for only passing satisfiable ranges
-   * and for setting the corresponding response metadata.
    */
   public async getData(identifier: ResourceIdentifier, range?: RangeOptions): Promise<Guarded<Readable>> {
     const link = await this.resourceMapper.mapUrlToFilePath(identifier, false);

--- a/test/integration/LdpHandlerWithoutAuth.test.ts
+++ b/test/integration/LdpHandlerWithoutAuth.test.ts
@@ -778,4 +778,37 @@ describe.each(stores)('An LDP handler allowing all requests %s', (name, { storeC
     response = await fetch(resourceUrl, { headers: { range: 'bytes=5-15' }});
     expect(response.status).toBe(416);
   });
+
+  it('returns identical windows for explicit byte ranges.', async(): Promise<void> => {
+    const resourceUrl = joinUrl(baseUrl, 'range-windows');
+    const body = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    await putResource(resourceUrl, { contentType: 'text/plain', body });
+
+    // Start-of-file, mid-file, and end-of-file windows. On the file backend these use the seek path,
+    // on the in-memory backend the slice path; both must produce byte-identical responses.
+    const windows: [number, number][] = [[ 0, 5 ], [ 10, 15 ], [ 20, 25 ], [ 24, 25 ], [ 0, 25 ]];
+    for (const [ start, end ] of windows) {
+      const response = await fetch(resourceUrl, { headers: { range: `bytes=${start}-${end}` }});
+      expect(response.status).toBe(206);
+      expect(response.headers.get('content-range')).toBe(`bytes ${start}-${end}/${body.length}`);
+      expect(response.headers.get('content-length')).toBe(`${end - start + 1}`);
+      await expect(response.text()).resolves.toBe(body.slice(start, end + 1));
+    }
+  });
+
+  it('applies byte ranges to the converted representation, not the stored bytes.', async(): Promise<void> => {
+    const resourceUrl = joinUrl(baseUrl, 'convert-range');
+    await putResource(resourceUrl, { contentType: 'text/turtle', body: '<http://ex/s> <http://ex/p> <http://ex/o>.' });
+
+    // Full converted (turtle -> n-triples) representation.
+    const fullResponse = await fetch(resourceUrl, { headers: { accept: 'application/n-triples' }});
+    expect(fullResponse.status).toBe(200);
+    const fullConverted = await fullResponse.text();
+    expect(fullConverted.length).toBeGreaterThan(5);
+
+    // A ranged request with a conversion must slice the CONVERTED output (seek path must not apply here).
+    const response = await fetch(resourceUrl, { headers: { accept: 'application/n-triples', range: 'bytes=0-4' }});
+    expect(response.status).toBe(206);
+    await expect(response.text()).resolves.toBe(fullConverted.slice(0, 5));
+  });
 });

--- a/test/integration/LdpHandlerWithoutAuth.test.ts
+++ b/test/integration/LdpHandlerWithoutAuth.test.ts
@@ -784,8 +784,7 @@ describe.each(stores)('An LDP handler allowing all requests %s', (name, { storeC
     const body = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     await putResource(resourceUrl, { contentType: 'text/plain', body });
 
-    // Start-of-file, mid-file, and end-of-file windows. On the file backend these use the seek path,
-    // on the in-memory backend the slice path; both must produce byte-identical responses.
+    // Start-of-file, mid-file, and end-of-file windows
     const windows: [number, number][] = [[ 0, 5 ], [ 10, 15 ], [ 20, 25 ], [ 24, 25 ], [ 0, 25 ]];
     for (const [ start, end ] of windows) {
       const response = await fetch(resourceUrl, { headers: { range: `bytes=${start}-${end}` }});
@@ -800,13 +799,12 @@ describe.each(stores)('An LDP handler allowing all requests %s', (name, { storeC
     const resourceUrl = joinUrl(baseUrl, 'convert-range');
     await putResource(resourceUrl, { contentType: 'text/turtle', body: '<http://ex/s> <http://ex/p> <http://ex/o>.' });
 
-    // Full converted (turtle -> n-triples) representation.
     const fullResponse = await fetch(resourceUrl, { headers: { accept: 'application/n-triples' }});
     expect(fullResponse.status).toBe(200);
     const fullConverted = await fullResponse.text();
     expect(fullConverted.length).toBeGreaterThan(5);
 
-    // A ranged request with a conversion must slice the CONVERTED output (seek path must not apply here).
+    // The range has to slice the converted output, so the seek optimization can not apply here
     const response = await fetch(resourceUrl, { headers: { accept: 'application/n-triples', range: 'bytes=0-4' }});
     expect(response.status).toBe(206);
     await expect(response.text()).resolves.toBe(fullConverted.slice(0, 5));

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -73,7 +73,7 @@ class SimpleDataAccessor implements DataAccessor {
     this.checkExists(identifier);
     const data = this.data[identifier.path].data;
     if (range) {
-      // Mirror a range-honouring accessor (like FileDataAccessor) by returning only the requested window.
+      // Mirrors a range-honouring accessor such as the FileDataAccessor by returning only the requested window
       const buffer = await readableToString(data);
       return guardedStreamFrom(buffer.slice(range.start, range.end + 1));
     }
@@ -268,7 +268,7 @@ describe('A DataAccessorBasedStore', (): void => {
       } as Representation;
     }
 
-    // Asserts the range was NOT pushed down: full stream returned, no range metadata, no range passed to getData.
+    // Asserts the range was not pushed down: full stream returned, no range metadata, no range passed to getData.
     async function expectFullRead(result: Representation, body: string): Promise<void> {
       expect(result.metadata.has(SOLID_HTTP.terms.unit)).toBe(false);
       await expect(readableToString(result.data)).resolves.toBe(body);

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -8,8 +8,9 @@ import type { AuxiliaryStrategy } from '../../../src/http/auxiliary/AuxiliaryStr
 import { BasicRepresentation } from '../../../src/http/representation/BasicRepresentation';
 import type { Representation } from '../../../src/http/representation/Representation';
 import { RepresentationMetadata } from '../../../src/http/representation/RepresentationMetadata';
+import type { RepresentationPreferences } from '../../../src/http/representation/RepresentationPreferences';
 import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
-import type { DataAccessor } from '../../../src/storage/accessors/DataAccessor';
+import type { DataAccessor, RangeOptions } from '../../../src/storage/accessors/DataAccessor';
 import { DataAccessorBasedStore } from '../../../src/storage/DataAccessorBasedStore';
 import { INTERNAL_QUADS } from '../../../src/util/ContentTypes';
 import { BadRequestHttpError } from '../../../src/util/errors/BadRequestHttpError';
@@ -23,13 +24,30 @@ import type { Guarded } from '../../../src/util/GuardedStream';
 import { ContentType } from '../../../src/util/Header';
 import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
 import { trimTrailingSlashes } from '../../../src/util/PathUtil';
-import { guardedStreamFrom } from '../../../src/util/StreamUtil';
-import { AS, CONTENT_TYPE, DC, LDP, PIM, RDF, SOLID_AS, SOLID_HTTP, SOLID_META } from '../../../src/util/Vocabularies';
+import { guardedStreamFrom, readableToString } from '../../../src/util/StreamUtil';
+import { toLiteral } from '../../../src/util/TermUtil';
+import {
+  AS,
+  CONTENT_TYPE,
+  DC,
+  LDP,
+  PIM,
+  POSIX,
+  RDF,
+  SOLID_AS,
+  SOLID_HTTP,
+  SOLID_META,
+} from '../../../src/util/Vocabularies';
 import { SimpleSuffixStrategy } from '../../util/SimpleSuffixStrategy';
 
 const { namedNode, quad, literal } = DataFactory;
 
 const GENERATED_PREDICATE = namedNode('generated');
+
+// Preferences with a fixed satisfiable byte range and the given output type preferences.
+function rangeWithType(type: RepresentationPreferences['type']): RepresentationPreferences {
+  return { range: { unit: 'bytes', parts: [{ start: 2, end: 5 }]}, type };
+}
 
 class SimpleDataAccessor implements DataAccessor {
   public readonly data: Record<string, Representation> = {};
@@ -51,9 +69,15 @@ class SimpleDataAccessor implements DataAccessor {
     delete this.data[identifier.path];
   }
 
-  public async getData(identifier: ResourceIdentifier): Promise<Guarded<Readable>> {
+  public async getData(identifier: ResourceIdentifier, range?: RangeOptions): Promise<Guarded<Readable>> {
     this.checkExists(identifier);
-    return this.data[identifier.path].data;
+    const data = this.data[identifier.path].data;
+    if (range) {
+      // Mirror a range-honouring accessor (like FileDataAccessor) by returning only the requested window.
+      const buffer = await readableToString(data);
+      return guardedStreamFrom(buffer.slice(range.start, range.end + 1));
+    }
+    return data;
   }
 
   public async getMetadata(identifier: ResourceIdentifier): Promise<RepresentationMetadata> {
@@ -220,6 +244,190 @@ describe('A DataAccessorBasedStore', (): void => {
         ),
       );
       expect(result.metadata.contentType).toBe(INTERNAL_QUADS);
+    });
+  });
+
+  describe('getting a byte range of a Representation', (): void => {
+    const resourceID = { path: `${root}resource` };
+    let seekStore: DataAccessorBasedStore;
+    let getDataSpy: jest.SpyInstance;
+
+    // Stores a document with the given body/content-type and (unless omitted) a matching `posix:size`.
+    function storeResource(body: string, contentType: string | undefined = 'text/plain', size?: number): void {
+      const metadata = new RepresentationMetadata({ [RDF.type]: namedNode(LDP.Resource) });
+      metadata.identifier = namedNode(resourceID.path);
+      if (typeof contentType === 'string') {
+        metadata.contentType = contentType;
+      }
+      metadata.set(POSIX.terms.size, toLiteral(size ?? body.length, XSD.terms.integer));
+      accessor.data[resourceID.path] = {
+        binary: true,
+        data: guardedStreamFrom([ body ]),
+        metadata,
+        isEmpty: false,
+      } as Representation;
+    }
+
+    // Asserts the range was NOT pushed down: full stream returned, no range metadata, no range passed to getData.
+    async function expectFullRead(result: Representation, body: string): Promise<void> {
+      expect(result.metadata.has(SOLID_HTTP.terms.unit)).toBe(false);
+      await expect(readableToString(result.data)).resolves.toBe(body);
+      expect(getDataSpy).toHaveBeenLastCalledWith(resourceID);
+    }
+
+    beforeEach((): void => {
+      seekStore = new DataAccessorBasedStore(accessor, identifierStrategy, auxiliaryStrategy, metadataStrategy, true);
+      getDataSpy = jest.spyOn(accessor, 'getData');
+    });
+
+    it('pushes a satisfiable byte range down to the accessor and sets the range metadata.', async(): Promise<void> => {
+      storeResource('0123456789');
+      const result = await seekStore.getRepresentation(
+        resourceID,
+        { range: { unit: 'bytes', parts: [{ start: 2, end: 5 }]}},
+      );
+      await expect(readableToString(result.data)).resolves.toBe('2345');
+      expect(result.metadata.get(SOLID_HTTP.terms.unit)?.value).toBe('bytes');
+      expect(result.metadata.get(SOLID_HTTP.terms.start)?.value).toBe('2');
+      expect(result.metadata.get(SOLID_HTTP.terms.end)?.value).toBe('5');
+      expect(getDataSpy).toHaveBeenLastCalledWith(resourceID, { start: 2, end: 5 });
+    });
+
+    it('returns byte-identical windows to a full slice for many ranges.', async(): Promise<void> => {
+      const body = 'abcdefghijklmnopqrstuvwxyz';
+      const ranges: [number, number][] = [[ 0, 3 ], [ 0, 24 ], [ 10, 15 ], [ 22, 24 ], [ 5, 6 ], [ 24, 25 ]];
+      for (const [ start, end ] of ranges) {
+        storeResource(body);
+        const result = await seekStore.getRepresentation(
+          resourceID,
+          { range: { unit: 'bytes', parts: [{ start, end }]}},
+        );
+        // The seek window must equal the slice a top-level SliceStream would produce (inclusive end).
+        await expect(readableToString(result.data)).resolves.toBe(body.slice(start, end + 1));
+        expect(result.metadata.get(SOLID_HTTP.terms.start)?.value).toBe(`${start}`);
+        expect(result.metadata.get(SOLID_HTTP.terms.end)?.value).toBe(`${end}`);
+        expect(getDataSpy).toHaveBeenLastCalledWith(resourceID, { start, end });
+      }
+    });
+
+    it('does not seek when range optimization is disabled.', async(): Promise<void> => {
+      storeResource('0123456789');
+      // The default `store` is constructed without the optimizeRange flag.
+      const result = await store.getRepresentation(
+        resourceID,
+        { range: { unit: 'bytes', parts: [{ start: 2, end: 5 }]}},
+      );
+      await expectFullRead(result, '0123456789');
+    });
+
+    it('does not seek when there are no or non-byte range preferences.', async(): Promise<void> => {
+      storeResource('0123456789');
+      // No preferences at all.
+      await expectFullRead(await seekStore.getRepresentation(resourceID), '0123456789');
+      storeResource('0123456789');
+      // Empty preferences.
+      await expectFullRead(await seekStore.getRepresentation(resourceID, {}), '0123456789');
+      storeResource('0123456789');
+      // Non-bytes unit.
+      await expectFullRead(
+        await seekStore.getRepresentation(resourceID, { range: { unit: 'items', parts: [{ start: 2, end: 5 }]}}),
+        '0123456789',
+      );
+      storeResource('0123456789');
+      // Multipart range.
+      await expectFullRead(
+        await seekStore.getRepresentation(
+          resourceID,
+          { range: { unit: 'bytes', parts: [{ start: 0, end: 1 }, { start: 3, end: 4 }]}},
+        ),
+        '0123456789',
+      );
+    });
+
+    it('does not seek for open-ended, suffix or malformed ranges.', async(): Promise<void> => {
+      // Open-ended range (no `end`): left to the slicing store so `defaultSliceSize` stays authoritative.
+      storeResource('0123456789');
+      await expectFullRead(
+        await seekStore.getRepresentation(resourceID, { range: { unit: 'bytes', parts: [{ start: 2 }]}}),
+        '0123456789',
+      );
+      // Suffix range (negative start).
+      storeResource('0123456789');
+      await expectFullRead(
+        await seekStore.getRepresentation(resourceID, { range: { unit: 'bytes', parts: [{ start: -4, end: 5 }]}}),
+        '0123456789',
+      );
+      // Malformed range with a missing start.
+      storeResource('0123456789');
+      await expectFullRead(
+        await seekStore.getRepresentation(
+          resourceID,
+          { range: { unit: 'bytes', parts: [ { end: 5 } as any ]}},
+        ),
+        '0123456789',
+      );
+    });
+
+    it('does not seek when a conversion would happen.', async(): Promise<void> => {
+      // JSON is excluded because a converter can transform it ahead of the content-negotiation decision.
+      storeResource('0123456789', 'application/json');
+      await expectFullRead(
+        await seekStore.getRepresentation(resourceID, rangeWithType({ '*/*': 1 })),
+        '0123456789',
+      );
+
+      // Unexpected media type makes `getTypeWeight` throw; must fall back.
+      storeResource('0123456789', 'text/plain');
+      accessor.data[resourceID.path].metadata.set(CONTENT_TYPE_TERM, literal('nomedia'));
+      await expectFullRead(
+        await seekStore.getRepresentation(resourceID, rangeWithType({ '*/*': 1 })),
+        '0123456789',
+      );
+
+      // Stored type does not match the preferences at all (weight 0) so a conversion/406 would occur.
+      storeResource('0123456789', 'text/plain');
+      await expectFullRead(
+        await seekStore.getRepresentation(resourceID, rangeWithType({ 'image/png': 1 })),
+        '0123456789',
+      );
+
+      // Stored type matches but a different type is preferred more strongly, so a conversion would occur.
+      storeResource('0123456789', 'text/plain');
+      await expectFullRead(
+        await seekStore.getRepresentation(resourceID, rangeWithType({ 'text/plain': 0.5, 'text/html': 1 })),
+        '0123456789',
+      );
+    });
+
+    it('does not seek when the content-type is missing.', async(): Promise<void> => {
+      storeResource('0123456789', 'text/plain');
+      accessor.data[resourceID.path].metadata.removeAll(CONTENT_TYPE_TERM);
+      await expectFullRead(
+        await seekStore.getRepresentation(resourceID, { range: { unit: 'bytes', parts: [{ start: 2, end: 5 }]}}),
+        '0123456789',
+      );
+    });
+
+    it('falls back for unsatisfiable ranges so the slicing store 416s.', async(): Promise<void> => {
+      // Unknown size.
+      storeResource('0123456789', 'text/plain');
+      accessor.data[resourceID.path].metadata.removeAll(POSIX.terms.size);
+      await expectFullRead(
+        await seekStore.getRepresentation(resourceID, { range: { unit: 'bytes', parts: [{ start: 2, end: 5 }]}}),
+        '0123456789',
+      );
+      // Start >= end.
+      storeResource('0123456789');
+      await expectFullRead(
+        await seekStore.getRepresentation(resourceID, { range: { unit: 'bytes', parts: [{ start: 5, end: 5 }]}}),
+        '0123456789',
+      );
+      // End >= size.
+      storeResource('0123456789');
+      await expectFullRead(
+        await seekStore.getRepresentation(resourceID, { range: { unit: 'bytes', parts: [{ start: 0, end: 10 }]}}),
+        '0123456789',
+      );
     });
   });
 

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -70,6 +70,12 @@ describe('A FileDataAccessor', (): void => {
       await expect(readableToString(stream)).resolves.toBe('data');
     });
 
+    it('returns only the requested byte range when a range is provided.', async(): Promise<void> => {
+      cache.data = { resource: '0123456789' };
+      const stream = await accessor.getData({ path: `${base}resource` }, { start: 2, end: 5 });
+      await expect(readableToString(stream)).resolves.toBe('2345');
+    });
+
     it('throws an error if something else went wrong.', async(): Promise<void> => {
       jest.requireMock('fs-extra').stat = (): any => {
         throw new Error('error');

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -161,9 +161,15 @@ export function mockFileSystem(rootFilepath?: string, time?: Date): { data: any 
   }
 
   const mockFs = {
-    createReadStream(path: string): any {
+    createReadStream(path: string, options?: { start?: number; end?: number }): any {
       const { folder, name } = getFolder(path);
-      return Readable.from([ folder[name] ]);
+      const content = folder[name];
+      // Honour the inclusive `{ start, end }` byte range like the real `fs.createReadStream`.
+      if (options && typeof options.start === 'number' && typeof options.end === 'number' &&
+        typeof content === 'string') {
+        return Readable.from([ content.slice(options.start, options.end + 1) ]);
+      }
+      return Readable.from([ content ]);
     },
     createWriteStream(path: string): any {
       const { folder, name } = getFolder(path);
@@ -309,8 +315,8 @@ export function mockFileSystem(rootFilepath?: string, time?: Date): { data: any 
         return false;
       }
     },
-    createReadStream(path: string): any {
-      return mockFs.createReadStream(path);
+    createReadStream(path: string, options?: { start?: number; end?: number }): any {
+      return mockFs.createReadStream(path, options);
     },
     createWriteStream(path: string): any {
       return mockFs.createWriteStream(path);


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue describing the full-file read on ranged requests must be created before this is submitted to CommunitySolidServer (the template requires one).

#### ✍️ Description

For a `Range` request on a file resource, the backend reads the **whole file** (`FileDataAccessor.getData` → `createReadStream(filePath)`) and `BinarySliceResourceStore`'s `SliceStream` discards the bytes outside the window. For a window near the end of a large file this reads essentially the entire file just to throw it away — the classic media "seek to the end" case: a 64 KiB window at the end of a 64 MiB file reads all 67,108,864 bytes.

The read cannot simply move up to `BinarySliceResourceStore` (it sits outside the `LockingResourceStore` read lock, so re-opening the file there races a concurrent writer), and could not move down to the accessor either, because a `RepresentationConverter` sits between them and the convert-or-not decision was only made *after* the data was fetched. This PR makes that decision metadata-first, inside the lock:

1. `DataAccessor.getData` gains an optional `range` argument (new exported `RangeOptions`, resolved inclusive offsets). `FileDataAccessor` honours it with `createReadStream(path, { start, end })`; every other accessor ignores it and keeps returning the full stream (a one-parameter function is assignable to the two-parameter type, so they compile and behave identically with no changes).
2. `DataAccessorBasedStore` decides from metadata + preferences alone (both already available inside the read lock) whether the outgoing conversion is a no-op, and only then pushes the byte range down and sets the `SOLID_HTTP` unit/start/end metadata, which `BinarySliceResourceStore` already treats as "range applied". The seeked read happens exactly where the full read happened before.

A range is only pushed down when **all** of the following hold; every other case falls back to the current full-read + slice path, keeping responses byte-identical:

- `optimizeRange` is enabled: a new optional `DataAccessorBasedStore` constructor flag, default `false`, so all existing and custom configs are untouched. It is enabled only in `config/storage/backend/file.json`, where the accessor is `FileDataAccessor` and the out-converter is the standard `ChainedConverter` waterfall.
- It is a single `bytes` range with explicit, non-negative `start` and `end`. Open-ended `bytes=N-` and suffix `bytes=-N` stay with `BinarySliceResourceStore`, so its `defaultSliceSize` and suffix handling remain the single source of truth.
- No conversion will happen: `getTypeWeight(storedType, cleanPreferences(prefs.type))` equals the maximal preference weight and is `> 0`, using the same `ConversionUtil` primitives the converter uses. This is provably the `ChainedConverter` identity case: its no-op path starts at that weight, no path can exceed the max, `findBest` keeps the no-op path on ties, and `removeBadPaths` stops once the best weight is within 0.01 of the max — so the converter returns the same stream unchanged. `application/json` is excluded because `DynamicJsonToTemplateConverter` runs ahead of the `ChainedConverter` in the shipped configs and can transform matching JSON. The predicate only *under*-approximates "no conversion", which is safe: a false negative just falls back. An unexpected stored media type (where `getTypeWeight` throws) also falls back, so the converter raises the same error it does today.
- The range is satisfiable given the known `posix:size` (`start < end < size`). Unsatisfiable ranges fall back so `SliceStream` throws the exact same 416, rather than reproducing that logic in a second place.

**Alternative considered:** the converter could expose a "would this be a no-op?" query, so the store never has to assume anything about the converter stack above it. That is a larger interface change; the `optimizeRange` opt-in is the smaller mechanism, and is the one config-level assertion to review here.

**Behaviour equivalence evidence:**

- The existing "supports range requests" integration test runs via `describe.each` against both the in-memory backend (slice path) and the file backend (seek path).
- A new integration test asserts identical status / `Content-Range` / `Content-Length` / body for start-, mid-, and end-of-file windows across both backends; another asserts that a ranged request needing a conversion slices the *converted* output, proving the seek path correctly does not engage.
- New unit tests cover the seek branch and every fallback branch of the predicate; the full unit suite passes with the 100% `./src` coverage gate (`npm run test:unit`), and `npm run lint` and `npm run build` are clean.

**Measured effect** — deterministic byte counts, not wall-clock: a 64 KiB window at the end of a 64 MiB file, read through `FileDataAccessor.getData(range)` vs the current `getData()` + `SliceStream`:

| Path | Bytes read from disk | Window bytes |
| --- | --- | --- |
| Full read + `SliceStream` | 67,108,864 | identical |
| Seek (`getData` with range) | 65,536 | identical |

That is 1024× fewer bytes read. There is no committed benchmark command: the counts follow directly from the file and window sizes (the full-read path streams the whole file, the seek path reads only the window) and were confirmed by instrumenting the two read paths directly.

**Branch target and semver:** this changes the `DataAccessor` interface and default configuration behaviour, so per the contributing guide it should target the latest `versions/*` branch (`versions/next-major`), not `main` — it currently targets the fork's `main` for review only and needs retargeting on upstream submission. Intended semver level: **semver.major** by the checklist's definition (an interface and config-behaviour change), though the change is additive and existing `DataAccessor` implementations stay source-compatible, so semver.minor is arguable — maintainer's call (contributors cannot set the labels).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
