### PR TITLE
🚧 fix: Compare ETags correctly for weak validators and hyphenated content types

### DIFF
--- a/src/storage/conditions/BasicETagHandler.ts
+++ b/src/storage/conditions/BasicETagHandler.ts
@@ -25,7 +25,7 @@ export class BasicETagHandler implements ETagHandler {
     const { contentType } = metadata;
 
     // RFC 9110, §8.8.3.2: an `If-None-Match` header requires a weak comparison,
-    // meaning an optional `W/` prefix, as added by intermediaries such as compressing proxies, needs to be ignored.
+    // meaning an optional `W/` prefix needs to be ignored.
     const strippedETag = eTag.startsWith('W/') ? eTag.slice(2) : eTag;
 
     // Slicing of the double quotes

--- a/src/storage/conditions/BasicETagHandler.ts
+++ b/src/storage/conditions/BasicETagHandler.ts
@@ -24,8 +24,16 @@ export class BasicETagHandler implements ETagHandler {
     const date = new Date(modified.value);
     const { contentType } = metadata;
 
+    // RFC 9110, §8.8.3.2: an `If-None-Match` header requires a weak comparison,
+    // meaning an optional `W/` prefix, as added by intermediaries such as compressing proxies, needs to be ignored.
+    const strippedETag = eTag.startsWith('W/') ? eTag.slice(2) : eTag;
+
     // Slicing of the double quotes
-    const [ eTagTimestamp, eTagContentType ] = eTag.slice(1, -1).split('-');
+    const value = strippedETag.slice(1, -1);
+    // Only split on the first `-`, as content types can also contain a `-`, e.g., `application/n-quads`
+    const splitIndex = value.indexOf('-');
+    const eTagTimestamp = splitIndex >= 0 ? value.slice(0, splitIndex) : value;
+    const eTagContentType = splitIndex >= 0 ? value.slice(splitIndex + 1) : undefined;
 
     return eTagTimestamp === `${date.getTime()}` && (!strict || eTagContentType === contentType);
   }

--- a/test/unit/storage/conditions/BasicETagHandler.test.ts
+++ b/test/unit/storage/conditions/BasicETagHandler.test.ts
@@ -48,6 +48,52 @@ describe('A BasicETagHandler', (): void => {
     expect(handler.matchesETag(metadata, eTag, false)).toBe(true);
   });
 
+  it('matches weak ETags according to the RFC 9110 weak comparison.', async(): Promise<void> => {
+    expect(handler.matchesETag(metadata, `W/${eTag}`, true)).toBe(true);
+    expect(handler.matchesETag(metadata, `W/${eTag}`, false)).toBe(true);
+  });
+
+  it('does not match weak ETags corresponding to a different resource state.', async(): Promise<void> => {
+    const differentTime = `W/"${now.getTime() + 1}-${contentType}"`;
+    expect(handler.matchesETag(metadata, differentTime, true)).toBe(false);
+    expect(handler.matchesETag(metadata, differentTime, false)).toBe(false);
+  });
+
+  it('only ignores the content type of weak ETags when not comparing on representation level.', async():
+  Promise<void> => {
+    const differentType = `W/"${now.getTime()}-text/plain"`;
+    expect(handler.matchesETag(metadata, differentType, true)).toBe(false);
+    expect(handler.matchesETag(metadata, differentType, false)).toBe(true);
+  });
+
+  it('can validate generated ETags for content types containing hyphens.', async(): Promise<void> => {
+    for (const type of [ 'text/turtle', 'application/n-quads', 'application/n-triples', 'application/ld+json' ]) {
+      metadata.contentType = type;
+      const generated = handler.getETag(metadata)!;
+      expect(generated).toBe(`"${now.getTime()}-${type}"`);
+      expect(handler.matchesETag(metadata, generated, true)).toBe(true);
+      expect(handler.matchesETag(metadata, generated, false)).toBe(true);
+    }
+  });
+
+  it('keeps the full content type when it contains multiple hyphens.', async(): Promise<void> => {
+    metadata.contentType = 'application/x-fake-type';
+    expect(handler.matchesETag(metadata, `"${now.getTime()}-application/x-fake-type"`, true)).toBe(true);
+    expect(handler.matchesETag(metadata, `"${now.getTime()}-application/x-fake"`, true)).toBe(false);
+  });
+
+  it('does not match malformed ETags.', async(): Promise<void> => {
+    expect(handler.matchesETag(metadata, 'no-quotes', true)).toBe(false);
+    expect(handler.matchesETag(metadata, 'no-quotes', false)).toBe(false);
+    expect(handler.matchesETag(metadata, '""', true)).toBe(false);
+    expect(handler.matchesETag(metadata, `"${now.getTime()}"`, true)).toBe(false);
+  });
+
+  it('does not require a content type in the ETag when not comparing on representation level.', async():
+  Promise<void> => {
+    expect(handler.matchesETag(metadata, `"${now.getTime()}"`, false)).toBe(true);
+  });
+
   it('can verify if 2 ETags reference the same resource state.', async(): Promise<void> => {
     expect(handler.sameResourceState(eTag, eTag)).toBe(true);
     expect(handler.sameResourceState(eTag, `"${now.getTime()}-text/plain"`)).toBe(true);


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — the PR template requires one, so an upstream issue describing these two defects must be created before this is submitted to CommunitySolidServer; it will be linked here.

#### ✍️ Description

`BasicETagHandler.matchesETag`, the validator comparison behind `304`/`412` handling for conditional requests, has two RFC 9110 conformance defects:

1. **Weak validators never match.** The parse only slices off the surrounding quotes, so an incoming `If-None-Match: W/"1234-text/turtle"` yields the "timestamp" `/"1234` and can never equal the stored value. RFC 9110 [§8.8.3.2](https://www.rfc-editor.org/rfc/rfc9110#section-8.8.3.2) requires weak comparison for `If-None-Match`, which ignores the `W/` prefix. Weak ETags occur in practice because intermediaries such as compressing proxies (e.g. nginx `gzip`) and several CDNs weaken them, so clients behind one permanently lose `304` revalidation and their write preconditions never match.
2. **Hyphenated content types never match strictly.** The ETag embeds the content type after a `-` separator, but the parse split on *every* `-`: `"1234-application/n-quads"` yielded the content type `application/n`. Strict comparison was therefore always false, so `application/n-quads` / `application/n-triples` representations could never produce a `304`.

The fix is confined to `matchesETag`: strip an optional leading `W/` before slicing the quotes, and split on the *first* `-` only, keeping the full remainder as the content type. `getETag` (generation) and `sameResourceState` are byte-for-byte unchanged, so ETags already held by client caches stay valid. The `strict` parameter keeps its meaning (representation-level vs. resource-level comparison). No interface, config, or `index.ts` changes.

The change is a pure widening: the only observable difference is that conditional requests which previously (incorrectly) never matched now match — some responses change from `200` to `304`, and failing preconditions on writes now correctly yield `412` for weak validators — exactly the cases RFC 9110 prescribes. Identical strong-ETag round-trips behave exactly as before, and every pre-existing test passes untouched. The motivation is conformance rather than performance, so no benchmark is included; there is no reproducible benchmark command for the incidental bandwidth saving of the extra `304`s.

Both defects were reproduced with failing tests first (4 new tests failed on the unfixed code). New unit tests cover weak match/mismatch (strict and non-strict), `getETag` → `matchesETag` round-trips for `text/turtle`, `application/n-quads`, `application/n-triples` and `application/ld+json`, multi-hyphen content types, and malformed ETags (no quotes / no hyphen — no match, no throw). `BasicETagHandler.ts` remains at 100% coverage.

This is a backwards-compatible bug fix: intended semver level is **patch** (contributors cannot set the label), targeting `main` per the branch policy for patch updates.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
