### PR TITLE
perf(identity): reuse known account ID on cookie refresh to drop a redundant read

### DIFF
--- a/src/identity/interaction/CookieInteractionHandler.ts
+++ b/src/identity/interaction/CookieInteractionHandler.ts
@@ -56,8 +56,10 @@ export class CookieInteractionHandler extends JsonInteractionHandler {
       return output;
     }
 
-    // Refresh the cookie, could be undefined if it was deleted by the operation
-    const expiration = await this.cookieStore.refresh(cookie);
+    // Refresh the cookie, reusing the account ID we just read to avoid a redundant lookup.
+    // Nothing mutates the cookie-to-account mapping between the read above and this call
+    // (only a read-only `getSetting`), so the previously fetched `accountId` is still valid.
+    const expiration = await this.cookieStore.refresh(cookie, accountId);
     if (expiration) {
       outputMetadata = outputMetadata ?? new RepresentationMetadata(input.target);
       outputMetadata.set(SOLID_HTTP.terms.accountCookie, cookie);

--- a/src/identity/interaction/account/util/BaseCookieStore.ts
+++ b/src/identity/interaction/account/util/BaseCookieStore.ts
@@ -26,10 +26,12 @@ export class BaseCookieStore implements CookieStore {
     return this.storage.get(cookie);
   }
 
-  public async refresh(cookie: string): Promise<Date | undefined> {
-    const accountId = await this.storage.get(cookie);
-    if (accountId) {
-      await this.storage.set(cookie, accountId, this.ttl);
+  public async refresh(cookie: string, accountId?: string): Promise<Date | undefined> {
+    // When the caller already knows the account ID (e.g. it just read it), reuse it
+    // to avoid a redundant storage read; otherwise look up the mapping ourselves.
+    const id = accountId ?? await this.storage.get(cookie);
+    if (id) {
+      await this.storage.set(cookie, id, this.ttl);
       return new Date(Date.now() + this.ttl);
     }
   }

--- a/src/identity/interaction/account/util/CookieStore.ts
+++ b/src/identity/interaction/account/util/CookieStore.ts
@@ -23,8 +23,12 @@ export interface CookieStore {
    * Refreshes the cookie expiration and returns when it will expire if the cookie exists.
    *
    * @param cookie - Cookie to refresh.
+   * @param accountId - The account ID already known to be associated with the cookie, if available.
+   *                    When provided, the store may skip re-reading the cookie-to-account mapping
+   *                    and refresh the expiration directly. When omitted, the mapping is looked up
+   *                    and the expiration is only refreshed if the cookie still maps to an account.
    */
-  refresh: (cookie: string) => Promise<Date | undefined>;
+  refresh: (cookie: string, accountId?: string) => Promise<Date | undefined>;
 
   /**
    * Deletes the given cookie.

--- a/test/unit/identity/interaction/CookieInteractionHandler.test.ts
+++ b/test/unit/identity/interaction/CookieInteractionHandler.test.ts
@@ -72,12 +72,14 @@ describe('A CookieInteractionHandler', (): void => {
     await expect(handler.handle(input)).resolves.toEqual(output);
     expect(source.handle).toHaveBeenCalledTimes(1);
     expect(source.handle).toHaveBeenLastCalledWith(input);
+    // The cookie-to-account mapping is only read once per request:
+    // the account ID is fetched here and reused for the refresh below.
     expect(cookieStore.get).toHaveBeenCalledTimes(1);
     expect(cookieStore.get).toHaveBeenLastCalledWith(cookie);
     expect(accountStore.getSetting).toHaveBeenCalledTimes(1);
     expect(accountStore.getSetting).toHaveBeenLastCalledWith(accountId, ACCOUNT_SETTINGS_REMEMBER_LOGIN);
     expect(cookieStore.refresh).toHaveBeenCalledTimes(1);
-    expect(cookieStore.refresh).toHaveBeenLastCalledWith(cookie);
+    expect(cookieStore.refresh).toHaveBeenLastCalledWith(cookie, accountId);
     expect(output.metadata?.get(SOLID_HTTP.terms.accountCookie)?.value).toBe(cookie);
     expect(output.metadata?.get(SOLID_HTTP.terms.accountCookieExpiration)?.value).toBe(date.toISOString());
   });
@@ -92,7 +94,7 @@ describe('A CookieInteractionHandler', (): void => {
     expect(accountStore.getSetting).toHaveBeenCalledTimes(1);
     expect(accountStore.getSetting).toHaveBeenLastCalledWith(accountId, ACCOUNT_SETTINGS_REMEMBER_LOGIN);
     expect(cookieStore.refresh).toHaveBeenCalledTimes(1);
-    expect(cookieStore.refresh).toHaveBeenLastCalledWith(cookie);
+    expect(cookieStore.refresh).toHaveBeenLastCalledWith(cookie, accountId);
     // Typescript things the typing of this is `never` since we deleted it above
     expect((output.metadata as any).get(SOLID_HTTP.terms.accountCookie)?.value).toBe(cookie);
     expect((output.metadata as any).get(SOLID_HTTP.terms.accountCookieExpiration)?.value).toBe(date.toISOString());
@@ -155,7 +157,7 @@ describe('A CookieInteractionHandler', (): void => {
     expect(accountStore.getSetting).toHaveBeenCalledTimes(1);
     expect(accountStore.getSetting).toHaveBeenLastCalledWith(accountId, ACCOUNT_SETTINGS_REMEMBER_LOGIN);
     expect(cookieStore.refresh).toHaveBeenCalledTimes(1);
-    expect(cookieStore.refresh).toHaveBeenLastCalledWith(cookie);
+    expect(cookieStore.refresh).toHaveBeenLastCalledWith(cookie, accountId);
     expect(output.metadata?.get(SOLID_HTTP.terms.accountCookie)).toBeUndefined();
     expect(output.metadata?.get(SOLID_HTTP.terms.accountCookieExpiration)).toBeUndefined();
   });

--- a/test/unit/identity/interaction/account/util/BaseCookieStore.test.ts
+++ b/test/unit/identity/interaction/account/util/BaseCookieStore.test.ts
@@ -45,6 +45,15 @@ describe('A BaseCookieStore', (): void => {
     expect(storage.set).toHaveBeenLastCalledWith(cookie, accountId, 14 * 24 * 60 * 60 * 1000);
   });
 
+  it('reuses a provided account ID to refresh without reading the storage.', async(): Promise<void> => {
+    await expect(store.refresh(cookie, 'other-id'))
+      .resolves.toEqual(new Date(now.getTime() + (14 * 24 * 60 * 60 * 1000)));
+    // The mapping is not re-read when the account ID is already known.
+    expect(storage.get).toHaveBeenCalledTimes(0);
+    expect(storage.set).toHaveBeenCalledTimes(1);
+    expect(storage.set).toHaveBeenLastCalledWith(cookie, 'other-id', 14 * 24 * 60 * 60 * 1000);
+  });
+
   it('does not reset the timer if there is no match.', async(): Promise<void> => {
     storage.get.mockResolvedValueOnce(undefined);
     await expect(store.refresh(cookie)).resolves.toBeUndefined();


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue describing the redundant read must be created before this is submitted to CommunitySolidServer (the PR template requires one).

#### ✍️ Description

On the authenticated `.account` request path, the same `cookie → accountId` mapping is read from storage twice per request: `CookieInteractionHandler.handle` reads it (`cookieStore.get(cookie)`) and guards on the result, then calls `cookieStore.refresh(cookie)`, and `BaseCookieStore.refresh` reads the very same mapping again before writing the refreshed TTL.

This PR adds an optional `accountId` parameter to `CookieStore.refresh`. When it is provided, `BaseCookieStore.refresh` skips its `storage.get` and writes directly; when it is omitted, behaviour is unchanged (get-then-set, no write if the cookie no longer maps to an account). `CookieInteractionHandler` passes the account ID it already read, so the mapping is read once per request instead of twice.

Why this is safe: the only operation between the handler's read and the `refresh` call is `accountStore.getSetting(...)` — a read-only lookup on the *account* store — so nothing mutates the `cookie → accountId` mapping in between, and the second read always returned the value the handler already had. The handler only reaches `refresh` after guarding `!accountId`, so the store still writes only for a real account. The parameter is optional, so any caller that omits it keeps the original semantics; `CookieInteractionHandler` is the only production caller. The sliding-expiration *write* on this path is deliberately untouched — this PR only removes the redundant read.

Reviewer note on the handler's previous inline comment ("could be undefined if it was deleted by the operation"): the source handler runs *before* the handler's own `cookieStore.get`, so a cookie deleted by the operation is already caught by the existing `!accountId` guard; the `if (expiration)` check remains because the interface still allows `undefined`.

Tests: a new `BaseCookieStore` unit test asserts the provided-ID path performs no storage read and writes the given ID with the configured TTL; the existing tests keep covering the omitted-ID paths, and the `CookieInteractionHandler` tests assert `refresh` receives the already-read account ID.

**Effect (deterministic op count).** Storage operations on the `cookie → accountId` mapping per authenticated `.account` request with `rememberLogin` enabled:

| | reads | writes |
| --- | --- | --- |
| before | 2 | 1 |
| after | 1 | 1 |

The saving is one `ExpiringStorage.get` per request (a round-trip when the storage backend is remote). No wall-clock benchmark exists for this path — the op-count table above is the reproducible evidence.

**Branch target and semver.** `CookieStore.refresh` is a public interface whose signature changes, so when submitted upstream this should target the latest `versions/*` branch (currently `versions/next-major`) rather than `main`. Intended semver level, stated in prose since contributors cannot set the labels: **minor** (backwards-compatible addition of an optional parameter) — major instead if the interface-signature change is judged breaking per the checklist definition.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
