### PR TITLE
feat: Add a Redis implementation of the cluster activity bus (fan-out Phase 2a)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -385,6 +385,7 @@ export * from './server/notifications/cluster/ClusterActivityBus';
 export * from './server/notifications/cluster/ClusterActivityEmitter';
 export * from './server/notifications/cluster/ClusterActivityUtil';
 export * from './server/notifications/cluster/InMemoryActivityBus';
+export * from './server/notifications/cluster/RedisActivityBus';
 
 // Server/Notifications/Generate
 export * from './server/notifications/generate/ActivityNotificationGenerator';

--- a/src/server/notifications/cluster/RedisActivityBus.ts
+++ b/src/server/notifications/cluster/RedisActivityBus.ts
@@ -1,0 +1,129 @@
+import Redis from 'ioredis';
+import type { Finalizable } from '../../../init/final/Finalizable';
+import type { Initializable } from '../../../init/Initializable';
+import { getLoggerFor } from '../../../logging/LogUtil';
+import { createErrorMessage } from '../../../util/errors/ErrorUtil';
+import type { RedisSettings } from '../../../util/locking/RedisLocker';
+import type { ClusterActivityBus, SerializedActivity } from './ClusterActivityBus';
+
+/**
+ * A {@link ClusterActivityBus} backed by Redis pub/sub, for multi-instance deployments.
+ *
+ * Activities cross the wire as the JSON encoding of a {@link SerializedActivity}.
+ * That envelope is transported byte-for-byte and is never re-encoded,
+ * which keeps the two invariants of the wire format intact:
+ * the metadata identifier term stays explicitly available
+ * (it can be a blank node, so it can not be derived from the topic),
+ * and the metadata quads stay in their exact N-Quads form,
+ * whose blank node labels the deserializer relies on.
+ *
+ * All instances publish on, and subscribe to, a single Redis channel.
+ * The channel name defaults to `css:activity` and is prefixed with the `namespacePrefix` setting,
+ * scoping it the same way {@link RedisLocker} scopes its keys on a shared Redis server.
+ *
+ * Because Redis delivers published messages to every subscribed connection,
+ * including other connections of the publishing process,
+ * activities loop back to the publishing instance as the bus contract requires.
+ * A Redis connection in subscriber mode can not issue regular commands,
+ * so this class uses two connections: one to publish and one to subscribe.
+ * Both are created on construction, mirroring {@link RedisLocker};
+ * the subscription starts on `initialize` and both connections close on `finalize`.
+ */
+export class RedisActivityBus implements ClusterActivityBus, Initializable, Finalizable {
+  protected readonly logger = getLoggerFor(this);
+
+  private readonly publisher: Redis;
+  private readonly subscriber: Redis;
+  private readonly channel: string;
+  private readonly listeners: ((activity: SerializedActivity) => void)[] = [];
+  private finalized = false;
+
+  /**
+   * Creates a new RedisActivityBus.
+   *
+   * @param redisClient - Redis connection string of a standalone Redis node.
+   * @param channel - Name of the Redis channel used to exchange activities.
+   * @param redisSettings - Additional settings used to create the Redis clients.
+   *                        The `namespacePrefix` setting prefixes the channel name.
+   */
+  public constructor(redisClient = '127.0.0.1:6379', channel = 'css:activity', redisSettings?: RedisSettings) {
+    redisSettings = { namespacePrefix: '', ...redisSettings };
+    const { namespacePrefix, ...options } = redisSettings;
+    this.publisher = this.createRedisClient(redisClient, options);
+    this.subscriber = this.createRedisClient(redisClient, options);
+    this.channel = `${namespacePrefix}${channel}`;
+  }
+
+  /**
+   * Generate and return a RedisClient based on the provided string.
+   * Identical to the client creation of {@link RedisLocker}.
+   *
+   * @param redisClientString - A string that contains either a host address and a
+   *                            port number like '127.0.0.1:6379' or just a port number like '6379'.
+   * @param options - Settings used to create the client.
+   */
+  private createRedisClient(redisClientString: string, options: Omit<RedisSettings, 'namespacePrefix'>): Redis {
+    if (redisClientString.length > 0) {
+      // Check if port number or ip with port number
+      // Definitely not perfect, but configuring this is only for experienced users
+      const match = /^(?:([^:]+):)?(\d{4,5})$/u.exec(redisClientString);
+      if (!match?.[2]) {
+        // At least a port number should be provided
+        throw new Error(`Invalid data provided to create a Redis client: ${redisClientString}\n
+            Please provide a port number like '6379' or a host address and a port number like '127.0.0.1:6379'`);
+      }
+      const port = Number(match[2]);
+      const host = match[1];
+      return new Redis(port, host, options);
+    }
+    throw new Error(`Empty redisClientString provided!\n
+            Please provide a port number like '6379' or a host address and a port number like '127.0.0.1:6379'`);
+  }
+
+  public async publish(activity: SerializedActivity): Promise<void> {
+    if (this.finalized) {
+      throw new Error('Invalid state: cannot publish activities once finalize() has been called.');
+    }
+    await this.publisher.publish(this.channel, JSON.stringify(activity));
+  }
+
+  public subscribe(listener: (activity: SerializedActivity) => void): void {
+    // Listeners can subscribe at any time, but delivery only starts once `initialize` has been called
+    this.listeners.push(listener);
+  }
+
+  /* Initializer & Finalizer methods */
+
+  public async initialize(): Promise<void> {
+    // The `message` event only fires for channels this connection is subscribed to,
+    // which is only ever `this.channel`, so no further filtering is needed.
+    this.subscriber.on('message', (channel: string, message: string): void => this.handleMessage(message));
+    await this.subscriber.subscribe(this.channel);
+  }
+
+  public async finalize(): Promise<void> {
+    this.finalized = true;
+    try {
+      await this.subscriber.quit();
+    } finally {
+      // Always quit the publishing client as well
+      await this.publisher.quit();
+    }
+  }
+
+  /**
+   * Calls all registered listeners with the parsed activity.
+   * Errors are logged instead of thrown,
+   * as a malformed message on the shared channel should not take down the process.
+   */
+  private handleMessage(message: string): void {
+    try {
+      const activity = JSON.parse(message) as SerializedActivity;
+      for (const listener of this.listeners) {
+        listener(activity);
+      }
+    } catch (error: unknown) {
+      this.logger.error(`Error handling activity message: ${createErrorMessage(error)}`);
+    }
+  }
+}

--- a/src/server/notifications/cluster/RedisActivityBus.ts
+++ b/src/server/notifications/cluster/RedisActivityBus.ts
@@ -8,26 +8,10 @@ import type { ClusterActivityBus, SerializedActivity } from './ClusterActivityBu
 
 /**
  * A {@link ClusterActivityBus} backed by Redis pub/sub, for multi-instance deployments.
- *
- * Activities cross the wire as the JSON encoding of a {@link SerializedActivity}.
- * That envelope is transported byte-for-byte and is never re-encoded,
- * which keeps the two invariants of the wire format intact:
- * the metadata identifier term stays explicitly available
- * (it can be a blank node, so it can not be derived from the topic),
- * and the metadata quads stay in their exact N-Quads form,
- * whose blank node labels the deserializer relies on.
- *
- * All instances publish on, and subscribe to, a single Redis channel.
- * The channel name defaults to `css:activity` and is prefixed with the `namespacePrefix` setting,
- * scoping it the same way {@link RedisLocker} scopes its keys on a shared Redis server.
- *
- * Because Redis delivers published messages to every subscribed connection,
- * including other connections of the publishing process,
- * activities loop back to the publishing instance as the bus contract requires.
- * A Redis connection in subscriber mode can not issue regular commands,
- * so this class uses two connections: one to publish and one to subscribe.
- * Both are created on construction, mirroring {@link RedisLocker};
- * the subscription starts on `initialize` and both connections close on `finalize`.
+ * All instances share a single Redis channel, prefixed with the `namespacePrefix` setting.
+ * Redis delivers published messages to every subscribed connection, including those of the publishing process,
+ * so activities loop back to the publishing instance as the bus contract requires.
+ * A connection in subscriber mode can not issue regular commands, so separate connections publish and subscribe.
  */
 export class RedisActivityBus implements ClusterActivityBus, Initializable, Finalizable {
   protected readonly logger = getLoggerFor(this);
@@ -95,8 +79,7 @@ export class RedisActivityBus implements ClusterActivityBus, Initializable, Fina
   /* Initializer & Finalizer methods */
 
   public async initialize(): Promise<void> {
-    // The `message` event only fires for channels this connection is subscribed to,
-    // which is only ever `this.channel`, so no further filtering is needed.
+    // This connection only ever subscribes to `this.channel`, so incoming messages need no filtering
     this.subscriber.on('message', (channel: string, message: string): void => this.handleMessage(message));
     await this.subscriber.subscribe(this.channel);
   }

--- a/test/unit/server/notifications/cluster/RedisActivityBus.test.ts
+++ b/test/unit/server/notifications/cluster/RedisActivityBus.test.ts
@@ -123,7 +123,7 @@ describe('A RedisActivityBus', (): void => {
     await expect(bus.publish(activity)).resolves.toBeUndefined();
     expect(publisher.publish).toHaveBeenCalledTimes(1);
     expect(publisher.publish).toHaveBeenLastCalledWith('css:activity', JSON.stringify(activity));
-    // The envelope decodes losslessly, keeping the explicit identifier term and the N-Quads intact
+    // The payload decodes losslessly back to the original activity
     expect(JSON.parse(publisher.publish.mock.calls[0][1])).toEqual(activity);
   });
 

--- a/test/unit/server/notifications/cluster/RedisActivityBus.test.ts
+++ b/test/unit/server/notifications/cluster/RedisActivityBus.test.ts
@@ -1,0 +1,188 @@
+import EventEmitter from 'node:events';
+import type { Logger } from '../../../../../src/logging/Logger';
+import { getLoggerFor } from '../../../../../src/logging/LogUtil';
+import type { SerializedActivity } from '../../../../../src/server/notifications/cluster/ClusterActivityBus';
+import { RedisActivityBus } from '../../../../../src/server/notifications/cluster/RedisActivityBus';
+
+/**
+ * The mock of an ioredis client, one instance per `new Redis()` call.
+ */
+type MockRedis = EventEmitter & {
+  publish: jest.Mock;
+  subscribe: jest.Mock;
+  quit: jest.Mock;
+  port: number;
+  host?: string;
+  options: Record<string, unknown>;
+};
+
+const mockClients: MockRedis[] = [];
+
+jest.mock('ioredis', (): any => jest.fn().mockImplementation(
+  (port: number, host?: string, options?: Record<string, unknown>): MockRedis => {
+    const client: MockRedis = Object.assign(new EventEmitter(), {
+      publish: jest.fn().mockResolvedValue(1),
+      subscribe: jest.fn().mockResolvedValue(1),
+      quit: jest.fn().mockResolvedValue('OK'),
+      port,
+      host,
+      options: options ?? {},
+    });
+    mockClients.push(client);
+    return client;
+  },
+));
+
+jest.mock('../../../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { error: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+
+describe('A RedisActivityBus', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
+  const activity: SerializedActivity = {
+    topic: 'http://example.com/foo',
+    activity: 'https://www.w3.org/ns/activitystreams#Add',
+    metadata: {
+      identifier: { termType: 'BlankNode', value: 'b1' },
+      quads: '_:b1 <https://www.w3.org/ns/activitystreams#object> <http://example.com/foo/bar> .\n',
+    },
+  };
+  let bus: RedisActivityBus;
+  let publisher: MockRedis;
+  let subscriber: MockRedis;
+
+  beforeEach(async(): Promise<void> => {
+    jest.clearAllMocks();
+    mockClients.length = 0;
+    bus = new RedisActivityBus('6379');
+    [ publisher, subscriber ] = mockClients;
+  });
+
+  it('connects to localhost by default.', async(): Promise<void> => {
+    mockClients.length = 0;
+    // eslint-disable-next-line no-new
+    new RedisActivityBus();
+    expect(mockClients).toHaveLength(2);
+    for (const client of mockClients) {
+      expect(client.port).toBe(6379);
+      expect(client.host).toBe('127.0.0.1');
+    }
+  });
+
+  it('creates a separate publisher and subscriber client.', async(): Promise<void> => {
+    expect(mockClients).toHaveLength(2);
+    expect(publisher.port).toBe(6379);
+    expect(publisher.host).toBeUndefined();
+    expect(subscriber.port).toBe(6379);
+    expect(subscriber.host).toBeUndefined();
+  });
+
+  it('parses the connection string and passes on the Redis settings.', async(): Promise<void> => {
+    mockClients.length = 0;
+    // eslint-disable-next-line no-new
+    new RedisActivityBus('myhost:16379', 'css:activity', { namespacePrefix: 'pre:', username: 'user', db: 4 });
+    expect(mockClients).toHaveLength(2);
+    for (const client of mockClients) {
+      expect(client.port).toBe(16379);
+      expect(client.host).toBe('myhost');
+      // The `namespacePrefix` setting is not a client option
+      expect(client.options).toEqual({ username: 'user', db: 4 });
+    }
+  });
+
+  it('errors on invalid connection strings.', async(): Promise<void> => {
+    expect((): RedisActivityBus => new RedisActivityBus('noport'))
+      .toThrow('Invalid data provided to create a Redis client: noport');
+    expect((): RedisActivityBus => new RedisActivityBus('123'))
+      .toThrow('Invalid data provided to create a Redis client: 123');
+    expect((): RedisActivityBus => new RedisActivityBus(''))
+      .toThrow('Empty redisClientString provided!');
+  });
+
+  it('subscribes to the channel on initialize.', async(): Promise<void> => {
+    await expect(bus.initialize()).resolves.toBeUndefined();
+    expect(subscriber.subscribe).toHaveBeenCalledTimes(1);
+    expect(subscriber.subscribe).toHaveBeenLastCalledWith('css:activity');
+    expect(publisher.subscribe).toHaveBeenCalledTimes(0);
+  });
+
+  it('prefixes the channel with the namespacePrefix.', async(): Promise<void> => {
+    mockClients.length = 0;
+    const prefixedBus = new RedisActivityBus('6379', 'my:channel', { namespacePrefix: 'tenant1:' });
+    const [ prefixedPublisher, prefixedSubscriber ] = mockClients;
+
+    await prefixedBus.initialize();
+    expect(prefixedSubscriber.subscribe).toHaveBeenLastCalledWith('tenant1:my:channel');
+
+    await prefixedBus.publish(activity);
+    expect(prefixedPublisher.publish).toHaveBeenLastCalledWith('tenant1:my:channel', JSON.stringify(activity));
+  });
+
+  it('publishes activities as JSON on the channel.', async(): Promise<void> => {
+    await expect(bus.publish(activity)).resolves.toBeUndefined();
+    expect(publisher.publish).toHaveBeenCalledTimes(1);
+    expect(publisher.publish).toHaveBeenLastCalledWith('css:activity', JSON.stringify(activity));
+    // The envelope decodes losslessly, keeping the explicit identifier term and the N-Quads intact
+    expect(JSON.parse(publisher.publish.mock.calls[0][1])).toEqual(activity);
+  });
+
+  it('delivers received messages to all subscribed listeners.', async(): Promise<void> => {
+    const listener1 = jest.fn();
+    const listener2 = jest.fn();
+    bus.subscribe(listener1);
+    bus.subscribe(listener2);
+    await bus.initialize();
+
+    subscriber.emit('message', 'css:activity', JSON.stringify(activity));
+
+    expect(listener1).toHaveBeenCalledTimes(1);
+    expect(listener1).toHaveBeenLastCalledWith(activity);
+    expect(listener2).toHaveBeenCalledTimes(1);
+    expect(listener2).toHaveBeenLastCalledWith(activity);
+    expect(logger.error).toHaveBeenCalledTimes(0);
+  });
+
+  it('logs an error on malformed messages.', async(): Promise<void> => {
+    const listener = jest.fn();
+    bus.subscribe(listener);
+    await bus.initialize();
+
+    subscriber.emit('message', 'css:activity', 'not json');
+
+    expect(listener).toHaveBeenCalledTimes(0);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith(expect.stringContaining('Error handling activity message: '));
+  });
+
+  it('logs an error when a listener errors.', async(): Promise<void> => {
+    bus.subscribe(jest.fn().mockImplementation((): never => {
+      throw new Error('bad listener');
+    }));
+    await bus.initialize();
+
+    subscriber.emit('message', 'css:activity', JSON.stringify(activity));
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith('Error handling activity message: bad listener');
+  });
+
+  it('quits both clients on finalize.', async(): Promise<void> => {
+    await expect(bus.finalize()).resolves.toBeUndefined();
+    expect(subscriber.quit).toHaveBeenCalledTimes(1);
+    expect(publisher.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('still quits the publisher when the subscriber fails to quit.', async(): Promise<void> => {
+    subscriber.quit.mockRejectedValue(new Error('quit failure'));
+    await expect(bus.finalize()).rejects.toThrow('quit failure');
+    expect(publisher.quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('errors when publishing after finalize.', async(): Promise<void> => {
+    await bus.finalize();
+    await expect(bus.publish(activity)).rejects
+      .toThrow('Invalid state: cannot publish activities once finalize() has been called.');
+    expect(publisher.publish).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

> **Stacked PR:** based on `feat/cluster-activity-bus` (#106). Until #106 lands the diff shows both changes; once it merges, this branch needs a rebase so only the Redis commit remains.

#### 📁 Related issues

None yet — before this is submitted upstream to CommunitySolidServer, an issue describing the cross-instance notification gap must be created there first (the upstream template requires one).

#### ✍️ Description

Adds `RedisActivityBus`, a `ClusterActivityBus` backed by Redis pub/sub, so the resource-change activities introduced in #106 reach every instance of a multi-instance deployment. This is purely additive library code: a new class, its `src/index.ts` export, and unit tests. There is no `config/*.json` wiring yet (that lands with the follow-up introducing the cluster-mode configuration), no change to any default, and no new dependency — `ioredis` is already used by `RedisLocker`.

Design, mirroring `RedisLocker` where possible:

* All instances publish on and subscribe to a single channel (default `css:activity`), prefixed with the `namespacePrefix` setting the same way `RedisLocker` scopes its keys on a shared Redis server. Connection-string parsing and the `RedisSettings` type are identical to `RedisLocker`.
* A Redis connection in subscriber mode cannot issue regular commands, so the bus holds one publishing and one subscribing connection. Both are created on construction; the subscription starts in `initialize()`; both `quit()` in `finalize()` (the publisher is closed even if the subscriber fails to quit), and publishing after `finalize()` fails with an invalid-state error, like `RedisLocker`'s finalized guard.
* Redis delivers published messages to every subscribed connection, including other connections of the publishing process, so activities loop back to the publishing instance as the `ClusterActivityBus` contract requires — no local re-delivery is needed.
* The bus transports the JSON encoding of a `SerializedActivity` byte-for-byte and never re-encodes it. That preserves the two wire-format invariants established in #106: the metadata identifier term is carried explicitly (it can be a blank node — e.g. container `Add`/`Remove` metadata — so it cannot be derived from the topic), and the metadata quads keep their exact N-Quads text, whose blank-node labels the deserializer relies on. A unit test asserts the published payload decodes losslessly back to the original activity.
* A malformed message on the shared channel, or a throwing listener, is logged rather than thrown: a bad message must not take down the process.

The unit tests mirror the `RedisLocker` test approach (`jest.mock('ioredis')`, one mock client per construction) and cover the new class at 100% statements/branches/functions/lines, matching the repo's `./src` coverage gate.

This is a backwards-compatible feature addition, so the intended semver level is **minor** (stated here in prose since contributors cannot set labels). As a feature it should target the latest `versions/*` branch (currently `versions/next-major`) when submitted upstream; here it is stacked on #106 and will be retargeted together with that PR.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
