### PR TITLE
ci: Add fork CI running the upstream test matrix

### DIFF
--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,18 +1,6 @@
-# Fork-scoped CI for jeswr/CommunitySolidServer.
-#
-# Mirrors the upstream test matrix (main.yml -> npm-test.yml / cth-test.yml) so
-# changes staged on the fork are validated the same way upstream validates
-# them, minus jobs that cannot work on a fork:
-#   - docker.yml        (needs upstream DockerHub secrets, pushes solidproject images)
-#   - mkdocs.yml        (release-only docs deploy to upstream gh-pages)
-#   - schedule.yml      (scheduled conformance runs; scheduled jobs trimmed)
-#   - Coveralls steps   (repo not registered on coveralls.io; coverage
-#                        thresholds are still enforced by jest.coverage.config.js)
-#   - windows-latest    (matrix-size reduction; upstream CI still covers Windows
-#                        when changes are upstreamed)
-#
-# Every job is guarded with `if: github.repository == 'jeswr/CommunitySolidServer'`
-# so this workflow stays inert if the file ever lands in the upstream repository.
+# Fork-only mirror of the upstream test matrix (main.yml -> npm-test.yml / cth-test.yml),
+# minus the Windows legs and the jobs that need upstream-only secrets or infrastructure.
+# The repository guard on every job keeps this workflow inert in the upstream repository.
 
 name: Fork CI
 
@@ -30,7 +18,6 @@ concurrency:
 
 jobs:
   lint:
-    # Mirrors upstream npm-test.yml `lint`.
     if: github.repository == 'jeswr/CommunitySolidServer'
     runs-on: ubuntu-latest
     steps:
@@ -42,8 +29,7 @@ jobs:
       - run: npm run lint
 
   test-unit:
-    # Mirrors upstream npm-test.yml `test-unit` with the full node-version
-    # spread, minus the windows-latest dimension and the Coveralls submission.
+    # Run unit tests on linux
     if: github.repository == 'jeswr/CommunitySolidServer'
     runs-on: ubuntu-latest
     strategy:
@@ -75,8 +61,7 @@ jobs:
         run: npm run test:unit
 
   test-integration:
-    # Mirrors upstream npm-test.yml `test-integration` (full suite, with
-    # external dependencies).
+    # Run integration tests on linux (full suite, with external dependencies)
     if: github.repository == 'jeswr/CommunitySolidServer'
     runs-on: ubuntu-latest
     strategy:
@@ -113,8 +98,7 @@ jobs:
         run: npm run test:integration
 
   test-configs:
-    # Mirrors upstream npm-test.yml `test-configs`: server startup with all
-    # configs inside the config/ folder.
+    # Test startup of CSS with all configs inside the config/ folder
     if: github.repository == 'jeswr/CommunitySolidServer'
     runs-on: ubuntu-latest
     services:
@@ -137,9 +121,7 @@ jobs:
         run: npm run test:deploy
 
   cth-test:
-    # Same as upstream main.yml: run the Conformance Test Harness on PRs
-    # targeting main, advisory only (ignore_failures). Reuses the upstream
-    # reusable workflow directly.
+    # Run the Conformance Test Harness on PRs targeting main
     if: github.repository == 'jeswr/CommunitySolidServer' && github.event_name == 'pull_request'
     uses: ./.github/workflows/cth-test.yml
     with:

--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -1,0 +1,147 @@
+# Fork-scoped CI for jeswr/CommunitySolidServer.
+#
+# Mirrors the upstream test matrix (main.yml -> npm-test.yml / cth-test.yml) so
+# changes staged on the fork are validated the same way upstream validates
+# them, minus jobs that cannot work on a fork:
+#   - docker.yml        (needs upstream DockerHub secrets, pushes solidproject images)
+#   - mkdocs.yml        (release-only docs deploy to upstream gh-pages)
+#   - schedule.yml      (scheduled conformance runs; scheduled jobs trimmed)
+#   - Coveralls steps   (repo not registered on coveralls.io; coverage
+#                        thresholds are still enforced by jest.coverage.config.js)
+#   - windows-latest    (matrix-size reduction; upstream CI still covers Windows
+#                        when changes are upstreamed)
+#
+# Every job is guarded with `if: github.repository == 'jeswr/CommunitySolidServer'`
+# so this workflow stays inert if the file ever lands in the upstream repository.
+
+name: Fork CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: fork-ci-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    # Mirrors upstream npm-test.yml `lint`.
+    if: github.repository == 'jeswr/CommunitySolidServer'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+      - run: npm ci --ignore-scripts
+      - run: npm run lint
+
+  test-unit:
+    # Mirrors upstream npm-test.yml `test-unit` with the full node-version
+    # spread, minus the windows-latest dimension and the Coveralls submission.
+    if: github.repository == 'jeswr/CommunitySolidServer'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - '18.0'
+          - 18.x
+          - '20.0'
+          - 20.x
+          - '22.1'
+          - 22.x
+          - '24.0'
+          - 24.x
+    timeout-minutes: 15
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Ensure line endings are consistent
+        run: git config --global core.autocrlf input
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+      - name: Install dependencies and run build scripts
+        run: npm ci
+      - name: Type-check tests
+        run: npm run test:ts
+      - name: Run unit tests
+        run: npm run test:unit
+
+  test-integration:
+    # Mirrors upstream npm-test.yml `test-integration` (full suite, with
+    # external dependencies).
+    if: github.repository == 'jeswr/CommunitySolidServer'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - 18.x
+          - 20.x
+          - 22.x
+          - 24.x
+    env:
+      TEST_DOCKER: true
+    services:
+      sparql-endpoint:
+        image: tenforce/virtuoso
+        env:
+          SPARQL_UPDATE: true
+        ports:
+          - 4000:8890
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+    timeout-minutes: 20
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+      - name: Install dependencies and run build scripts
+        run: npm ci
+      - name: Run integration tests
+        run: npm run test:integration
+
+  test-configs:
+    # Mirrors upstream npm-test.yml `test-configs`: server startup with all
+    # configs inside the config/ folder.
+    if: github.repository == 'jeswr/CommunitySolidServer'
+    runs-on: ubuntu-latest
+    services:
+      sparql-endpoint:
+        image: tenforce/virtuoso
+        env:
+          SPARQL_UPDATE: true
+        ports:
+          - 4000:8890
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+      - name: Check out repository
+        uses: actions/checkout@v7.0.0
+      - name: Install dependencies and run build scripts
+        run: npm ci
+      - name: Run deploy tests
+        run: npm run test:deploy
+
+  cth-test:
+    # Same as upstream main.yml: run the Conformance Test Harness on PRs
+    # targeting main, advisory only (ignore_failures). Reuses the upstream
+    # reusable workflow directly.
+    if: github.repository == 'jeswr/CommunitySolidServer' && github.event_name == 'pull_request'
+    uses: ./.github/workflows/cth-test.yml
+    with:
+      ignore_failures: true
+      version: 1.1.14 # The latest version that CSS is confirmed to pass


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready)

**Fork infrastructure only — not intended for upstream submission.** Every job is guarded by `if: github.repository == 'jeswr/CommunitySolidServer'`, so the workflow is inert if the file ever reaches the upstream repository.

#### 📁 Related issues

None — fork-only CI infrastructure, so no upstream issue exists. If this were ever submitted upstream, an issue must be created first: the upstream PR template hard-requires one.

#### ✍️ Description

Adds `.github/workflows/fork-ci.yml`, a fork-scoped workflow running the upstream test matrix on `push` and `pull_request` to this fork's `main`, so changes staged here (e.g. perf PRs) get the same validation upstream CI would give them.

It mirrors upstream `main.yml` → `npm-test.yml` with the same action versions, node versions, and npm scripts: `lint` (node 20.x), `test-unit` (the full node spread `18.0`–`24.x`; coverage thresholds still enforced by `jest.coverage.config.js`), `test-integration` (node 18.x–24.x, `TEST_DOCKER=true`, Virtuoso + Redis service containers), `test-configs` (`npm run test:deploy` with Virtuoso), and `cth-test` (Conformance Test Harness 1.1.14, PRs only, `ignore_failures: true`, reusing `./.github/workflows/cth-test.yml` directly). 15 jobs on a PR, 14 on a push; the `fork-ci-<branch>` concurrency group cancels superseded runs.

Deliberately not mirrored:

- `docker.yml` — needs upstream-only DockerHub secrets and pushes `solidproject/community-server` images.
- `mkdocs.yml` — release-only docs deploy to upstream gh-pages.
- `schedule.yml` — nightly scheduled conformance runs, out of scope for push/PR CI.
- The Coveralls submission and consolidation steps — the fork is not registered on coveralls.io, so every upload would fail. This is also why `npm-test.yml` is mirrored rather than called as a reusable workflow.
- The `windows-latest` matrix dimension (8 unit + 4 integration jobs) — a matrix-size reduction, not a fork limitation; upstream CI still covers Windows whenever a change is actually upstreamed. Easy to re-add.

Notes for review:

- Upstream's own "CI" workflow also triggers on `push`/`pull_request` to `main`, so with Actions enabled both run on the same events (and upstream's `docker` job fails on pushes for lack of secrets). Recommended: disable the "CI" workflow on this fork (Actions tab → CI → ⋯ → Disable workflow), and optionally "Documentation"; both re-enable with one click.
- Actions may need enabling on the fork (Settings → Actions → General → Allow all actions); if checks appear on this PR, it already is.
- YAML validated with a js-yaml parse + structural checks (all jobs guarded, valid `runs-on`/`uses`); the follow-up comment trim is proven behaviour-neutral by deep-equality of the parsed workflow before/after.
- The first commit is unsigned (the agent has no access to the signing key passphrase); re-sign on rebase if wanted.

Not a performance change, so no benchmarks apply. CI-only with no package change: no semver label applies (stated in prose — contributors cannot set labels) and no `RELEASE_NOTES.md` entry. Target branch is `main` — fork infrastructure, no interface or config-behaviour change, so `versions/*` targeting does not apply.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
