### PR TITLE
perf(identity): throttle cookie-refresh writes on the authed .account path (default 1 min, configurable)

### DIFF
--- a/config/identity/handler/storage/default.json
+++ b/config/identity/handler/storage/default.json
@@ -37,7 +37,7 @@
       "@type": "BaseCookieStore",
       "comment": [
         "refreshThreshold: a refresh only re-persists the cookie expiration when it advances it by more than this many milliseconds.",
-        "Set to 0 to persist a fresh expiration on every authenticated account request (pre-throttling behaviour)."
+        "Set to 0 to persist a fresh expiration on every authenticated account request."
       ],
       "refreshThreshold": 60000,
       "storage": {

--- a/config/identity/handler/storage/default.json
+++ b/config/identity/handler/storage/default.json
@@ -35,6 +35,11 @@
     {
       "@id": "urn:solid-server:default:CookieStore",
       "@type": "BaseCookieStore",
+      "comment": [
+        "refreshThreshold: a refresh only re-persists the cookie expiration when it advances it by more than this many milliseconds.",
+        "Set to 0 to persist a fresh expiration on every authenticated account request (pre-throttling behaviour)."
+      ],
+      "refreshThreshold": 60000,
       "storage": {
         "@id": "urn:solid-server:default:CookieStorage",
         "@type": "WrappedExpiringStorage",

--- a/documentation/markdown/usage/account/json-api.md
+++ b/documentation/markdown/usage/account/json-api.md
@@ -34,6 +34,11 @@ to achieve the same result.
 
 The expiration time of this cookie will be refreshed
 every time there is a successful request to the server with that cookie.
+To reduce storage writes, the refreshed expiration is only persisted
+when it advances the stored expiration by more than a threshold, 1 minute by default.
+This threshold can be changed through the `refreshThreshold` parameter
+of `urn:solid-server:default:CookieStore`, in milliseconds.
+Setting it to 0 persists a fresh expiration on every request.
 
 ## Redirecting
 

--- a/src/identity/interaction/account/util/BaseCookieStore.ts
+++ b/src/identity/interaction/account/util/BaseCookieStore.ts
@@ -7,15 +7,10 @@ import type { CookieStore } from './CookieStore';
  * Cookies have a specified time to live in seconds, default is 14 days,
  * after which they will be removed.
  *
- * To avoid a storage write on every refresh,
- * the expiration is only re-persisted when it would advance the stored expiration
- * by more than `refreshThreshold` milliseconds.
- * When the write is skipped, the currently stored expiration is returned,
- * so the expiration communicated to the client always matches the state stored on the server.
- * As the decision is based on the stored expiration,
- * it is consistent across multiple worker threads or server instances sharing the same storage.
- * Setting `refreshThreshold` to 0 disables the throttling entirely,
- * restoring a write on every refresh.
+ * To avoid a storage write on every refresh, the expiration is only re-persisted
+ * when it advances the stored expiration by more than `refreshThreshold` milliseconds.
+ * A skipped refresh returns the stored expiration, so the expiration sent to the client
+ * always matches the stored state. Setting `refreshThreshold` to 0 disables the throttling.
  */
 export class BaseCookieStore implements CookieStore {
   private readonly storage: ExpiringStorage<string, string>;
@@ -60,19 +55,9 @@ export class BaseCookieStore implements CookieStore {
     if (this.refreshThreshold > 0) {
       // Storages that cannot report the stored expiration fall through to a write on every refresh.
       const stored = await this.storage.getExpiration?.(cookie);
-      // Skip the write if it would advance the stored expiration by less than the threshold.
-      // Reading the shared stored expiration (instead of tracking writes per instance)
-      // keeps this decision consistent across worker threads/instances,
-      // and it is much cheaper than the (locked) write it replaces.
-      // Returning the *stored* expiration rather than a freshly computed one
-      // keeps the `Set-Cookie` expiration sent to the client identical to the server-side state,
-      // so the two can never diverge.
-      // A session can thus expire at most `refreshThreshold` earlier than without throttling,
-      // and its validity is never extended.
-      // A negative advance means the stored expiration exceeds a fresh one (e.g. after a TTL reduction),
-      // in which case the fresh expiration is persisted, exactly as it would be without throttling.
       if (stored) {
         const advance = Date.now() + this.ttl - stored.getTime();
+        // A negative advance (stored expiration past a fresh one, e.g. after a TTL reduction) falls through to a write.
         if (advance >= 0 && advance <= this.refreshThreshold) {
           return stored;
         }

--- a/src/identity/interaction/account/util/BaseCookieStore.ts
+++ b/src/identity/interaction/account/util/BaseCookieStore.ts
@@ -6,14 +6,37 @@ import type { CookieStore } from './CookieStore';
  * A {@link CookieStore} that uses an {@link ExpiringStorage} to keep track of the stored cookies.
  * Cookies have a specified time to live in seconds, default is 14 days,
  * after which they will be removed.
+ *
+ * To avoid a storage write on every refresh,
+ * the expiration is only re-persisted when it would advance the stored expiration
+ * by more than `refreshThreshold` milliseconds.
+ * When the write is skipped, the currently stored expiration is returned,
+ * so the expiration communicated to the client always matches the state stored on the server.
+ * As the decision is based on the stored expiration,
+ * it is consistent across multiple worker threads or server instances sharing the same storage.
+ * Setting `refreshThreshold` to 0 disables the throttling entirely,
+ * restoring a write on every refresh.
  */
 export class BaseCookieStore implements CookieStore {
   private readonly storage: ExpiringStorage<string, string>;
   private readonly ttl: number;
+  private readonly refreshThreshold: number;
 
-  public constructor(storage: ExpiringStorage<string, string>, ttl = 14 * 24 * 60 * 60) {
+  /**
+   * @param storage - Storage used to store the cookies and their expiration.
+   * @param ttl - How long the cookies should stay valid, in seconds. Defaults to 14 days.
+   * @param refreshThreshold - How much a refresh needs to advance the stored expiration
+   *   before it gets re-persisted, in milliseconds. Defaults to 1 minute.
+   *   Set to 0 to persist a fresh expiration on every refresh.
+   */
+  public constructor(
+    storage: ExpiringStorage<string, string>,
+    ttl = 14 * 24 * 60 * 60,
+    refreshThreshold = 60 * 1000,
+  ) {
     this.storage = storage;
     this.ttl = ttl * 1000;
+    this.refreshThreshold = refreshThreshold;
   }
 
   public async generate(accountId: string): Promise<string> {
@@ -30,10 +53,34 @@ export class BaseCookieStore implements CookieStore {
     // When the caller already knows the account ID (e.g. it just read it), reuse it
     // to avoid a redundant storage read; otherwise look up the mapping ourselves.
     const id = accountId ?? await this.storage.get(cookie);
-    if (id) {
-      await this.storage.set(cookie, id, this.ttl);
-      return new Date(Date.now() + this.ttl);
+    if (!id) {
+      return;
     }
+
+    if (this.refreshThreshold > 0) {
+      // Storages that cannot report the stored expiration fall through to a write on every refresh.
+      const stored = await this.storage.getExpiration?.(cookie);
+      // Skip the write if it would advance the stored expiration by less than the threshold.
+      // Reading the shared stored expiration (instead of tracking writes per instance)
+      // keeps this decision consistent across worker threads/instances,
+      // and it is much cheaper than the (locked) write it replaces.
+      // Returning the *stored* expiration rather than a freshly computed one
+      // keeps the `Set-Cookie` expiration sent to the client identical to the server-side state,
+      // so the two can never diverge.
+      // A session can thus expire at most `refreshThreshold` earlier than without throttling,
+      // and its validity is never extended.
+      // A negative advance means the stored expiration exceeds a fresh one (e.g. after a TTL reduction),
+      // in which case the fresh expiration is persisted, exactly as it would be without throttling.
+      if (stored) {
+        const advance = Date.now() + this.ttl - stored.getTime();
+        if (advance >= 0 && advance <= this.refreshThreshold) {
+          return stored;
+        }
+      }
+    }
+
+    await this.storage.set(cookie, id, this.ttl);
+    return new Date(Date.now() + this.ttl);
   }
 
   public async delete(cookie: string): Promise<boolean> {

--- a/src/identity/interaction/account/util/CookieStore.ts
+++ b/src/identity/interaction/account/util/CookieStore.ts
@@ -22,6 +22,9 @@ export interface CookieStore {
   /**
    * Refreshes the cookie expiration and returns when it will expire if the cookie exists.
    *
+   * Implementations may skip re-persisting the expiration when it would only advance marginally;
+   * the returned date always matches the expiration that is actually stored.
+   *
    * @param cookie - Cookie to refresh.
    * @param accountId - The account ID already known to be associated with the cookie, if available.
    *                    When provided, the store may skip re-reading the cookie-to-account mapping

--- a/src/storage/keyvalue/ExpiringStorage.ts
+++ b/src/storage/keyvalue/ExpiringStorage.ts
@@ -29,4 +29,19 @@ export interface ExpiringStorage<TKey, TValue> extends KeyValueStorage<TKey, TVa
    * @returns The storage.
    */
   set(key: TKey, value: TValue, expires?: Date): Promise<this>;
+
+  /**
+   * Returns the expiration date of the value stored under the given key, if any.
+   * Returns `undefined` if there is no entry for the key,
+   * if the entry has already expired,
+   * or if the entry has no expiration date.
+   *
+   * This method is optional:
+   * callers need to check for its presence and fall back to behaviour that does not need the expiration date.
+   *
+   * @param key - Key to check.
+   *
+   * @returns The expiration date of the corresponding entry, if any.
+   */
+  getExpiration?(key: TKey): Promise<Date | undefined>;
 }

--- a/src/storage/keyvalue/ExpiringStorage.ts
+++ b/src/storage/keyvalue/ExpiringStorage.ts
@@ -31,13 +31,9 @@ export interface ExpiringStorage<TKey, TValue> extends KeyValueStorage<TKey, TVa
   set(key: TKey, value: TValue, expires?: Date): Promise<this>;
 
   /**
-   * Returns the expiration date of the value stored under the given key, if any.
-   * Returns `undefined` if there is no entry for the key,
-   * if the entry has already expired,
-   * or if the entry has no expiration date.
-   *
-   * This method is optional:
-   * callers need to check for its presence and fall back to behaviour that does not need the expiration date.
+   * Returns the expiration date of the value stored under the given key.
+   * Returns `undefined` if there is no such entry, the entry has expired, or it never expires.
+   * Implementations are not required to support this method, so callers need a fallback.
    *
    * @param key - Key to check.
    *

--- a/src/storage/keyvalue/WrappedExpiringStorage.ts
+++ b/src/storage/keyvalue/WrappedExpiringStorage.ts
@@ -40,6 +40,19 @@ export class WrappedExpiringStorage<TKey, TValue> implements ExpiringStorage<TKe
     return Boolean(await this.getUnexpired(key));
   }
 
+  public async getExpiration(key: TKey): Promise<Date | undefined> {
+    const data = await this.source.get(key);
+    if (!data) {
+      return;
+    }
+    const { expires } = this.toData(data);
+    if (this.isExpired(expires)) {
+      // Unlike `get`, this call is strictly read-only and does not delete the expired entry.
+      return;
+    }
+    return expires;
+  }
+
   public async set(key: TKey, value: TValue, expiration?: number): Promise<this>;
   public async set(key: TKey, value: TValue, expires?: Date): Promise<this>;
   public async set(key: TKey, value: TValue, expireValue?: number | Date): Promise<this> {

--- a/test/unit/identity/interaction/account/util/BaseCookieStore.test.ts
+++ b/test/unit/identity/interaction/account/util/BaseCookieStore.test.ts
@@ -71,7 +71,6 @@ describe('A BaseCookieStore', (): void => {
   });
 
   it('persists on every refresh if the storage cannot report the stored expiration.', async(): Promise<void> => {
-    // Without `getExpiration` there is no way to safely skip a write, so every refresh persists.
     await expect(store.refresh(cookie, accountId)).resolves.toEqual(new Date(now.getTime() + ttl));
     await expect(store.refresh(cookie, accountId)).resolves.toEqual(new Date(now.getTime() + ttl));
     expect(storage.set).toHaveBeenCalledTimes(2);
@@ -93,13 +92,10 @@ describe('A BaseCookieStore', (): void => {
     });
 
     it('skips the write if the expiration would advance by less than the threshold.', async(): Promise<void> => {
-      // The stored expiration was last persisted 30 seconds ago,
-      // so a fresh expiration would only advance it by 30 seconds, which is below the 1 minute threshold.
+      // Last persisted 30 seconds ago, so a fresh expiration only advances it by 30 seconds, below the threshold.
       const stored = new Date(now.getTime() + ttl - (30 * 1000));
       getExpiration.mockResolvedValueOnce(stored);
       const expiration = await store.refresh(cookie, accountId);
-      // The returned expiration is exactly the stored one,
-      // so the value communicated to the client can never diverge from the server-side state.
       expect(expiration!.toISOString()).toBe(stored.toISOString());
       expect(getExpiration).toHaveBeenCalledTimes(1);
       expect(getExpiration).toHaveBeenLastCalledWith(cookie);
@@ -124,8 +120,7 @@ describe('A BaseCookieStore', (): void => {
     });
 
     it('persists a fresh expiration if the stored one is further in the future.', async(): Promise<void> => {
-      // This can happen when the configured TTL is reduced:
-      // just like without throttling, the next refresh then clamps the session to the new, shorter TTL.
+      // A stored expiration can exceed a fresh one when the configured TTL is reduced.
       const stored = new Date(now.getTime() + ttl + 1000);
       getExpiration.mockResolvedValueOnce(stored);
       await expect(store.refresh(cookie, accountId)).resolves.toEqual(new Date(now.getTime() + ttl));
@@ -150,9 +145,6 @@ describe('A BaseCookieStore', (): void => {
     });
 
     it('persists a fresh expiration on every refresh if the threshold is 0.', async(): Promise<void> => {
-      // A threshold of 0 restores the exact behaviour from before throttling was introduced:
-      // every refresh persists and returns a freshly computed expiration,
-      // without ever reading the stored expiration.
       store = new BaseCookieStore(storage, 14 * 24 * 60 * 60, 0);
       for (let count = 1; count <= 3; count++) {
         jest.setSystemTime(now.getTime() + (count * 10));
@@ -193,8 +185,7 @@ describe('A BaseCookieStore backed by a WrappedExpiringStorage', (): void => {
       const record = await source.get(generated);
       // The expiration sent to the client always matches the stored server-side state exactly.
       expect(expiration!.toISOString()).toBe(record!.expires);
-      // The effective lifetime is unchanged within the threshold:
-      // the session expires at most `threshold` earlier than without throttling, and never later.
+      // The session expires at most `threshold` earlier than an unthrottled refresh allows, and never later.
       const drift = Date.now() + ttl - expiration!.getTime();
       expect(drift).toBeGreaterThanOrEqual(0);
       expect(drift).toBeLessThanOrEqual(threshold);
@@ -219,8 +210,7 @@ describe('A BaseCookieStore backed by a WrappedExpiringStorage', (): void => {
     jest.setSystemTime(start + (280 * 1000) + ttl - 1);
     await expect(store.get(generated)).resolves.toBe(accountId);
 
-    // After 14 days of inactivity the session has expired:
-    // at most `threshold` earlier than it would have without throttling (280s + ttl vs 300s + ttl).
+    // After 14 days of inactivity the session has expired (stored expiration: 280s + ttl).
     jest.setSystemTime(start + (300 * 1000) + ttl);
     await expect(store.get(generated)).resolves.toBeUndefined();
   });

--- a/test/unit/identity/interaction/account/util/BaseCookieStore.test.ts
+++ b/test/unit/identity/interaction/account/util/BaseCookieStore.test.ts
@@ -1,8 +1,14 @@
 import crypto from 'node:crypto';
 import { BaseCookieStore } from '../../../../../../src/identity/interaction/account/util/BaseCookieStore';
 import type { ExpiringStorage } from '../../../../../../src/storage/keyvalue/ExpiringStorage';
+import { MemoryMapStorage } from '../../../../../../src/storage/keyvalue/MemoryMapStorage';
+import type { Expires } from '../../../../../../src/storage/keyvalue/WrappedExpiringStorage';
+import { WrappedExpiringStorage } from '../../../../../../src/storage/keyvalue/WrappedExpiringStorage';
 
 const cookie = '4c9b88c1-7502-4107-bb79-2a3a590c7aa3';
+
+const ttl = 14 * 24 * 60 * 60 * 1000;
+const threshold = 60 * 1000;
 
 const now = new Date();
 jest.useFakeTimers();
@@ -14,8 +20,10 @@ describe('A BaseCookieStore', (): void => {
   let store: BaseCookieStore;
 
   beforeEach(async(): Promise<void> => {
+    jest.setSystemTime(now);
     jest.spyOn(crypto, 'randomUUID').mockReturnValue(cookie);
 
+    // Note that this storage does not expose `getExpiration`
     storage = {
       get: jest.fn().mockResolvedValue(accountId),
       set: jest.fn(),
@@ -28,7 +36,7 @@ describe('A BaseCookieStore', (): void => {
   it('can create new cookies.', async(): Promise<void> => {
     await expect(store.generate(accountId)).resolves.toBe(cookie);
     expect(storage.set).toHaveBeenCalledTimes(1);
-    expect(storage.set).toHaveBeenLastCalledWith(cookie, accountId, 14 * 24 * 60 * 60 * 1000);
+    expect(storage.set).toHaveBeenLastCalledWith(cookie, accountId, ttl);
   });
 
   it('can return the matching account ID.', async(): Promise<void> => {
@@ -38,20 +46,20 @@ describe('A BaseCookieStore', (): void => {
   });
 
   it('can refresh the expiration timer.', async(): Promise<void> => {
-    await expect(store.refresh(cookie)).resolves.toEqual(new Date(now.getTime() + (14 * 24 * 60 * 60 * 1000)));
+    await expect(store.refresh(cookie)).resolves.toEqual(new Date(now.getTime() + ttl));
     expect(storage.get).toHaveBeenCalledTimes(1);
     expect(storage.get).toHaveBeenLastCalledWith(cookie);
     expect(storage.set).toHaveBeenCalledTimes(1);
-    expect(storage.set).toHaveBeenLastCalledWith(cookie, accountId, 14 * 24 * 60 * 60 * 1000);
+    expect(storage.set).toHaveBeenLastCalledWith(cookie, accountId, ttl);
   });
 
   it('reuses a provided account ID to refresh without reading the storage.', async(): Promise<void> => {
     await expect(store.refresh(cookie, 'other-id'))
-      .resolves.toEqual(new Date(now.getTime() + (14 * 24 * 60 * 60 * 1000)));
+      .resolves.toEqual(new Date(now.getTime() + ttl));
     // The mapping is not re-read when the account ID is already known.
     expect(storage.get).toHaveBeenCalledTimes(0);
     expect(storage.set).toHaveBeenCalledTimes(1);
-    expect(storage.set).toHaveBeenLastCalledWith(cookie, 'other-id', 14 * 24 * 60 * 60 * 1000);
+    expect(storage.set).toHaveBeenLastCalledWith(cookie, 'other-id', ttl);
   });
 
   it('does not reset the timer if there is no match.', async(): Promise<void> => {
@@ -62,9 +70,158 @@ describe('A BaseCookieStore', (): void => {
     expect(storage.set).toHaveBeenCalledTimes(0);
   });
 
+  it('persists on every refresh if the storage cannot report the stored expiration.', async(): Promise<void> => {
+    // Without `getExpiration` there is no way to safely skip a write, so every refresh persists.
+    await expect(store.refresh(cookie, accountId)).resolves.toEqual(new Date(now.getTime() + ttl));
+    await expect(store.refresh(cookie, accountId)).resolves.toEqual(new Date(now.getTime() + ttl));
+    expect(storage.set).toHaveBeenCalledTimes(2);
+  });
+
   it('can delete cookies.', async(): Promise<void> => {
     await expect(store.delete(cookie)).resolves.toBeUndefined();
     expect(storage.delete).toHaveBeenCalledTimes(1);
     expect(storage.delete).toHaveBeenLastCalledWith(cookie);
+  });
+
+  describe('with a storage that can report the stored expiration', (): void => {
+    let getExpiration: jest.Mock<Promise<Date | undefined>, [string]>;
+
+    beforeEach(async(): Promise<void> => {
+      getExpiration = jest.fn();
+      storage.getExpiration = getExpiration;
+      store = new BaseCookieStore(storage);
+    });
+
+    it('skips the write if the expiration would advance by less than the threshold.', async(): Promise<void> => {
+      // The stored expiration was last persisted 30 seconds ago,
+      // so a fresh expiration would only advance it by 30 seconds, which is below the 1 minute threshold.
+      const stored = new Date(now.getTime() + ttl - (30 * 1000));
+      getExpiration.mockResolvedValueOnce(stored);
+      const expiration = await store.refresh(cookie, accountId);
+      // The returned expiration is exactly the stored one,
+      // so the value communicated to the client can never diverge from the server-side state.
+      expect(expiration!.toISOString()).toBe(stored.toISOString());
+      expect(getExpiration).toHaveBeenCalledTimes(1);
+      expect(getExpiration).toHaveBeenLastCalledWith(cookie);
+      expect(storage.set).toHaveBeenCalledTimes(0);
+    });
+
+    it('skips the write if the expiration would advance by exactly the threshold.', async(): Promise<void> => {
+      const stored = new Date(now.getTime() + ttl - threshold);
+      getExpiration.mockResolvedValueOnce(stored);
+      const expiration = await store.refresh(cookie, accountId);
+      expect(expiration!.toISOString()).toBe(stored.toISOString());
+      expect(storage.set).toHaveBeenCalledTimes(0);
+    });
+
+    it('persists a fresh expiration if the stored one would advance by more than the threshold.', async():
+    Promise<void> => {
+      const stored = new Date(now.getTime() + ttl - threshold - 1);
+      getExpiration.mockResolvedValueOnce(stored);
+      await expect(store.refresh(cookie, accountId)).resolves.toEqual(new Date(now.getTime() + ttl));
+      expect(storage.set).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenLastCalledWith(cookie, accountId, ttl);
+    });
+
+    it('persists a fresh expiration if the stored one is further in the future.', async(): Promise<void> => {
+      // This can happen when the configured TTL is reduced:
+      // just like without throttling, the next refresh then clamps the session to the new, shorter TTL.
+      const stored = new Date(now.getTime() + ttl + 1000);
+      getExpiration.mockResolvedValueOnce(stored);
+      await expect(store.refresh(cookie, accountId)).resolves.toEqual(new Date(now.getTime() + ttl));
+      expect(storage.set).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenLastCalledWith(cookie, accountId, ttl);
+    });
+
+    it('persists a fresh expiration if there is no stored expiration.', async(): Promise<void> => {
+      getExpiration.mockResolvedValueOnce(undefined);
+      await expect(store.refresh(cookie, accountId)).resolves.toEqual(new Date(now.getTime() + ttl));
+      expect(storage.set).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenLastCalledWith(cookie, accountId, ttl);
+    });
+
+    it('also throttles refreshes that need to look up the account ID.', async(): Promise<void> => {
+      const stored = new Date(now.getTime() + ttl - (30 * 1000));
+      getExpiration.mockResolvedValueOnce(stored);
+      const expiration = await store.refresh(cookie);
+      expect(expiration!.toISOString()).toBe(stored.toISOString());
+      expect(storage.get).toHaveBeenCalledTimes(1);
+      expect(storage.set).toHaveBeenCalledTimes(0);
+    });
+
+    it('persists a fresh expiration on every refresh if the threshold is 0.', async(): Promise<void> => {
+      // A threshold of 0 restores the exact behaviour from before throttling was introduced:
+      // every refresh persists and returns a freshly computed expiration,
+      // without ever reading the stored expiration.
+      store = new BaseCookieStore(storage, 14 * 24 * 60 * 60, 0);
+      for (let count = 1; count <= 3; count++) {
+        jest.setSystemTime(now.getTime() + (count * 10));
+        await expect(store.refresh(cookie, accountId)).resolves.toEqual(new Date(Date.now() + ttl));
+        expect(storage.set).toHaveBeenCalledTimes(count);
+        expect(storage.set).toHaveBeenLastCalledWith(cookie, accountId, ttl);
+      }
+      expect(getExpiration).toHaveBeenCalledTimes(0);
+    });
+  });
+});
+
+describe('A BaseCookieStore backed by a WrappedExpiringStorage', (): void => {
+  const accountId = 'id';
+  let source: MemoryMapStorage<Expires<string>>;
+  let setSpy: jest.SpyInstance;
+  let store: BaseCookieStore;
+
+  beforeEach(async(): Promise<void> => {
+    jest.setSystemTime(now);
+    source = new MemoryMapStorage();
+    setSpy = jest.spyOn(source, 'set');
+    store = new BaseCookieStore(new WrappedExpiringStorage(source));
+  });
+
+  afterEach(async(): Promise<void> => {
+    jest.clearAllTimers();
+  });
+
+  it('keeps an active session alive with few writes and no client/server divergence.', async(): Promise<void> => {
+    const start = now.getTime();
+    const generated = await store.generate(accountId);
+
+    // Simulate an active "remembered" session: one authenticated request every 10 seconds for 5 minutes.
+    for (let count = 1; count <= 30; count++) {
+      jest.setSystemTime(start + (count * 10 * 1000));
+      const expiration = await store.refresh(generated, accountId);
+      const record = await source.get(generated);
+      // The expiration sent to the client always matches the stored server-side state exactly.
+      expect(expiration!.toISOString()).toBe(record!.expires);
+      // The effective lifetime is unchanged within the threshold:
+      // the session expires at most `threshold` earlier than without throttling, and never later.
+      const drift = Date.now() + ttl - expiration!.getTime();
+      expect(drift).toBeGreaterThanOrEqual(0);
+      expect(drift).toBeLessThanOrEqual(threshold);
+    }
+
+    // 31 write opportunities (1 generate + 30 refreshes) result in only 5 writes:
+    // the initial one and one refresh per elapsed threshold window (70s/140s/210s/280s).
+    expect(setSpy).toHaveBeenCalledTimes(5);
+  });
+
+  it('still expires a session after sufficient inactivity.', async(): Promise<void> => {
+    const start = now.getTime();
+    const generated = await store.generate(accountId);
+
+    // Activity until t = 300s, with the last persisted refresh at t = 280s.
+    for (let count = 1; count <= 30; count++) {
+      jest.setSystemTime(start + (count * 10 * 1000));
+      await store.refresh(generated, accountId);
+    }
+
+    // The session is still alive just before the stored expiration.
+    jest.setSystemTime(start + (280 * 1000) + ttl - 1);
+    await expect(store.get(generated)).resolves.toBe(accountId);
+
+    // After 14 days of inactivity the session has expired:
+    // at most `threshold` earlier than it would have without throttling (280s + ttl vs 300s + ttl).
+    jest.setSystemTime(start + (300 * 1000) + ttl);
+    await expect(store.get(generated)).resolves.toBeUndefined();
   });
 });

--- a/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
+++ b/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
@@ -71,6 +71,30 @@ describe('A WrappedExpiringStorage', (): void => {
     expect(source.delete).toHaveBeenLastCalledWith('key');
   });
 
+  it('returns the expiration date of non-expired data.', async(): Promise<void> => {
+    source.get.mockResolvedValueOnce(createExpires('data!', tomorrow));
+    await expect(storage.getExpiration('key')).resolves.toEqual(tomorrow);
+    expect(source.get).toHaveBeenCalledTimes(1);
+    expect(source.get).toHaveBeenLastCalledWith('key');
+  });
+
+  it('returns no expiration date if there is no data.', async(): Promise<void> => {
+    await expect(storage.getExpiration('key')).resolves.toBeUndefined();
+    expect(source.get).toHaveBeenCalledTimes(1);
+    expect(source.get).toHaveBeenLastCalledWith('key');
+  });
+
+  it('returns no expiration date for expired data, without deleting it.', async(): Promise<void> => {
+    source.get.mockResolvedValueOnce(createExpires('data!', yesterday));
+    await expect(storage.getExpiration('key')).resolves.toBeUndefined();
+    expect(source.delete).toHaveBeenCalledTimes(0);
+  });
+
+  it('returns no expiration date for data that does not expire.', async(): Promise<void> => {
+    source.get.mockResolvedValueOnce(createExpires('data!'));
+    await expect(storage.getExpiration('key')).resolves.toBeUndefined();
+  });
+
   it('converts the expiry date to a string when storing data.', async(): Promise<void> => {
     await storage.set('key', 'data!', tomorrow);
     expect(source.set).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue describing the per-request cookie write on the authenticated account path
must be created before this is submitted upstream (the CSS template requires one).

#### ✍️ Description

Every authenticated account request for a "remembered" session re-persists the session cookie's sliding
expiration (`expires = now + 14 days`). In file-backed configurations that is one locked JSON write to disk
per request on the hot authenticated path
(`BaseCookieStore.refresh` → `WrappedExpiringStorage.set` → the full locking `ResourceStore`).

This PR throttles that write: a refresh only re-persists the expiration when it would advance the stored
expiration by more than a configurable `refreshThreshold` (default 1 minute). Setting the threshold to `0`
keeps a write on every refresh, which is the current behaviour.

Why the trade-off is safe:

- **Bounded earliness, never extension.** A session that goes idle right after a skipped write expires at
  most `refreshThreshold` earlier than it does today (≤ 1 minute on a 14-day TTL). It can never live longer:
  a skipped refresh never advances anything, and a stored expiration that exceeds a fresh one (e.g. after a
  TTL reduction) is clamped by a write, exactly as today.
- **No client/server divergence.** When the write is skipped, `refresh()` returns the currently stored
  expiration rather than a freshly computed one, so the `Set-Cookie` expiration emitted by
  `CookieMetadataWriter` always matches the server-side state.
- **Multi-process safe.** The skip decision reads the shared stored expiration — a new optional
  `ExpiringStorage.getExpiration`, implemented read-only on `WrappedExpiringStorage` — instead of tracking
  writes per instance, so all workers/instances throttle consistently against the same record. A
  concurrent-refresh race degrades to at most one extra write, never a missed or later expiry. The extra
  read is much cheaper than the locked write it replaces.
- **Safe fallback.** Storages that do not implement the optional `getExpiration` keep writing on every
  refresh.

Changes:

- `BaseCookieStore`: new third constructor parameter `refreshThreshold` (milliseconds, default `60000`).
- `ExpiringStorage`: new optional `getExpiration(key)` — non-breaking for external implementations.
- `WrappedExpiringStorage`: implements `getExpiration` (read-only; unlike `get` it does not delete expired
  entries).
- `config/identity/handler/storage/default.json`: sets `refreshThreshold: 60000` on
  `urn:solid-server:default:CookieStore`.
- Documentation note in `documentation/markdown/usage/account/json-api.md`.

Measured effect (deterministic write counts): the committed unit test simulates an active session refreshing
every 10 seconds for 5 minutes — 31 write opportunities drop to 5 writes (the initial one plus one per
elapsed threshold window), reproducible with
`npm run jest -- test/unit/identity/interaction/account/util/BaseCookieStore.test.ts`.
A longer ad-hoc run (1 refresh/second for 10 minutes over `BaseCookieStore` + `WrappedExpiringStorage` on a
counting backend with a virtual clock) showed 600 → 9 writes, with the returned expiration equal to the
stored one on every request; that harness is not committed, so the unit test above is the reproducible
evidence.

Notes for review:

- **Stacked on #101** (`perf/cookie-single-read`, the base branch of this PR), so the diff shows only the
  throttle change; it needs restacking once #101 lands. Uses #101's `refresh(cookie, accountId?)` signature.
- The default-on 1-minute threshold is the one product-visible choice here; `refreshThreshold: 0` in the
  config keeps the current write-per-request behaviour exactly.
- Branch target for upstream submission: the latest `versions/*` branch (currently `versions/next-major`) —
  this adds to the `ExpiringStorage` interface and changes shipped config behaviour, so it is not a `main`
  patch. Intended semver level: **minor** (backwards-compatible additions: an optional interface method and
  a defaulted constructor parameter).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
