### PR TITLE
perf: Skip the data fetch for HEAD requests that need no conversion

### DIFF
--- a/config/storage/backend/file.json
+++ b/config/storage/backend/file.json
@@ -13,7 +13,8 @@
       "accessor": { "@id": "urn:solid-server:default:FileDataAccessor" },
       "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" },
       "optimizeRange": true,
-      "eTagHandler": { "@id": "urn:solid-server:default:ETagHandler" }
+      "eTagHandler": { "@id": "urn:solid-server:default:ETagHandler" },
+      "optimizeMetadataOnly": true
     }
   ]
 }

--- a/config/storage/backend/memory.json
+++ b/config/storage/backend/memory.json
@@ -12,7 +12,8 @@
       "auxiliaryStrategy": { "@id": "urn:solid-server:default:AuxiliaryStrategy" },
       "accessor": { "@id": "urn:solid-server:default:MemoryDataAccessor" },
       "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" },
-      "eTagHandler": { "@id": "urn:solid-server:default:ETagHandler" }
+      "eTagHandler": { "@id": "urn:solid-server:default:ETagHandler" },
+      "optimizeMetadataOnly": true
     }
   ]
 }

--- a/src/http/input/preferences/AcceptPreferenceParser.ts
+++ b/src/http/input/preferences/AcceptPreferenceParser.ts
@@ -11,7 +11,7 @@ import type { RepresentationPreferences } from '../../representation/Representat
 import { PreferenceParser } from './PreferenceParser';
 
 const parsers: {
-  name: Exclude<keyof RepresentationPreferences, 'range'>;
+  name: Exclude<keyof RepresentationPreferences, 'range' | 'metadataOnly'>;
   header: string;
   parse: (value: string) => AcceptHeader[];
 }[] = [

--- a/src/http/input/preferences/UnionPreferenceParser.ts
+++ b/src/http/input/preferences/UnionPreferenceParser.ts
@@ -20,12 +20,17 @@ export class UnionPreferenceParser extends UnionHandler<PreferenceParser> {
 
     const preferences: RepresentationPreferences = {};
     for (const result of results) {
-      for (const key of Object.keys(result) as (keyof RepresentationPreferences)[]) {
-        if (key === 'range') {
-          preferences[key] = result[key];
-        } else {
-          preferences[key] = { ...preferences[key], ...result[key] };
-        }
+      // `range` and `metadataOnly` are not per-value preference maps and cannot be merged,
+      // so they are taken directly; the remaining dimensions are `ValuePreferences` maps that are combined.
+      const { range, metadataOnly, ...valuePreferences } = result;
+      if (typeof range !== 'undefined') {
+        preferences.range = range;
+      }
+      if (typeof metadataOnly !== 'undefined') {
+        preferences.metadataOnly = metadataOnly;
+      }
+      for (const key of Object.keys(valuePreferences) as (keyof typeof valuePreferences)[]) {
+        preferences[key] = { ...preferences[key], ...valuePreferences[key] };
       }
     }
     return preferences;

--- a/src/http/input/preferences/UnionPreferenceParser.ts
+++ b/src/http/input/preferences/UnionPreferenceParser.ts
@@ -20,8 +20,7 @@ export class UnionPreferenceParser extends UnionHandler<PreferenceParser> {
 
     const preferences: RepresentationPreferences = {};
     for (const result of results) {
-      // `range` and `metadataOnly` are not per-value preference maps and cannot be merged,
-      // so they are taken directly; the remaining dimensions are `ValuePreferences` maps that are combined.
+      // `range` and `metadataOnly` are not `ValuePreferences` maps, so they are taken directly instead of merged.
       const { range, metadataOnly, ...valuePreferences } = result;
       if (typeof range !== 'undefined') {
         preferences.range = range;

--- a/src/http/ldp/HeadOperationHandler.ts
+++ b/src/http/ldp/HeadOperationHandler.ts
@@ -28,10 +28,7 @@ export class HeadOperationHandler extends OperationHandler {
   }
 
   public async handle({ operation }: OperationHandlerInput): Promise<ResponseDescription> {
-    // A HEAD response only carries the metadata; the data body is always discarded below.
-    // Signal this to the store so a backend that can fully determine the response metadata without
-    // reading the data (no conversion, no range) can skip fetching it. Stores that cannot make this
-    // guarantee ignore the hint and return the data as usual, keeping the response unchanged.
+    // A HEAD response never contains the data, so the store only needs to return the metadata.
     const preferences = { ...operation.preferences, metadataOnly: true };
     const body = await this.store.getRepresentation(operation.target, preferences, operation.conditions);
 

--- a/src/http/ldp/HeadOperationHandler.ts
+++ b/src/http/ldp/HeadOperationHandler.ts
@@ -28,7 +28,12 @@ export class HeadOperationHandler extends OperationHandler {
   }
 
   public async handle({ operation }: OperationHandlerInput): Promise<ResponseDescription> {
-    const body = await this.store.getRepresentation(operation.target, operation.preferences, operation.conditions);
+    // A HEAD response only carries the metadata; the data body is always discarded below.
+    // Signal this to the store so a backend that can fully determine the response metadata without
+    // reading the data (no conversion, no range) can skip fetching it. Stores that cannot make this
+    // guarantee ignore the hint and return the data as usual, keeping the response unchanged.
+    const preferences = { ...operation.preferences, metadataOnly: true };
+    const body = await this.store.getRepresentation(operation.target, preferences, operation.conditions);
 
     // Check whether the cached representation is still valid or it is necessary to send a new representation.
     // Generally it doesn't make much sense to use condition headers with a HEAD request, but it should be supported.

--- a/src/http/representation/RepresentationPreferences.ts
+++ b/src/http/representation/RepresentationPreferences.ts
@@ -33,4 +33,11 @@ export interface RepresentationPreferences {
   language?: ValuePreferences;
   // `start` can be negative and implies the last X of a stream
   range?: { unit: string; parts: { start: number; end?: number }[] };
+  /**
+   * Indicates the consumer only needs the metadata of the representation and will discard the data
+   * (e.g. a `HEAD` request). This is an optional, backwards-compatible hint: a store that can determine
+   * the full response metadata without reading the data MAY skip fetching it, but any store that cannot
+   * MUST ignore this hint and return the data as usual, keeping the response unchanged.
+   */
+  metadataOnly?: boolean;
 }

--- a/src/http/representation/RepresentationPreferences.ts
+++ b/src/http/representation/RepresentationPreferences.ts
@@ -34,10 +34,8 @@ export interface RepresentationPreferences {
   // `start` can be negative and implies the last X of a stream
   range?: { unit: string; parts: { start: number; end?: number }[] };
   /**
-   * Indicates the consumer only needs the metadata of the representation and will discard the data
-   * (e.g. a `HEAD` request). This is an optional, backwards-compatible hint: a store that can determine
-   * the full response metadata without reading the data MAY skip fetching it, but any store that cannot
-   * MUST ignore this hint and return the data as usual, keeping the response unchanged.
+   * Indicates the consumer only needs the metadata and will discard the data (e.g. a `HEAD` request).
+   * Stores that cannot determine the response metadata without reading the data should ignore this hint.
    */
   metadataOnly?: boolean;
 }

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -110,15 +110,11 @@ export class DataAccessorBasedStore implements ResourceStore {
    *   the metadata already read; every other case falls back to the full read + post-conversion
    *   condition check, keeping the response byte-identical. The same requirement (b) as `optimizeRange`
    *   applies. When omitted, no such requests are short-circuited, keeping the original behaviour.
-   * @param optimizeMetadataOnly - Enables skipping the `accessor.getData` call (and the file open it
-   *   entails) for requests that only need the metadata and will discard the data (`preferences.metadataOnly`,
-   *   set for `HEAD` requests). This is only done for a regular resource, when no byte range was requested,
-   *   and when this store can prove from metadata alone that no conversion will happen, so every header the
-   *   response carries (content-type, `posix:size`-derived content-length, ETag, last-modified, ...) is fully
-   *   determined by the metadata already read and is unaffected by the data. In that case an empty data stream
-   *   is returned instead of the resource data; the metadata is identical, so the discarded-body response stays
-   *   byte-identical. The same requirement (b) as `optimizeRange` applies. Defaults to `false`, keeping the
-   *   original behaviour.
+   * @param optimizeMetadataOnly - Skips the `accessor.getData` call (and the file open it entails) for
+   *   requests that only need the metadata (`preferences.metadataOnly`, set for `HEAD` requests),
+   *   returning an empty data stream instead. Only done for a regular resource, with no byte range,
+   *   when this store can prove from metadata alone that no conversion will happen, so the response
+   *   stays identical. The same requirement (b) as `optimizeRange` applies. Defaults to `false`.
    */
   public constructor(
     accessor: DataAccessor,
@@ -226,9 +222,7 @@ export class DataAccessorBasedStore implements ResourceStore {
         metadata.set(SOLID_HTTP.terms.end, toLiteral(range.end, XSD.terms.integer));
         representation = new BasicRepresentation(await this.accessor.getData(identifier, range), metadata);
       } else if (this.skipDataForMetadataOnly(preferences, metadata)) {
-        // The consumer only needs the metadata (e.g. a HEAD) and no conversion will change it, so the
-        // response is fully determined by the metadata we already read. Return an empty data stream
-        // instead of opening the resource data; the metadata is unchanged, so the response stays identical.
+        // The metadata fully determines the response, so the data does not need to be opened.
         representation = new BasicRepresentation(guardedStreamFrom([], { objectMode: false }), metadata);
       } else {
         representation = new BasicRepresentation(await this.accessor.getData(identifier), metadata);
@@ -325,18 +319,10 @@ export class DataAccessorBasedStore implements ResourceStore {
   }
 
   /**
-   * Determines whether the `accessor.getData` call can be skipped for a request that only needs the
-   * metadata and discards the data (e.g. a `HEAD`), returning an empty data stream instead.
-   *
-   * Returns `true` only when ALL of the following hold, guaranteeing the (body-discarding) response stays
-   * byte-identical to the one the full-read path would produce for the same request:
-   *  - The optimization is enabled for this store (`optimizeMetadataOnly`).
-   *  - The request is metadata-only (`preferences.metadataOnly`), so the caller will discard the data.
-   *  - No byte range was requested. A range would need the data to be sliced and would add `Content-Range`
-   *    metadata in the full-read path, so ranged requests keep fetching the data.
-   *  - No content conversion will happen ({@link servedWithoutConversion}), so the served content-type equals
-   *    the stored one and every response header (content-type, the `posix:size`-derived content-length, ETag,
-   *    last-modified, ...) is fully determined by the metadata already read and is unaffected by the data.
+   * Determines whether the data fetch can be skipped for a request that only needs the metadata
+   * (e.g. a `HEAD`), with an empty data stream returned instead. This is only safe when no byte range
+   * was requested and no conversion will happen ({@link servedWithoutConversion}), since every header
+   * of the response is then fully determined by the metadata that was already read.
    */
   private skipDataForMetadataOnly(
     preferences: RepresentationPreferences | undefined,
@@ -345,7 +331,6 @@ export class DataAccessorBasedStore implements ResourceStore {
     if (!this.optimizeMetadataOnly || preferences?.metadataOnly !== true) {
       return false;
     }
-    // A byte range would need the data to slice it, so ranged requests keep fetching the data.
     if (typeof preferences?.range !== 'undefined') {
       return false;
     }

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -32,6 +32,7 @@ import {
 } from '../util/PathUtil';
 import { termToInt } from '../util/QuadUtil';
 import { addResourceMetadata, getConditionalNotModifiedError, updateModifiedDate } from '../util/ResourceUtil';
+import { guardedStreamFrom } from '../util/StreamUtil';
 import { toLiteral } from '../util/TermUtil';
 import {
   AS,
@@ -85,6 +86,7 @@ export class DataAccessorBasedStore implements ResourceStore {
   private readonly auxiliaryStrategy: AuxiliaryStrategy;
   private readonly metadataStrategy: AuxiliaryStrategy;
   private readonly optimizeRange: boolean;
+  private readonly optimizeMetadataOnly: boolean;
   private readonly eTagHandler?: ETagHandler;
 
   /**
@@ -108,6 +110,15 @@ export class DataAccessorBasedStore implements ResourceStore {
    *   the metadata already read; every other case falls back to the full read + post-conversion
    *   condition check, keeping the response byte-identical. The same requirement (b) as `optimizeRange`
    *   applies. When omitted, no such requests are short-circuited, keeping the original behaviour.
+   * @param optimizeMetadataOnly - Enables skipping the `accessor.getData` call (and the file open it
+   *   entails) for requests that only need the metadata and will discard the data (`preferences.metadataOnly`,
+   *   set for `HEAD` requests). This is only done for a regular resource, when no byte range was requested,
+   *   and when this store can prove from metadata alone that no conversion will happen, so every header the
+   *   response carries (content-type, `posix:size`-derived content-length, ETag, last-modified, ...) is fully
+   *   determined by the metadata already read and is unaffected by the data. In that case an empty data stream
+   *   is returned instead of the resource data; the metadata is identical, so the discarded-body response stays
+   *   byte-identical. The same requirement (b) as `optimizeRange` applies. Defaults to `false`, keeping the
+   *   original behaviour.
    */
   public constructor(
     accessor: DataAccessor,
@@ -116,6 +127,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     metadataStrategy: AuxiliaryStrategy,
     optimizeRange = false,
     eTagHandler?: ETagHandler,
+    optimizeMetadataOnly = false,
   ) {
     this.accessor = accessor;
     this.identifierStrategy = identifierStrategy;
@@ -123,6 +135,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     this.metadataStrategy = metadataStrategy;
     this.optimizeRange = optimizeRange;
     this.eTagHandler = eTagHandler;
+    this.optimizeMetadataOnly = optimizeMetadataOnly;
   }
 
   public async hasResource(identifier: ResourceIdentifier): Promise<boolean> {
@@ -212,6 +225,11 @@ export class DataAccessorBasedStore implements ResourceStore {
         metadata.set(SOLID_HTTP.terms.start, toLiteral(range.start, XSD.terms.integer));
         metadata.set(SOLID_HTTP.terms.end, toLiteral(range.end, XSD.terms.integer));
         representation = new BasicRepresentation(await this.accessor.getData(identifier, range), metadata);
+      } else if (this.skipDataForMetadataOnly(preferences, metadata)) {
+        // The consumer only needs the metadata (e.g. a HEAD) and no conversion will change it, so the
+        // response is fully determined by the metadata we already read. Return an empty data stream
+        // instead of opening the resource data; the metadata is unchanged, so the response stays identical.
+        representation = new BasicRepresentation(guardedStreamFrom([], { objectMode: false }), metadata);
       } else {
         representation = new BasicRepresentation(await this.accessor.getData(identifier), metadata);
       }
@@ -304,6 +322,34 @@ export class DataAccessorBasedStore implements ResourceStore {
       return;
     }
     return getConditionalNotModifiedError(metadata, this.eTagHandler, conditions);
+  }
+
+  /**
+   * Determines whether the `accessor.getData` call can be skipped for a request that only needs the
+   * metadata and discards the data (e.g. a `HEAD`), returning an empty data stream instead.
+   *
+   * Returns `true` only when ALL of the following hold, guaranteeing the (body-discarding) response stays
+   * byte-identical to the one the full-read path would produce for the same request:
+   *  - The optimization is enabled for this store (`optimizeMetadataOnly`).
+   *  - The request is metadata-only (`preferences.metadataOnly`), so the caller will discard the data.
+   *  - No byte range was requested. A range would need the data to be sliced and would add `Content-Range`
+   *    metadata in the full-read path, so ranged requests keep fetching the data.
+   *  - No content conversion will happen ({@link servedWithoutConversion}), so the served content-type equals
+   *    the stored one and every response header (content-type, the `posix:size`-derived content-length, ETag,
+   *    last-modified, ...) is fully determined by the metadata already read and is unaffected by the data.
+   */
+  private skipDataForMetadataOnly(
+    preferences: RepresentationPreferences | undefined,
+    metadata: RepresentationMetadata,
+  ): boolean {
+    if (!this.optimizeMetadataOnly || preferences?.metadataOnly !== true) {
+      return false;
+    }
+    // A byte range would need the data to slice it, so ranged requests keep fetching the data.
+    if (typeof preferences?.range !== 'undefined') {
+      return false;
+    }
+    return this.servedWithoutConversion(preferences, metadata);
   }
 
   /**

--- a/test/integration/LdpHandlerWithoutAuth.test.ts
+++ b/test/integration/LdpHandlerWithoutAuth.test.ts
@@ -811,4 +811,73 @@ describe.each(stores)('An LDP handler allowing all requests %s', (name, { storeC
     expect(response.status).toBe(206);
     await expect(response.text()).resolves.toBe(fullConverted.slice(0, 5));
   });
+
+  // The headers that fully determine a HEAD response; a HEAD must carry exactly the same ones as the GET.
+  const headHeaders = [ 'content-type', 'content-length', 'etag', 'last-modified', 'accept-ranges', 'content-range' ];
+  async function expectHeadMatchesGet(url: string, init?: RequestInit): Promise<Response> {
+    const get = await fetch(url, init);
+    await get.text();
+    const head = await fetch(url, { ...init, method: 'HEAD' });
+    expect(head.status).toBe(get.status);
+    // A HEAD never has a body.
+    await expect(head.text()).resolves.toBe('');
+    for (const header of headHeaders) {
+      expect(head.headers.get(header)).toBe(get.headers.get(header));
+    }
+    return head;
+  }
+
+  it('answers a plain HEAD with the same headers as the GET, without a body.', async(): Promise<void> => {
+    const resourceUrl = joinUrl(baseUrl, 'head-plain');
+    const body = 'HEAD-TEST-BODY';
+    await putResource(resourceUrl, { contentType: 'text/plain', body });
+
+    const head = await expectHeadMatchesGet(resourceUrl);
+    expect(head.status).toBe(200);
+    // The content-length is served from the stored size even though the data was not read.
+    expect(head.headers.get('content-length')).toBe(`${body.length}`);
+    expect(head.headers.get('content-type')).toBe('text/plain');
+  });
+
+  it('answers a converting HEAD (fallback) with the same headers as the converting GET.', async(): Promise<void> => {
+    const resourceUrl = joinUrl(baseUrl, 'head-convert');
+    await putResource(resourceUrl, { contentType: 'text/turtle', body: '<http://ex/s> <http://ex/p> <http://ex/o>.' });
+
+    // The stored type is turtle but n-triples is requested, so the HEAD must still convert (fallback).
+    const head = await expectHeadMatchesGet(resourceUrl, { headers: { accept: 'application/n-triples' }});
+    expect(head.status).toBe(200);
+    expect(head.headers.get('content-type')).toBe('application/n-triples');
+  });
+
+  it('answers a HEAD on a container (fallback) with the same headers as the GET.', async(): Promise<void> => {
+    const containerUrl = joinUrl(baseUrl, 'head-container/');
+    await putResource(containerUrl, { contentType: 'text/turtle' });
+
+    const head = await expectHeadMatchesGet(containerUrl);
+    expect(head.status).toBe(200);
+  });
+
+  it('answers a ranged HEAD (fallback) with the same headers as the ranged GET.', async(): Promise<void> => {
+    const resourceUrl = joinUrl(baseUrl, 'head-range');
+    const body = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    await putResource(resourceUrl, { contentType: 'text/plain', body });
+
+    const head = await expectHeadMatchesGet(resourceUrl, { headers: { range: 'bytes=2-5' }});
+    expect(head.status).toBe(206);
+    expect(head.headers.get('content-range')).toBe(`bytes 2-5/${body.length}`);
+    expect(head.headers.get('content-length')).toBe('4');
+  });
+
+  it('answers a conditional HEAD that matches the ETag with a 304.', async(): Promise<void> => {
+    const resourceUrl = joinUrl(baseUrl, 'head-conditional');
+    await putResource(resourceUrl, { contentType: 'text/plain', body: 'conditional' });
+    const get = await fetch(resourceUrl);
+    await get.text();
+    const eTag = get.headers.get('etag')!;
+    expect(eTag).not.toBeNull();
+
+    const head = await fetch(resourceUrl, { method: 'HEAD', headers: { 'if-none-match': eTag }});
+    expect(head.status).toBe(304);
+    await expect(head.text()).resolves.toBe('');
+  });
 });

--- a/test/integration/LdpHandlerWithoutAuth.test.ts
+++ b/test/integration/LdpHandlerWithoutAuth.test.ts
@@ -812,14 +812,13 @@ describe.each(stores)('An LDP handler allowing all requests %s', (name, { storeC
     await expect(response.text()).resolves.toBe(fullConverted.slice(0, 5));
   });
 
-  // The headers that fully determine a HEAD response; a HEAD must carry exactly the same ones as the GET.
+  // The headers a HEAD response must share with the corresponding GET.
   const headHeaders = [ 'content-type', 'content-length', 'etag', 'last-modified', 'accept-ranges', 'content-range' ];
   async function expectHeadMatchesGet(url: string, init?: RequestInit): Promise<Response> {
     const get = await fetch(url, init);
     await get.text();
     const head = await fetch(url, { ...init, method: 'HEAD' });
     expect(head.status).toBe(get.status);
-    // A HEAD never has a body.
     await expect(head.text()).resolves.toBe('');
     for (const header of headHeaders) {
       expect(head.headers.get(header)).toBe(get.headers.get(header));
@@ -834,22 +833,21 @@ describe.each(stores)('An LDP handler allowing all requests %s', (name, { storeC
 
     const head = await expectHeadMatchesGet(resourceUrl);
     expect(head.status).toBe(200);
-    // The content-length is served from the stored size even though the data was not read.
     expect(head.headers.get('content-length')).toBe(`${body.length}`);
     expect(head.headers.get('content-type')).toBe('text/plain');
   });
 
-  it('answers a converting HEAD (fallback) with the same headers as the converting GET.', async(): Promise<void> => {
+  it('answers a converting HEAD with the same headers as the converting GET.', async(): Promise<void> => {
     const resourceUrl = joinUrl(baseUrl, 'head-convert');
     await putResource(resourceUrl, { contentType: 'text/turtle', body: '<http://ex/s> <http://ex/p> <http://ex/o>.' });
 
-    // The stored type is turtle but n-triples is requested, so the HEAD must still convert (fallback).
+    // The stored type is turtle but n-triples is requested, so the response is converted.
     const head = await expectHeadMatchesGet(resourceUrl, { headers: { accept: 'application/n-triples' }});
     expect(head.status).toBe(200);
     expect(head.headers.get('content-type')).toBe('application/n-triples');
   });
 
-  it('answers a HEAD on a container (fallback) with the same headers as the GET.', async(): Promise<void> => {
+  it('answers a HEAD on a container with the same headers as the GET.', async(): Promise<void> => {
     const containerUrl = joinUrl(baseUrl, 'head-container/');
     await putResource(containerUrl, { contentType: 'text/turtle' });
 
@@ -857,7 +855,7 @@ describe.each(stores)('An LDP handler allowing all requests %s', (name, { storeC
     expect(head.status).toBe(200);
   });
 
-  it('answers a ranged HEAD (fallback) with the same headers as the ranged GET.', async(): Promise<void> => {
+  it('answers a ranged HEAD with the same headers as the ranged GET.', async(): Promise<void> => {
     const resourceUrl = joinUrl(baseUrl, 'head-range');
     const body = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     await putResource(resourceUrl, { contentType: 'text/plain', body });

--- a/test/unit/http/input/preferences/UnionPreferenceParser.test.ts
+++ b/test/unit/http/input/preferences/UnionPreferenceParser.test.ts
@@ -38,6 +38,22 @@ describe('A UnionPreferenceParser', (): void => {
     });
   });
 
+  it('takes a metadataOnly hint directly instead of merging it.', async(): Promise<void> => {
+    parsers[0].handle.mockResolvedValue({
+      type: { 'text/turtle': 1 },
+      metadataOnly: true,
+    });
+    parsers[1].handle.mockResolvedValue({
+      language: { nl: 0.8 },
+    });
+
+    await expect(parser.handle({} as any)).resolves.toEqual({
+      type: { 'text/turtle': 1 },
+      language: { nl: 0.8 },
+      metadataOnly: true,
+    });
+  });
+
   it('throws an error if multiple parsers return a range.', async(): Promise<void> => {
     parsers[0].handle.mockResolvedValue({
       type: { 'text/turtle': 1 },

--- a/test/unit/http/ldp/HeadOperationHandler.test.ts
+++ b/test/unit/http/ldp/HeadOperationHandler.test.ts
@@ -63,7 +63,6 @@ describe('A HeadOperationHandler', (): void => {
     expect(result.data).toBeUndefined();
     expect(data.destroy).toHaveBeenCalledTimes(1);
     expect(store.getRepresentation).toHaveBeenCalledTimes(1);
-    // The handler signals that only the metadata is needed so the store can skip fetching the data.
     expect(store.getRepresentation).toHaveBeenLastCalledWith(
       operation.target,
       { ...preferences, metadataOnly: true },
@@ -79,7 +78,6 @@ describe('A HeadOperationHandler', (): void => {
       { type: { 'text/turtle': 1 }, metadataOnly: true },
       conditions,
     );
-    // The original operation preferences object is left untouched.
     expect(operation.preferences).toEqual({ type: { 'text/turtle': 1 }});
   });
 

--- a/test/unit/http/ldp/HeadOperationHandler.test.ts
+++ b/test/unit/http/ldp/HeadOperationHandler.test.ts
@@ -63,7 +63,24 @@ describe('A HeadOperationHandler', (): void => {
     expect(result.data).toBeUndefined();
     expect(data.destroy).toHaveBeenCalledTimes(1);
     expect(store.getRepresentation).toHaveBeenCalledTimes(1);
-    expect(store.getRepresentation).toHaveBeenLastCalledWith(operation.target, preferences, conditions);
+    // The handler signals that only the metadata is needed so the store can skip fetching the data.
+    expect(store.getRepresentation).toHaveBeenLastCalledWith(
+      operation.target,
+      { ...preferences, metadataOnly: true },
+      conditions,
+    );
+  });
+
+  it('signals that only the metadata is needed without mutating the original preferences.', async(): Promise<void> => {
+    operation.preferences = { type: { 'text/turtle': 1 }};
+    await handler.handle({ operation });
+    expect(store.getRepresentation).toHaveBeenLastCalledWith(
+      operation.target,
+      { type: { 'text/turtle': 1 }, metadataOnly: true },
+      conditions,
+    );
+    // The original operation preferences object is left untouched.
+    expect(operation.preferences).toEqual({ type: { 'text/turtle': 1 }});
   });
 
   it('returns a 304 if the conditions do not match.', async(): Promise<void> => {

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -575,8 +575,7 @@ describe('A DataAccessorBasedStore', (): void => {
     let metadataStore: DataAccessorBasedStore;
     let getDataSpy: jest.SpyInstance;
 
-    // Stores a document with the given content-type, a size and a fixed modified date, so the metadata
-    // carries every header a HEAD response would (content-type, content-length, ETag, last-modified).
+    // Stores a document whose metadata carries every header a HEAD response contains.
     function storeResource(contentType = 'text/plain', body = 'data'): void {
       const metadata = new RepresentationMetadata({ [RDF.type]: namedNode(LDP.Resource) });
       metadata.identifier = namedNode(resourceID.path);
@@ -608,9 +607,7 @@ describe('A DataAccessorBasedStore', (): void => {
       storeResource();
       const preferences = { type: { 'text/plain': 1 }, metadataOnly: true };
       const result = await metadataStore.getRepresentation(resourceID, preferences);
-      // The whole point of the optimization: the data was never read.
       expect(getDataSpy).not.toHaveBeenCalled();
-      // The returned data stream is empty (a HEAD discards it anyway).
       await expect(readableToString(result.data)).resolves.toBe('');
       // Every header the HEAD response carries is still present in the metadata.
       expect(result.metadata.contentType).toBe('text/plain');
@@ -618,20 +615,19 @@ describe('A DataAccessorBasedStore', (): void => {
       expect(result.metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
     });
 
-    it('returns metadata byte-identical to the full-read path.', async(): Promise<void> => {
+    it('returns the same metadata as the full-read path.', async(): Promise<void> => {
       storeResource();
       const preferences = { type: { 'text/plain': 1 }};
 
-      // Full-read path: the default store fetches the data and returns the same metadata a HEAD would keep.
+      // The default store fetches the data.
       const fetched = await store.getRepresentation(resourceID, preferences);
       fetched.data.destroy();
       expect(getDataSpy).toHaveBeenCalledTimes(1);
 
-      // Skip path: the metadata-only store short-circuits without fetching the data.
+      // The metadata-only store skips the data fetch.
       const skipped = await metadataStore.getRepresentation(resourceID, { ...preferences, metadataOnly: true });
       expect(getDataSpy).toHaveBeenCalledTimes(1);
 
-      // The ETag (derived from the metadata) and the full metadata are identical between the two paths.
       expect(eTagHandler.getETag(skipped.metadata)).toBe(eTagHandler.getETag(fetched.metadata));
       expect(skipped.metadata.identifier).toEqualRdfTerm(fetched.metadata.identifier);
       expect(skipped.metadata.quads()).toBeRdfIsomorphic(fetched.metadata.quads());
@@ -644,14 +640,14 @@ describe('A DataAccessorBasedStore', (): void => {
       await expect(readableToString(result.data)).resolves.toBe('');
     });
 
-    it('does not skip (fetches data) when the request is not metadata-only.', async(): Promise<void> => {
+    it('does not skip the data fetch when the request is not metadata-only.', async(): Promise<void> => {
       storeResource();
       const result = await metadataStore.getRepresentation(resourceID, { type: { 'text/plain': 1 }});
       await expect(readableToString(result.data)).resolves.toBe('data');
       expect(getDataSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('does not skip (fetches data) when a conversion would happen.', async(): Promise<void> => {
+    it('does not skip the data fetch when a conversion would happen.', async(): Promise<void> => {
       storeResource('text/plain');
       // A different type is requested, so a conversion would occur and could change the response metadata.
       const result = await metadataStore.getRepresentation(
@@ -662,7 +658,7 @@ describe('A DataAccessorBasedStore', (): void => {
       expect(getDataSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('does not skip (fetches data) when a byte range is requested.', async(): Promise<void> => {
+    it('does not skip the data fetch when a byte range is requested.', async(): Promise<void> => {
       storeResource();
       const result = await metadataStore.getRepresentation(
         resourceID,
@@ -672,7 +668,7 @@ describe('A DataAccessorBasedStore', (): void => {
       expect(getDataSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('does not skip (fetches data) when the optimization is disabled.', async(): Promise<void> => {
+    it('does not skip the data fetch when the optimization is disabled.', async(): Promise<void> => {
       storeResource();
       // The default `store` is constructed without the optimizeMetadataOnly flag.
       const result = await store.getRepresentation(resourceID, { type: { 'text/plain': 1 }, metadataOnly: true });
@@ -680,13 +676,12 @@ describe('A DataAccessorBasedStore', (): void => {
       expect(getDataSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('does not skip (fetches data) for a container request.', async(): Promise<void> => {
-      // A container falls in the container branch, which always composes its data from the metadata/children.
+    it('still returns the container data for a metadata-only request.', async(): Promise<void> => {
+      // Container data is composed from the metadata and children, so the hint does not apply.
       const containerID = { path: `${root}container/` };
       accessor.data[containerID.path] = { metadata: new RepresentationMetadata(containerID) } as Representation;
       const result = await metadataStore.getRepresentation(containerID, { metadataOnly: true });
       expect(result.metadata.contentType).toBe(INTERNAL_QUADS);
-      // The container data (its quads) is still produced, unaffected by the metadata-only hint.
       await expect(arrayifyStream(result.data)).resolves.not.toHaveLength(0);
     });
   });

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -569,6 +569,128 @@ describe('A DataAccessorBasedStore', (): void => {
     });
   });
 
+  describe('serving a metadata-only request (e.g. HEAD)', (): void => {
+    const resourceID = { path: `${root}resource` };
+    const eTagHandler = new BasicETagHandler();
+    let metadataStore: DataAccessorBasedStore;
+    let getDataSpy: jest.SpyInstance;
+
+    // Stores a document with the given content-type, a size and a fixed modified date, so the metadata
+    // carries every header a HEAD response would (content-type, content-length, ETag, last-modified).
+    function storeResource(contentType = 'text/plain', body = 'data'): void {
+      const metadata = new RepresentationMetadata({ [RDF.type]: namedNode(LDP.Resource) });
+      metadata.identifier = namedNode(resourceID.path);
+      metadata.contentType = contentType;
+      metadata.set(POSIX.terms.size, toLiteral(body.length, XSD.terms.integer));
+      metadata.set(DC.terms.modified, toLiteral(now.toISOString(), XSD.terms.dateTime));
+      accessor.data[resourceID.path] = {
+        binary: true,
+        data: guardedStreamFrom([ body ]),
+        metadata,
+        isEmpty: false,
+      } as Representation;
+    }
+
+    beforeEach((): void => {
+      metadataStore = new DataAccessorBasedStore(
+        accessor,
+        identifierStrategy,
+        auxiliaryStrategy,
+        metadataStrategy,
+        false,
+        undefined,
+        true,
+      );
+      getDataSpy = jest.spyOn(accessor, 'getData');
+    });
+
+    it('skips the data fetch when no conversion is needed and returns empty data.', async(): Promise<void> => {
+      storeResource();
+      const preferences = { type: { 'text/plain': 1 }, metadataOnly: true };
+      const result = await metadataStore.getRepresentation(resourceID, preferences);
+      // The whole point of the optimization: the data was never read.
+      expect(getDataSpy).not.toHaveBeenCalled();
+      // The returned data stream is empty (a HEAD discards it anyway).
+      await expect(readableToString(result.data)).resolves.toBe('');
+      // Every header the HEAD response carries is still present in the metadata.
+      expect(result.metadata.contentType).toBe('text/plain');
+      expect(result.metadata.get(POSIX.terms.size)?.value).toBe('4');
+      expect(result.metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
+    });
+
+    it('returns metadata byte-identical to the full-read path.', async(): Promise<void> => {
+      storeResource();
+      const preferences = { type: { 'text/plain': 1 }};
+
+      // Full-read path: the default store fetches the data and returns the same metadata a HEAD would keep.
+      const fetched = await store.getRepresentation(resourceID, preferences);
+      fetched.data.destroy();
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+
+      // Skip path: the metadata-only store short-circuits without fetching the data.
+      const skipped = await metadataStore.getRepresentation(resourceID, { ...preferences, metadataOnly: true });
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+
+      // The ETag (derived from the metadata) and the full metadata are identical between the two paths.
+      expect(eTagHandler.getETag(skipped.metadata)).toBe(eTagHandler.getETag(fetched.metadata));
+      expect(skipped.metadata.identifier).toEqualRdfTerm(fetched.metadata.identifier);
+      expect(skipped.metadata.quads()).toBeRdfIsomorphic(fetched.metadata.quads());
+    });
+
+    it('skips the data fetch even when no type preferences are given.', async(): Promise<void> => {
+      storeResource();
+      const result = await metadataStore.getRepresentation(resourceID, { metadataOnly: true });
+      expect(getDataSpy).not.toHaveBeenCalled();
+      await expect(readableToString(result.data)).resolves.toBe('');
+    });
+
+    it('does not skip (fetches data) when the request is not metadata-only.', async(): Promise<void> => {
+      storeResource();
+      const result = await metadataStore.getRepresentation(resourceID, { type: { 'text/plain': 1 }});
+      await expect(readableToString(result.data)).resolves.toBe('data');
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not skip (fetches data) when a conversion would happen.', async(): Promise<void> => {
+      storeResource('text/plain');
+      // A different type is requested, so a conversion would occur and could change the response metadata.
+      const result = await metadataStore.getRepresentation(
+        resourceID,
+        { type: { 'text/turtle': 1 }, metadataOnly: true },
+      );
+      await expect(readableToString(result.data)).resolves.toBe('data');
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not skip (fetches data) when a byte range is requested.', async(): Promise<void> => {
+      storeResource();
+      const result = await metadataStore.getRepresentation(
+        resourceID,
+        { type: { 'text/plain': 1 }, metadataOnly: true, range: { unit: 'bytes', parts: [{ start: 0, end: 2 }]}},
+      );
+      await expect(readableToString(result.data)).resolves.toBe('data');
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not skip (fetches data) when the optimization is disabled.', async(): Promise<void> => {
+      storeResource();
+      // The default `store` is constructed without the optimizeMetadataOnly flag.
+      const result = await store.getRepresentation(resourceID, { type: { 'text/plain': 1 }, metadataOnly: true });
+      await expect(readableToString(result.data)).resolves.toBe('data');
+      expect(getDataSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not skip (fetches data) for a container request.', async(): Promise<void> => {
+      // A container falls in the container branch, which always composes its data from the metadata/children.
+      const containerID = { path: `${root}container/` };
+      accessor.data[containerID.path] = { metadata: new RepresentationMetadata(containerID) } as Representation;
+      const result = await metadataStore.getRepresentation(containerID, { metadataOnly: true });
+      expect(result.metadata.contentType).toBe(INTERNAL_QUADS);
+      // The container data (its quads) is still produced, unaffected by the metadata-only hint.
+      await expect(arrayifyStream(result.data)).resolves.not.toHaveLength(0);
+    });
+  });
+
   describe('adding a Resource', (): void => {
     it('will 404 if the identifier does not contain the root.', async(): Promise<void> => {
       await expect(store.addResource({ path: 'verybadpath' }, representation))


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

> **Stacked on #99 (and #98).** The base branch is `perf/metadata-first-304-skip`, so "Files changed" shows only this PR's own commits. Review/merge order: #98 → #99 → this.

#### 📁 Related issues

None yet — an issue must be opened on CommunitySolidServer/CommunitySolidServer before this is submitted upstream (the PR template requires one).

#### ✍️ Description

A `HEAD` request currently fetches and content-negotiates the full representation only to throw the body away: `HeadOperationHandler` calls `store.getRepresentation`, then destroys the data stream and answers from the metadata. On the file backend that is a wasted file open + read per `HEAD`.

This PR answers such a `HEAD` without opening the resource data, reusing the "no conversion will happen" predicate (`servedWithoutConversion`) introduced in #98 and shared with the #99 304-skip:

* `RepresentationPreferences` gains an optional `metadataOnly` hint, set by `HeadOperationHandler` (a `HEAD` always discards the body). This mirrors how #98 threads `range` through the preferences, so no new plumbing is needed through the store decorator chain. The hint is backwards compatible: a store that cannot determine the response metadata without reading the data simply ignores it, keeping the response unchanged.
* `DataAccessorBasedStore` gains an opt-in `optimizeMetadataOnly` constructor flag. When enabled, a metadata-only request for a regular resource, with no byte range, that this store can prove will not be converted returns an empty data stream instead of calling `accessor.getData`. Every other case (conversion, any range, containers, metadata resources, flag off) takes the unchanged full-read path.
* `UnionPreferenceParser` treats the new non-mergeable scalar like `range`; `AcceptPreferenceParser`'s key bookkeeping is updated. No parser ever sets the hint, so request parsing is unchanged.
* Enabled on the default file and memory backends (matching #99).

Why the skipped path cannot change the response: `accessor.getMetadata` runs unconditionally and produces the same metadata in both paths; `accessor.getData` returns only a stream and structurally cannot contribute a response header (`Content-Type`, `posix:size`, ETag, `Last-Modified` are all set by `getMetadata`); `Content-Length` is written by `RangeMetadataWriter` from `posix:size` in the metadata, never from the byte stream; and since `servedWithoutConversion` guarantees the outgoing converter chain is a no-op, the empty stream passes through it and the decorator chain untouched. `HeadOperationHandler` then applies `assertReadConditions` and returns `OkResponseDescription(metadata)` exactly as before.

Verification: unit tests assert the skip path returns metadata identical to the full-read path (RDF-isomorphic, same ETag) and that every deviation (not metadata-only, conversion, byte range, container, flag off) still fetches the data; integration tests run on both the memory and file backends and compare `HEAD` headers against the corresponding `GET` for the plain, converting, container, ranged, and conditional cases.

Measured effect: running the file-backend server under `strace -f -e trace=openat` and requesting a 6.7 MB `text/plain` resource:

| | data-file `openat` calls | headers |
|---|---|---|
| `GET` | 1 | `Content-Type`, `Content-Length: 6754388`, `ETag`, `Last-Modified`, `Accept-Ranges` |
| plain `HEAD` | 0 | identical (`Content-Length` served from the stored size) |

There is no committed benchmark harness for this, so the deterministic op count above is the reproducible evidence; no wall-clock numbers are claimed.

Since this changes the `RepresentationPreferences` interface and the `DataAccessorBasedStore` constructor signature, it should target the latest `versions/*` branch rather than `main`. Intended semver level: **minor** (backwards-compatible feature addition — stating it in prose since contributors cannot set the semver labels).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
