### PR TITLE
perf: Skip data fetch for conditional requests that resolve to 304

### DIFF
--- a/config/storage/backend/file.json
+++ b/config/storage/backend/file.json
@@ -12,7 +12,8 @@
       "auxiliaryStrategy": { "@id": "urn:solid-server:default:AuxiliaryStrategy" },
       "accessor": { "@id": "urn:solid-server:default:FileDataAccessor" },
       "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" },
-      "optimizeRange": true
+      "optimizeRange": true,
+      "eTagHandler": { "@id": "urn:solid-server:default:ETagHandler" }
     }
   ]
 }

--- a/config/storage/backend/memory.json
+++ b/config/storage/backend/memory.json
@@ -11,7 +11,8 @@
       "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },
       "auxiliaryStrategy": { "@id": "urn:solid-server:default:AuxiliaryStrategy" },
       "accessor": { "@id": "urn:solid-server:default:MemoryDataAccessor" },
-      "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" }
+      "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" },
+      "eTagHandler": { "@id": "urn:solid-server:default:ETagHandler" }
     }
   ]
 }

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -18,6 +18,7 @@ import { ForbiddenHttpError } from '../util/errors/ForbiddenHttpError';
 import { MethodNotAllowedHttpError } from '../util/errors/MethodNotAllowedHttpError';
 import { NotFoundHttpError } from '../util/errors/NotFoundHttpError';
 import { NotImplementedHttpError } from '../util/errors/NotImplementedHttpError';
+import type { NotModifiedHttpError } from '../util/errors/NotModifiedHttpError';
 import { PreconditionFailedHttpError } from '../util/errors/PreconditionFailedHttpError';
 import type { IdentifierStrategy } from '../util/identifiers/IdentifierStrategy';
 import { concat } from '../util/IterableUtil';
@@ -30,7 +31,7 @@ import {
   trimTrailingSlashes,
 } from '../util/PathUtil';
 import { termToInt } from '../util/QuadUtil';
-import { addResourceMetadata, updateModifiedDate } from '../util/ResourceUtil';
+import { addResourceMetadata, getConditionalNotModifiedError, updateModifiedDate } from '../util/ResourceUtil';
 import { toLiteral } from '../util/TermUtil';
 import {
   AS,
@@ -48,6 +49,7 @@ import {
 } from '../util/Vocabularies';
 import type { DataAccessor, RangeOptions } from './accessors/DataAccessor';
 import type { Conditions } from './conditions/Conditions';
+import type { ETagHandler } from './conditions/ETagHandler';
 import { cleanPreferences, getTypeWeight } from './conversion/ConversionUtil';
 import type { ChangeMap, ResourceStore } from './ResourceStore';
 import namedNode = DataFactory.namedNode;
@@ -83,6 +85,7 @@ export class DataAccessorBasedStore implements ResourceStore {
   private readonly auxiliaryStrategy: AuxiliaryStrategy;
   private readonly metadataStrategy: AuxiliaryStrategy;
   private readonly optimizeRange: boolean;
+  private readonly eTagHandler?: ETagHandler;
 
   /**
    * @param accessor - The accessor used to read/write the data.
@@ -98,6 +101,13 @@ export class DataAccessorBasedStore implements ResourceStore {
    *   does). When enabled, a range is only ever pushed down for cases where this store can prove from
    *   metadata alone that no conversion will happen; every other case falls back to the full read.
    *   Defaults to `false`, keeping the original behaviour.
+   * @param eTagHandler - Enables answering conditional requests that resolve to "304 Not Modified"
+   *   from metadata alone, skipping the `accessor.getData` call (and the file open it entails).
+   *   This is only attempted when this store can prove from metadata alone that no conversion will
+   *   happen, so the served content-type equals the stored one and the ETag is fully determined by
+   *   the metadata already read; every other case falls back to the full read + post-conversion
+   *   condition check, keeping the response byte-identical. The same requirement (b) as `optimizeRange`
+   *   applies. When omitted, no such requests are short-circuited, keeping the original behaviour.
    */
   public constructor(
     accessor: DataAccessor,
@@ -105,12 +115,14 @@ export class DataAccessorBasedStore implements ResourceStore {
     auxiliaryStrategy: AuxiliaryStrategy,
     metadataStrategy: AuxiliaryStrategy,
     optimizeRange = false,
+    eTagHandler?: ETagHandler,
   ) {
     this.accessor = accessor;
     this.identifierStrategy = identifierStrategy;
     this.auxiliaryStrategy = auxiliaryStrategy;
     this.metadataStrategy = metadataStrategy;
     this.optimizeRange = optimizeRange;
+    this.eTagHandler = eTagHandler;
   }
 
   public async hasResource(identifier: ResourceIdentifier): Promise<boolean> {
@@ -132,6 +144,7 @@ export class DataAccessorBasedStore implements ResourceStore {
   public async getRepresentation(
     identifier: ResourceIdentifier,
     preferences?: RepresentationPreferences,
+    conditions?: Conditions,
   ): Promise<Representation> {
     this.validateIdentifier(identifier);
     let isMetadata = false;
@@ -182,6 +195,13 @@ export class DataAccessorBasedStore implements ResourceStore {
     if (isContainer || isMetadata) {
       representation = new BasicRepresentation(data, metadata, INTERNAL_QUADS);
     } else {
+      // If this is a conditional request that we can prove will resolve to "304 Not Modified" without
+      // any content conversion, answer it from the metadata we already have and skip opening the data.
+      const notModified = this.getConditionalNotModified(preferences, metadata, conditions);
+      if (notModified) {
+        throw notModified;
+      }
+
       // If we can prove from metadata alone that no conversion will happen for this request,
       // and a satisfiable byte range was requested, read only that window from the accessor.
       // In every other case we read the full stream and let the higher slicing store handle the range,
@@ -236,23 +256,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     }
 
     // The stored content-type must already satisfy the request without conversion.
-    const { contentType } = metadata;
-    if (typeof contentType !== 'string' || contentType === APPLICATION_JSON) {
-      return;
-    }
-    let weight: number;
-    let maxWeight: number;
-    try {
-      const cleaned = cleanPreferences(preferences?.type);
-      maxWeight = Math.max(...Object.values(cleaned));
-      weight = getTypeWeight(contentType, cleaned);
-    } catch {
-      // `getTypeWeight` throws on an unexpected media type; fall back to the full read.
-      return;
-    }
-    // Identical to the `ChainedConverter` "no conversion needed" decision:
-    // the stored type is (one of) the best match(es) for the preferences.
-    if (weight <= 0 || weight < maxWeight) {
+    if (!this.servedWithoutConversion(preferences, metadata)) {
       return;
     }
 
@@ -262,6 +266,74 @@ export class DataAccessorBasedStore implements ResourceStore {
       return;
     }
     return { start, end };
+  }
+
+  /**
+   * Determines whether a conditional request can be answered with a "304 Not Modified" response using
+   * only the metadata that has already been read, allowing the `accessor.getData` call to be skipped.
+   *
+   * Returns the {@link NotModifiedHttpError} to throw, or `undefined` to continue with the normal read.
+   * A 304 is only returned early when ALL of the following hold, guaranteeing the response stays
+   * byte-identical to the response the post-conversion condition check ({@link assertReadConditions})
+   * would produce for the same request:
+   *  - An {@link ETagHandler} was provided to this store (the optimization is opt-in).
+   *  - The request carries conditions (e.g. an `If-None-Match` / `If-Modified-Since` header).
+   *  - No byte range was requested. A range would add `Content-Range` metadata to the response in the
+   *    full-read path, so ranged conditional requests are left to that path.
+   *  - No content conversion will happen ({@link servedWithoutConversion}), so the served content-type
+   *    equals the stored one and the ETag is fully determined by the metadata we already have.
+   *  - The conditions do not match the metadata, i.e. the request actually resolves to a 304.
+   *
+   * The exact same ETag/condition logic (`getConditionalNotModifiedError`) that the operation handler
+   * applies after conversion is reused here, so the ETag and the 304-vs-200 decision are identical.
+   */
+  private getConditionalNotModified(
+    preferences: RepresentationPreferences | undefined,
+    metadata: RepresentationMetadata,
+    conditions?: Conditions,
+  ): NotModifiedHttpError | undefined {
+    if (!this.eTagHandler || !conditions) {
+      return;
+    }
+    // A byte range would add Content-Range metadata to the response in the full-read path,
+    // so ranged conditional requests are left to that path to stay byte-identical.
+    if (typeof preferences?.range !== 'undefined') {
+      return;
+    }
+    if (!this.servedWithoutConversion(preferences, metadata)) {
+      return;
+    }
+    return getConditionalNotModifiedError(metadata, this.eTagHandler, conditions);
+  }
+
+  /**
+   * Determines from metadata alone whether the outgoing content negotiation will be a no-op for the
+   * given request: the stored content-type already satisfies the request preferences at the maximal
+   * requested weight. This is exactly the condition under which the default `ChainedConverter` returns
+   * the stored representation unchanged, so the served content-type equals the stored one.
+   *
+   * `application/json` is excluded because a converter (`DynamicJsonToTemplateConverter`) can transform
+   * matching JSON ahead of that decision.
+   */
+  private servedWithoutConversion(
+    preferences: RepresentationPreferences | undefined,
+    metadata: RepresentationMetadata,
+  ): boolean {
+    const { contentType } = metadata;
+    if (typeof contentType !== 'string' || contentType === APPLICATION_JSON) {
+      return false;
+    }
+    try {
+      const cleaned = cleanPreferences(preferences?.type);
+      const maxWeight = Math.max(...Object.values(cleaned));
+      const weight = getTypeWeight(contentType, cleaned);
+      // Identical to the `ChainedConverter` "no conversion needed" decision:
+      // the stored type is (one of) the best match(es) for the preferences.
+      return weight > 0 && weight >= maxWeight;
+    } catch {
+      // `getTypeWeight` throws on an unexpected media type; treat it as "a conversion might happen".
+      return false;
+    }
   }
 
   public async addResource(container: ResourceIdentifier, representation: Representation, conditions?: Conditions):

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -102,12 +102,9 @@ export class DataAccessorBasedStore implements ResourceStore {
    *   metadata alone that no conversion will happen; every other case falls back to the full read.
    *   Defaults to `false`, keeping the original behaviour.
    * @param eTagHandler - Enables answering conditional requests that resolve to "304 Not Modified"
-   *   from metadata alone, skipping the `accessor.getData` call (and the file open it entails).
-   *   This is only attempted when this store can prove from metadata alone that no conversion will
-   *   happen, so the served content-type equals the stored one and the ETag is fully determined by
-   *   the metadata already read; every other case falls back to the full read + post-conversion
-   *   condition check, keeping the response byte-identical. The same requirement (b) as `optimizeRange`
-   *   applies. When omitted, no such requests are short-circuited, keeping the original behaviour.
+   *   from metadata alone, skipping the `accessor.getData` call.
+   *   Requirement (b) above applies. When omitted, such requests are not short-circuited,
+   *   keeping the original behaviour.
    */
   public constructor(
     accessor: DataAccessor,
@@ -195,8 +192,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     if (isContainer || isMetadata) {
       representation = new BasicRepresentation(data, metadata, INTERNAL_QUADS);
     } else {
-      // If this is a conditional request that we can prove will resolve to "304 Not Modified" without
-      // any content conversion, answer it from the metadata we already have and skip opening the data.
+      // Answer a conditional request from metadata alone when it provably resolves to a 304 without conversion.
       const notModified = this.getConditionalNotModified(preferences, metadata, conditions);
       if (notModified) {
         throw notModified;
@@ -269,23 +265,11 @@ export class DataAccessorBasedStore implements ResourceStore {
   }
 
   /**
-   * Determines whether a conditional request can be answered with a "304 Not Modified" response using
-   * only the metadata that has already been read, allowing the `accessor.getData` call to be skipped.
-   *
-   * Returns the {@link NotModifiedHttpError} to throw, or `undefined` to continue with the normal read.
-   * A 304 is only returned early when ALL of the following hold, guaranteeing the response stays
-   * byte-identical to the response the post-conversion condition check ({@link assertReadConditions})
-   * would produce for the same request:
-   *  - An {@link ETagHandler} was provided to this store (the optimization is opt-in).
-   *  - The request carries conditions (e.g. an `If-None-Match` / `If-Modified-Since` header).
-   *  - No byte range was requested. A range would add `Content-Range` metadata to the response in the
-   *    full-read path, so ranged conditional requests are left to that path.
-   *  - No content conversion will happen ({@link servedWithoutConversion}), so the served content-type
-   *    equals the stored one and the ETag is fully determined by the metadata we already have.
-   *  - The conditions do not match the metadata, i.e. the request actually resolves to a 304.
-   *
-   * The exact same ETag/condition logic (`getConditionalNotModifiedError`) that the operation handler
-   * applies after conversion is reused here, so the ETag and the 304-vs-200 decision are identical.
+   * Determines whether a conditional request resolves to "304 Not Modified" using only the metadata
+   * that was already read, so the `accessor.getData` call can be skipped.
+   * The 304 is only generated when no conversion will happen and no range was requested,
+   * since only then does that metadata fully determine the ETag and the response headers;
+   * every other case returns `undefined` so the normal read and condition check happen.
    */
   private getConditionalNotModified(
     preferences: RepresentationPreferences | undefined,
@@ -295,8 +279,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     if (!this.eTagHandler || !conditions) {
       return;
     }
-    // A byte range would add Content-Range metadata to the response in the full-read path,
-    // so ranged conditional requests are left to that path to stay byte-identical.
+    // Ranged requests are left to the full read, which adds the Content-Range metadata to the response.
     if (typeof preferences?.range !== 'undefined') {
       return;
     }
@@ -307,11 +290,8 @@ export class DataAccessorBasedStore implements ResourceStore {
   }
 
   /**
-   * Determines from metadata alone whether the outgoing content negotiation will be a no-op for the
-   * given request: the stored content-type already satisfies the request preferences at the maximal
-   * requested weight. This is exactly the condition under which the default `ChainedConverter` returns
-   * the stored representation unchanged, so the served content-type equals the stored one.
-   *
+   * Determines from metadata alone whether the given request will be served without content conversion,
+   * so the served content-type equals the stored one.
    * `application/json` is excluded because a converter (`DynamicJsonToTemplateConverter`) can transform
    * matching JSON ahead of that decision.
    */

--- a/src/storage/IndexRepresentationStore.ts
+++ b/src/storage/IndexRepresentationStore.ts
@@ -45,10 +45,8 @@ export class IndexRepresentationStore extends PassthroughStore {
     if (isContainerIdentifier(identifier) && this.matchesPreferences(preferences)) {
       try {
         const indexIdentifier = { path: `${identifier.path}${this.indexName}` };
-        // The conditions are deliberately not forwarded to these sub-reads: this store composes a new
-        // representation (the container metadata with the index content-type), so the conditional
-        // "304 Not Modified" decision must be made against that composed metadata by the caller, not
-        // against the individual index/container reads (which may have a different last-modified date).
+        // Conditions are not forwarded to these reads: this store composes a new representation,
+        // so the caller has to make the "304 Not Modified" decision against the composed metadata.
         const index = await this.source.getRepresentation(indexIdentifier, preferences);
         // We only care about the container metadata so preferences don't matter
         const container = await this.source.getRepresentation(identifier, {});

--- a/src/storage/IndexRepresentationStore.ts
+++ b/src/storage/IndexRepresentationStore.ts
@@ -45,9 +45,13 @@ export class IndexRepresentationStore extends PassthroughStore {
     if (isContainerIdentifier(identifier) && this.matchesPreferences(preferences)) {
       try {
         const indexIdentifier = { path: `${identifier.path}${this.indexName}` };
-        const index = await this.source.getRepresentation(indexIdentifier, preferences, conditions);
+        // The conditions are deliberately not forwarded to these sub-reads: this store composes a new
+        // representation (the container metadata with the index content-type), so the conditional
+        // "304 Not Modified" decision must be made against that composed metadata by the caller, not
+        // against the individual index/container reads (which may have a different last-modified date).
+        const index = await this.source.getRepresentation(indexIdentifier, preferences);
         // We only care about the container metadata so preferences don't matter
-        const container = await this.source.getRepresentation(identifier, {}, conditions);
+        const container = await this.source.getRepresentation(identifier, {});
         container.data.destroy();
 
         // Uses the container metadata but with the index content-type.

--- a/src/util/ResourceUtil.ts
+++ b/src/util/ResourceUtil.ts
@@ -73,17 +73,9 @@ export async function cloneRepresentation(representation: Representation): Promi
  * Determines whether the given conditions and metadata result in a "304 Not Modified" response,
  * without reading or modifying any data.
  *
- * If the conditions are defined and do not match the metadata, a {@link NotModifiedHttpError} is
- * returned carrying the resource ETag and a copy of the metadata, so that the 304 response sends
- * exactly the same headers as a full response would. In every other case `undefined` is returned,
- * meaning a normal response should be sent.
- *
  * This uses the strict conditions check which takes the content type into account;
  * therefore, this should only be called once the output content type is certain:
  * either after content negotiation, or when it is known that no conversion will happen.
- *
- * Unlike {@link assertReadConditions}, this function does not touch any data stream and does not modify
- * the given metadata, so it is safe to call before the data of a representation has been fetched.
  *
  * @param metadata - The metadata to compare the conditions against.
  * @param eTagHandler - Used to generate the ETag to return with the 304 response.

--- a/src/util/ResourceUtil.ts
+++ b/src/util/ResourceUtil.ts
@@ -70,6 +70,48 @@ export async function cloneRepresentation(representation: Representation): Promi
 }
 
 /**
+ * Determines whether the given conditions and metadata result in a "304 Not Modified" response,
+ * without reading or modifying any data.
+ *
+ * If the conditions are defined and do not match the metadata, a {@link NotModifiedHttpError} is
+ * returned carrying the resource ETag and a copy of the metadata, so that the 304 response sends
+ * exactly the same headers as a full response would. In every other case `undefined` is returned,
+ * meaning a normal response should be sent.
+ *
+ * This uses the strict conditions check which takes the content type into account;
+ * therefore, this should only be called once the output content type is certain:
+ * either after content negotiation, or when it is known that no conversion will happen.
+ *
+ * Unlike {@link assertReadConditions}, this function does not touch any data stream and does not modify
+ * the given metadata, so it is safe to call before the data of a representation has been fetched.
+ *
+ * @param metadata - The metadata to compare the conditions against.
+ * @param eTagHandler - Used to generate the ETag to return with the 304 response.
+ * @param conditions - The conditions to assert.
+ *
+ * @returns A {@link NotModifiedHttpError} to return if the request resolves to a 304, `undefined` otherwise.
+ */
+export function getConditionalNotModifiedError(
+  metadata: RepresentationMetadata,
+  eTagHandler: ETagHandler,
+  conditions?: Conditions,
+): NotModifiedHttpError | undefined {
+  if (conditions && !conditions.matchesMetadata(metadata, true)) {
+    const error = new NotModifiedHttpError(eTagHandler.getETag(metadata));
+
+    // From RFC 9111:
+    // > the cache MUST add each header field in the provided response to the stored response,
+    // > replacing field values that are already present
+    // So we need to make sure to send either no partial headers, or the exact same headers.
+    // By adding the metadata of the original resource here, we ensure we send the same headers.
+    error.metadata.identifier = metadata.identifier;
+    error.metadata.addQuads(metadata.quads());
+
+    return error;
+  }
+}
+
+/**
  * Verify whether the given {@link Representation} matches the given conditions.
  * If true, add the corresponding ETag to the body metadata.
  * If not, destroy the data stream and throw a {@link NotModifiedHttpError} with the same ETag.
@@ -87,20 +129,10 @@ export async function cloneRepresentation(representation: Representation): Promi
  * @param conditions - The conditions to assert.
  */
 export function assertReadConditions(body: Representation, eTagHandler: ETagHandler, conditions?: Conditions): void {
-  const eTag = eTagHandler.getETag(body.metadata);
-  if (conditions && !conditions.matchesMetadata(body.metadata, true)) {
+  const error = getConditionalNotModifiedError(body.metadata, eTagHandler, conditions);
+  if (error) {
     body.data.destroy();
-    const error = new NotModifiedHttpError(eTag);
-
-    // From RFC 9111:
-    // > the cache MUST add each header field in the provided response to the stored response,
-    // > replacing field values that are already present
-    // So we need to make sure to send either no partial headers, or the exact same headers.
-    // By adding the metadata of the original resource here, we ensure we send the same headers.
-    error.metadata.identifier = body.metadata.identifier;
-    error.metadata.addQuads(body.metadata.quads());
-
     throw error;
   }
-  body.metadata.set(HH.terms.etag, eTag);
+  body.metadata.set(HH.terms.etag, eTagHandler.getETag(body.metadata));
 }

--- a/test/integration/Conditions.test.ts
+++ b/test/integration/Conditions.test.ts
@@ -220,8 +220,7 @@ describe.each(stores)('A server supporting conditions with %s', (name, { storeCo
   });
 
   it('returns a byte-identical 304 for a non-converted document.', async(): Promise<void> => {
-    // A regular document served without conversion: this exercises the metadata-first 304 skip path
-    // (the store answers from metadata alone without opening the data), unlike the container cases above.
+    // A regular document served without conversion, so the store can answer the 304 from metadata alone.
     const documentUrl = `${baseUrl}conditional.txt`;
     await putResource(documentUrl, { contentType: 'text/plain', body: 'CONTENT' });
 

--- a/test/integration/Conditions.test.ts
+++ b/test/integration/Conditions.test.ts
@@ -219,6 +219,44 @@ describe.each(stores)('A server supporting conditions with %s', (name, { storeCo
     expect(response.status).toBe(200);
   });
 
+  it('returns a byte-identical 304 for a non-converted document.', async(): Promise<void> => {
+    // A regular document served without conversion: this exercises the metadata-first 304 skip path
+    // (the store answers from metadata alone without opening the data), unlike the container cases above.
+    const documentUrl = `${baseUrl}conditional.txt`;
+    await putResource(documentUrl, { contentType: 'text/plain', body: 'CONTENT' });
+
+    // Full GET to capture the ETag and the full set of response headers.
+    let response = await getResource(documentUrl);
+    const eTag = response.headers.get('ETag');
+    expect(typeof eTag).toBe('string');
+    const originalHeaders = extractHeadersObject(response);
+
+    // Conditional GET whose ETag matches: must resolve to a byte-identical 304 with no body.
+    response = await fetch(documentUrl, { method: 'GET', headers: { 'if-none-match': eTag! }});
+    expect(response.status).toBe(304);
+    expect(response.headers.get('etag')).toBe(eTag);
+    await expect(response.text()).resolves.toBe('');
+    const newGetHeaders = extractHeadersObject(response);
+    // Date field shouldn't be the same
+    delete newGetHeaders.date;
+    expect(expect.objectContaining(newGetHeaders)).toEqual(originalHeaders);
+
+    // Same for a conditional HEAD.
+    response = await fetch(documentUrl, { method: 'HEAD', headers: { 'if-none-match': eTag! }});
+    expect(response.status).toBe(304);
+    expect(response.headers.get('etag')).toBe(eTag);
+    const newHeadHeaders = extractHeadersObject(response);
+    delete newHeadHeaders.date;
+    expect(expect.objectContaining(newHeadHeaders)).toEqual(originalHeaders);
+
+    // A non-matching conditional still returns the full 200 body.
+    response = await fetch(documentUrl, { method: 'GET', headers: { 'if-none-match': '"123456"' }});
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe('CONTENT');
+
+    await expect(deleteResource(documentUrl)).resolves.toBeUndefined();
+  });
+
   it('prevents operations if the "if-unmodified-since" header is before the modified date.', async(): Promise<void> => {
     const documentUrl = `${baseUrl}document3.txt`;
     // PUT

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -448,14 +448,13 @@ describe('A DataAccessorBasedStore', (): void => {
   describe('serving a conditional request that resolves to 304', (): void => {
     const resourceID = { path: `${root}resource` };
     const eTagHandler = new BasicETagHandler();
-    // A conditional request that always resolves to 304 (mismatch) resp. 200 (match).
+    // Conditions that never match resolve to a 304; conditions that match resolve to a 200.
     const notMatching: Conditions = { matchesMetadata: (): boolean => false };
     const matching: Conditions = { matchesMetadata: (): boolean => true };
     let conditionalStore: DataAccessorBasedStore;
     let getDataSpy: jest.SpyInstance;
 
-    // Stores a document with the given content-type and a fixed modified date, so it has a stable ETag,
-    // and returns its metadata (from which the expected ETag can be derived).
+    // Stores a document with the given content-type and a fixed modified date, so it has a stable ETag.
     function storeResource(contentType = 'text/plain'): RepresentationMetadata {
       const metadata = new RepresentationMetadata({ [RDF.type]: namedNode(LDP.Resource) });
       metadata.identifier = namedNode(resourceID.path);
@@ -490,7 +489,6 @@ describe('A DataAccessorBasedStore', (): void => {
       );
       expect(NotModifiedHttpError.isInstance(error)).toBe(true);
       expect(error.metadata.get(HH.terms.etag)?.value).toBe(eTagHandler.getETag(stored));
-      // The whole point of the optimization: the data was never read.
       expect(getDataSpy).not.toHaveBeenCalled();
     });
 
@@ -498,8 +496,7 @@ describe('A DataAccessorBasedStore', (): void => {
       storeResource();
       const preferences = { type: { 'text/plain': 1 }};
 
-      // Fetched path: the store without an ETagHandler returns the full representation,
-      // and the post-conversion condition check produces the 304, exactly as the operation handler does.
+      // Fetched path: a full read followed by the condition check, as the operation handler applies it.
       const body = await store.getRepresentation(resourceID, preferences);
       let fetched: NotModifiedHttpError;
       try {

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -11,6 +11,7 @@ import { RepresentationMetadata } from '../../../src/http/representation/Represe
 import type { RepresentationPreferences } from '../../../src/http/representation/RepresentationPreferences';
 import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
 import type { DataAccessor, RangeOptions } from '../../../src/storage/accessors/DataAccessor';
+import { BasicETagHandler } from '../../../src/storage/conditions/BasicETagHandler';
 import { DataAccessorBasedStore } from '../../../src/storage/DataAccessorBasedStore';
 import { INTERNAL_QUADS } from '../../../src/util/ContentTypes';
 import { BadRequestHttpError } from '../../../src/util/errors/BadRequestHttpError';
@@ -19,17 +20,20 @@ import { ForbiddenHttpError } from '../../../src/util/errors/ForbiddenHttpError'
 import { MethodNotAllowedHttpError } from '../../../src/util/errors/MethodNotAllowedHttpError';
 import { NotFoundHttpError } from '../../../src/util/errors/NotFoundHttpError';
 import { NotImplementedHttpError } from '../../../src/util/errors/NotImplementedHttpError';
+import { NotModifiedHttpError } from '../../../src/util/errors/NotModifiedHttpError';
 import { PreconditionFailedHttpError } from '../../../src/util/errors/PreconditionFailedHttpError';
 import type { Guarded } from '../../../src/util/GuardedStream';
 import { ContentType } from '../../../src/util/Header';
 import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
 import { trimTrailingSlashes } from '../../../src/util/PathUtil';
+import { assertReadConditions } from '../../../src/util/ResourceUtil';
 import { guardedStreamFrom, readableToString } from '../../../src/util/StreamUtil';
 import { toLiteral } from '../../../src/util/TermUtil';
 import {
   AS,
   CONTENT_TYPE,
   DC,
+  HH,
   LDP,
   PIM,
   POSIX,
@@ -47,6 +51,16 @@ const GENERATED_PREDICATE = namedNode('generated');
 // Preferences with a fixed satisfiable byte range and the given output type preferences.
 function rangeWithType(type: RepresentationPreferences['type']): RepresentationPreferences {
   return { range: { unit: 'bytes', parts: [{ start: 2, end: 5 }]}, type };
+}
+
+// Awaits a promise that is expected to reject, returning the rejection reason.
+async function getError(promise: Promise<unknown>): Promise<NotModifiedHttpError> {
+  try {
+    await promise;
+  } catch (error: unknown) {
+    return error as NotModifiedHttpError;
+  }
+  throw new Error('Expected the promise to reject.');
 }
 
 class SimpleDataAccessor implements DataAccessor {
@@ -428,6 +442,130 @@ describe('A DataAccessorBasedStore', (): void => {
         await seekStore.getRepresentation(resourceID, { range: { unit: 'bytes', parts: [{ start: 0, end: 10 }]}}),
         '0123456789',
       );
+    });
+  });
+
+  describe('serving a conditional request that resolves to 304', (): void => {
+    const resourceID = { path: `${root}resource` };
+    const eTagHandler = new BasicETagHandler();
+    // A conditional request that always resolves to 304 (mismatch) resp. 200 (match).
+    const notMatching: Conditions = { matchesMetadata: (): boolean => false };
+    const matching: Conditions = { matchesMetadata: (): boolean => true };
+    let conditionalStore: DataAccessorBasedStore;
+    let getDataSpy: jest.SpyInstance;
+
+    // Stores a document with the given content-type and a fixed modified date, so it has a stable ETag,
+    // and returns its metadata (from which the expected ETag can be derived).
+    function storeResource(contentType = 'text/plain'): RepresentationMetadata {
+      const metadata = new RepresentationMetadata({ [RDF.type]: namedNode(LDP.Resource) });
+      metadata.identifier = namedNode(resourceID.path);
+      metadata.contentType = contentType;
+      metadata.set(POSIX.terms.size, toLiteral(4, XSD.terms.integer));
+      metadata.set(DC.terms.modified, toLiteral(now.toISOString(), XSD.terms.dateTime));
+      accessor.data[resourceID.path] = {
+        binary: true,
+        data: guardedStreamFrom([ 'data' ]),
+        metadata,
+        isEmpty: false,
+      } as Representation;
+      return metadata;
+    }
+
+    beforeEach((): void => {
+      conditionalStore = new DataAccessorBasedStore(
+        accessor,
+        identifierStrategy,
+        auxiliaryStrategy,
+        metadataStrategy,
+        false,
+        eTagHandler,
+      );
+      getDataSpy = jest.spyOn(accessor, 'getData');
+    });
+
+    it('returns a 304 without fetching the data when no conversion is needed.', async(): Promise<void> => {
+      const stored = storeResource();
+      const error = await getError(
+        conditionalStore.getRepresentation(resourceID, { type: { 'text/plain': 1 }}, notMatching),
+      );
+      expect(NotModifiedHttpError.isInstance(error)).toBe(true);
+      expect(error.metadata.get(HH.terms.etag)?.value).toBe(eTagHandler.getETag(stored));
+      // The whole point of the optimization: the data was never read.
+      expect(getDataSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns an ETag and metadata identical to the fetched (post-conversion) 304.', async(): Promise<void> => {
+      storeResource();
+      const preferences = { type: { 'text/plain': 1 }};
+
+      // Fetched path: the store without an ETagHandler returns the full representation,
+      // and the post-conversion condition check produces the 304, exactly as the operation handler does.
+      const body = await store.getRepresentation(resourceID, preferences);
+      let fetched: NotModifiedHttpError;
+      try {
+        assertReadConditions(body, eTagHandler, notMatching);
+        throw new Error('Expected assertReadConditions to throw.');
+      } catch (error: unknown) {
+        fetched = error as NotModifiedHttpError;
+      }
+      expect(NotModifiedHttpError.isInstance(fetched)).toBe(true);
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+
+      // Skipped path: the store with an ETagHandler short-circuits without fetching the data.
+      const skipped = await getError(conditionalStore.getRepresentation(resourceID, preferences, notMatching));
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+
+      expect(skipped.metadata.get(HH.terms.etag)?.value).toBe(fetched.metadata.get(HH.terms.etag)?.value);
+      expect(skipped.metadata.identifier).toEqualRdfTerm(fetched.metadata.identifier);
+      expect(skipped.metadata.quads()).toBeRdfIsomorphic(fetched.metadata.quads());
+    });
+
+    it('returns the full representation (fetching data) when the conditions match.', async(): Promise<void> => {
+      storeResource();
+      const result = await conditionalStore.getRepresentation(resourceID, { type: { 'text/plain': 1 }}, matching);
+      await expect(readableToString(result.data)).resolves.toBe('data');
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not skip (fetches data) when a conversion would happen.', async(): Promise<void> => {
+      storeResource('text/plain');
+      // A different type is requested, so a conversion would occur and the ETag depends on its output.
+      const result = conditionalStore.getRepresentation(resourceID, { type: { 'text/turtle': 1 }}, notMatching);
+      await expect(result).resolves.toBeDefined();
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not skip (fetches data) when a byte range is requested.', async(): Promise<void> => {
+      storeResource();
+      const result = conditionalStore.getRepresentation(
+        resourceID,
+        { type: { 'text/plain': 1 }, range: { unit: 'bytes', parts: [{ start: 0, end: 2 }]}},
+        notMatching,
+      );
+      await expect(result).resolves.toBeDefined();
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not skip (fetches data) when no ETagHandler is configured.', async(): Promise<void> => {
+      storeResource();
+      // The default `store` has no ETagHandler, so the optimization is disabled.
+      const result = store.getRepresentation(resourceID, { type: { 'text/plain': 1 }}, notMatching);
+      await expect(result).resolves.toBeDefined();
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not skip (fetches data) when there are no conditions.', async(): Promise<void> => {
+      storeResource();
+      const result = conditionalStore.getRepresentation(resourceID, { type: { 'text/plain': 1 }});
+      await expect(result).resolves.toBeDefined();
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the fetch even when no preferences are given.', async(): Promise<void> => {
+      storeResource();
+      const error = await getError(conditionalStore.getRepresentation(resourceID, undefined, notMatching));
+      expect(NotModifiedHttpError.isInstance(error)).toBe(true);
+      expect(getDataSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/storage/IndexRepresentationstore.test.ts
+++ b/test/unit/storage/IndexRepresentationstore.test.ts
@@ -38,8 +38,8 @@ describe('An IndexRepresentationStore', (): void => {
     const result = await store.getRepresentation({ path: baseUrl }, preferences);
     await expect(readableToString(result.data)).resolves.toBe('index data');
     expect(source.getRepresentation).toHaveBeenCalledTimes(2);
-    expect(source.getRepresentation).toHaveBeenCalledWith({ path: `${baseUrl}index.html` }, preferences, undefined);
-    expect(source.getRepresentation).toHaveBeenLastCalledWith({ path: baseUrl }, {}, undefined);
+    expect(source.getRepresentation).toHaveBeenCalledWith({ path: `${baseUrl}index.html` }, preferences);
+    expect(source.getRepresentation).toHaveBeenLastCalledWith({ path: baseUrl }, {});
 
     // Use correct metadata
     expect(result.metadata.identifier.value).toBe(baseUrl);
@@ -51,8 +51,8 @@ describe('An IndexRepresentationStore', (): void => {
     const result = await store.getRepresentation({ path: baseUrl }, preferences);
     await expect(readableToString(result.data)).resolves.toBe('index data');
     expect(source.getRepresentation).toHaveBeenCalledTimes(2);
-    expect(source.getRepresentation).toHaveBeenCalledWith({ path: `${baseUrl}index.html` }, preferences, undefined);
-    expect(source.getRepresentation).toHaveBeenLastCalledWith({ path: baseUrl }, {}, undefined);
+    expect(source.getRepresentation).toHaveBeenCalledWith({ path: `${baseUrl}index.html` }, preferences);
+    expect(source.getRepresentation).toHaveBeenLastCalledWith({ path: baseUrl }, {});
 
     // Use correct metadata
     expect(result.metadata.identifier.value).toBe(baseUrl);
@@ -93,7 +93,6 @@ describe('An IndexRepresentationStore', (): void => {
     expect(source.getRepresentation).toHaveBeenCalledWith(
       { path: `${emptyContainer.path}index.html` },
       preferences,
-      undefined,
     );
     expect(source.getRepresentation).toHaveBeenLastCalledWith(emptyContainer, preferences, undefined);
   });
@@ -115,8 +114,8 @@ describe('An IndexRepresentationStore', (): void => {
     const result = await store.getRepresentation({ path: baseUrl }, preferences);
     await expect(readableToString(result.data)).resolves.toBe('index data');
     expect(source.getRepresentation).toHaveBeenCalledTimes(2);
-    expect(source.getRepresentation).toHaveBeenCalledWith({ path: `${baseUrl}base.html` }, preferences, undefined);
-    expect(source.getRepresentation).toHaveBeenLastCalledWith({ path: baseUrl }, {}, undefined);
+    expect(source.getRepresentation).toHaveBeenCalledWith({ path: `${baseUrl}base.html` }, preferences);
+    expect(source.getRepresentation).toHaveBeenLastCalledWith({ path: baseUrl }, {});
 
     // Use correct metadata
     expect(result.metadata.identifier.value).toBe(baseUrl);
@@ -132,7 +131,7 @@ describe('An IndexRepresentationStore', (): void => {
     const result = await store.getRepresentation({ path: baseUrl }, preferences);
     await expect(readableToString(result.data)).resolves.toBe('index data');
     expect(source.getRepresentation).toHaveBeenCalledTimes(2);
-    expect(source.getRepresentation).toHaveBeenCalledWith({ path: `${baseUrl}base.html` }, preferences, undefined);
-    expect(source.getRepresentation).toHaveBeenLastCalledWith({ path: baseUrl }, {}, undefined);
+    expect(source.getRepresentation).toHaveBeenCalledWith({ path: `${baseUrl}base.html` }, preferences);
+    expect(source.getRepresentation).toHaveBeenLastCalledWith({ path: baseUrl }, {});
   });
 });

--- a/test/unit/util/ResourceUtil.test.ts
+++ b/test/unit/util/ResourceUtil.test.ts
@@ -12,6 +12,7 @@ import {
   addTemplateMetadata,
   assertReadConditions,
   cloneRepresentation,
+  getConditionalNotModifiedError,
   updateModifiedDate,
 } from '../../../src/util/ResourceUtil';
 import { CONTENT_TYPE_TERM, DC, HH, SOLID_META, XSD } from '../../../src/util/Vocabularies';
@@ -66,6 +67,44 @@ describe('ResourceUtil', (): void => {
       const res = await cloneRepresentation(representation);
       res.metadata.contentType = 'type/type';
       expect(representation.metadata.contentType).not.toBe(res.metadata.contentType);
+    });
+  });
+
+  describe('#getConditionalNotModifiedError', (): void => {
+    const eTagHandler: ETagHandler = {
+      getETag: (): string => 'ETag',
+      matchesETag: jest.fn(),
+      sameResourceState: jest.fn(),
+    };
+    let metadata: RepresentationMetadata;
+
+    beforeEach((): void => {
+      metadata = new RepresentationMetadata();
+      metadata.add(DC.terms.modified, 'modified-value');
+    });
+
+    it('returns undefined if the conditions are undefined.', (): void => {
+      expect(getConditionalNotModifiedError(metadata, eTagHandler)).toBeUndefined();
+    });
+
+    it('returns undefined if the conditions match.', (): void => {
+      const conditions: Conditions = { matchesMetadata: (): boolean => true };
+      expect(getConditionalNotModifiedError(metadata, eTagHandler, conditions)).toBeUndefined();
+    });
+
+    it('returns a NotModifiedHttpError with the ETag and metadata if the conditions do not match.', (): void => {
+      const conditions: Conditions = { matchesMetadata: (): boolean => false };
+      const error = getConditionalNotModifiedError(metadata, eTagHandler, conditions);
+      expect(NotModifiedHttpError.isInstance(error)).toBe(true);
+      expect(error!.metadata.get(HH.terms.etag)?.value).toBe('ETag');
+      expect(error!.metadata.identifier.value).toBe(metadata.identifier.value);
+      expect(error!.metadata.get(DC.terms.modified)?.value).toBe('modified-value');
+    });
+
+    it('does not modify the given metadata.', (): void => {
+      const conditions: Conditions = { matchesMetadata: (): boolean => false };
+      getConditionalNotModifiedError(metadata, eTagHandler, conditions);
+      expect(metadata.get(HH.terms.etag)).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

> **Stacked on #98** (`perf/metadata-first-range-seek`): the base branch is that PR's branch, so the diff shown is only this increment. Review/merge #98 first; this PR then needs a retarget/restack onto the target branch.

#### 📁 Related issues

No upstream issue exists yet — the CSS PR template requires one, so an issue describing the redundant data fetch on `304 Not Modified` revalidations must be opened on CommunitySolidServer/CommunitySolidServer before this is submitted upstream. Builds on the metadata-first "no conversion will happen" predicate introduced in #98.

#### ✍️ Description

A conditional `GET`/`HEAD` (`If-None-Match` / `If-Modified-Since`) that resolves to **304 Not Modified** still opens the resource's data stream today: `getRepresentation` calls `accessor.getData` (a file open on the file backend), the outgoing converter wires up its pipeline, and only afterwards does `assertReadConditions` — in the operation handler, after content negotiation — throw the 304 and destroy the stream unread. For the common browser revalidation, where a resource is re-requested in the same representation it was stored in, that work is pure waste.

`DataAccessorBasedStore` now takes an optional `eTagHandler` constructor parameter (the opt-in switch, wired into the default file and memory backends; other backends opt in by adding the same reference). When configured, a conditional, non-range request that provably needs no content conversion — the #98 metadata-only predicate, factored into a shared `servedWithoutConversion` method used by both this path and `getSeekRange` — is evaluated against the same strict read-conditions logic *before* `accessor.getData`, and a resulting 304 is thrown early. Every other case (conversion, byte range, no conditions, no `eTagHandler`, or any uncertainty) falls through to the existing fetch → convert → `assertReadConditions` path unchanged.

To guarantee both paths decide identically, the non-mutating core of `assertReadConditions` is extracted as `getConditionalNotModifiedError` in `ResourceUtil`: it returns the exact `NotModifiedHttpError` (same ETag, same identifier, same copied metadata quads, hence the same headers) that `assertReadConditions` throws, and `assertReadConditions` now delegates to it.

Why the skipped 304 stays byte-identical to the fetched one:

1. The skip requires **no conversion** (proven from metadata), so the served content-type equals the stored one and the ETag (`"<mtime>-<contentType>"`) is fully determined by the metadata already read. A conversion case is excluded because there the ETag depends on the converted type — the reason a naive "check conditions first" reorder is unsafe.
1. The skip requires **no byte range**, because the full-read path adds `Content-Range` metadata to a ranged 304.
1. With no conversion, the intermediate stores (`LockingResourceStore`, `PatchingStore`, `BinarySliceResourceStore` without a range, `MonitoringStore`) pass the metadata through untouched, and the 304-vs-200 decision reuses the identical strict `conditions.matchesMetadata(metadata, true)` check.

`IndexRepresentationStore` composes a new representation (the container's metadata with the index document's content-type), so its 304 must be decided by the caller against that composed metadata, not against the individual index/container sub-reads (which can have a different `dc:modified`). It therefore no longer forwards `conditions` to those sub-reads — a no-op today (no store consumed `conditions` on `getRepresentation` before this PR), and it prevents the new skip from firing on the wrong metadata.

Tests: unit tests assert the skipped 304 never calls `getData`, that its ETag and metadata are RDF-isomorphic to the fetched 304 for the same resource, and that the conversion / range / no-conditions / no-`eTagHandler` cases all still call `getData`. A new integration test in `Conditions.test.ts` (memory and file backends) asserts a conditional `GET`/`HEAD` of a non-converted document returns a 304 whose headers are byte-identical to the full `GET` (`date` excluded), and that a non-matching conditional still returns the full body.

**Before/after** — data-file opens per request on the file backend (the deterministic effect; wall-clock timings deliberately omitted):

| Request | Before | After |
| ------- | ------ | ----- |
| `GET` → 200 | 1 | 1 |
| Conditional `GET` → 304, same representation | 1 | 0 |
| Conditional `GET` → 304, conversion or range needed | 1 | 1 (fallback) |

Reproducible via the `getData` spy assertions: `npx jest test/unit/storage/DataAccessorBasedStore.test.ts` (the "serving a conditional request that resolves to 304" cases). The live numbers were additionally observed with `strace -f -e trace=openat` against a `config/file.json` server (PUT a `text/plain` resource, full `GET`, then a conditional `GET` with the matching `If-None-Match`): the skipped 304 opens the data file 0 times. There is no scripted benchmark command in the repo for this; the op-count table is the reproducible evidence.

**Branch target:** this adds a constructor parameter and changes default config wiring, so the upstream submission should target the latest `versions/*` branch, not `main`. Intended semver level: **minor** (backwards-compatible feature addition — stated in prose since contributors cannot set the semver labels).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
