### PR TITLE
feat: Split notification handlers + wire cluster activity bus (fan-out Phase 1)

### DIFF
--- a/config/http/notifications/cluster/listener.json
+++ b/config/http/notifications/cluster/listener.json
@@ -1,0 +1,38 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Publishes the activities of the local store on the cluster bus and re-emits the activities of every instance in the cluster.",
+      "@id": "urn:solid-server:default:ClusterActivityEmitter",
+      "@type": "ClusterActivityEmitter",
+      "source": { "@id": "urn:solid-server:default:ResourceStore" },
+      "bus": { "@id": "urn:solid-server:default:ClusterActivityBus" }
+    },
+    {
+      "comment": "WebSockets are pinned to an instance, so this handler listens to the changes of the entire cluster and delivers to the sockets held by this instance.",
+      "@id": "urn:solid-server:default:WebSocketListeningActivityHandler",
+      "@type": "WebSocketListeningActivityHandler",
+      "storage": { "@id": "urn:solid-server:default:SubscriptionStorage" },
+      "emitter": { "@id": "urn:solid-server:default:ClusterActivityEmitter" },
+      "handler": { "@id": "urn:solid-server:default:WebSocket2023NotificationHandler" },
+      "socketMap": { "@id": "urn:solid-server:default:WebSocketMap" }
+    },
+    {
+      "comment": "Webhooks are delivered by the instance where the change happened, so this handler listens to the local store only.",
+      "@id": "urn:solid-server:default:WebhookListeningActivityHandler",
+      "@type": "WebhookListeningActivityHandler",
+      "storage": { "@id": "urn:solid-server:default:SubscriptionStorage" },
+      "emitter": { "@id": "urn:solid-server:default:ResourceStore" },
+      "handler": { "@id": "urn:solid-server:default:WebhookNotificationHandler" }
+    },
+    {
+      "comment": "The listening handlers are added to the list of Initializers so Components.js finds and instantiates them.",
+      "@id": "urn:solid-server:default:PrimaryParallelInitializer",
+      "@type": "ParallelHandler",
+      "handlers": [
+        { "@id": "urn:solid-server:default:WebSocketListeningActivityHandler" },
+        { "@id": "urn:solid-server:default:WebhookListeningActivityHandler" }
+      ]
+    }
+  ]
+}

--- a/config/http/notifications/cluster/memory.json
+++ b/config/http/notifications/cluster/memory.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "import": [
+    "css:config/http/notifications/base/description.json",
+    "css:config/http/notifications/base/handler.json",
+    "css:config/http/notifications/base/http.json",
+    "css:config/http/notifications/base/storage.json",
+    "css:config/http/notifications/cluster/listener.json",
+    "css:config/http/notifications/cluster/streaming-http.json",
+    "css:config/http/notifications/websockets/handler.json",
+    "css:config/http/notifications/websockets/http.json",
+    "css:config/http/notifications/websockets/subscription.json",
+    "css:config/http/notifications/webhooks/handler.json",
+    "css:config/http/notifications/webhooks/routes.json",
+    "css:config/http/notifications/webhooks/subscription.json"
+  ],
+  "@graph": [
+    {
+      "comment": [
+        "Supports all notification types, wired for cluster deployments, with an in-memory activity bus.",
+        "Import this file instead of http/notifications/all.json.",
+        "The in-memory bus only reaches the process it runs in, so this configuration behaves like the default one.",
+        "It is mainly useful for testing the cluster wiring, and as a template for other bus implementations."
+      ],
+      "@id": "urn:solid-server:default:ClusterActivityBus",
+      "@type": "InMemoryActivityBus"
+    }
+  ]
+}

--- a/config/http/notifications/cluster/redis.json
+++ b/config/http/notifications/cluster/redis.json
@@ -1,0 +1,51 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "import": [
+    "css:config/http/notifications/base/description.json",
+    "css:config/http/notifications/base/handler.json",
+    "css:config/http/notifications/base/http.json",
+    "css:config/http/notifications/base/storage.json",
+    "css:config/http/notifications/cluster/listener.json",
+    "css:config/http/notifications/cluster/streaming-http.json",
+    "css:config/http/notifications/websockets/handler.json",
+    "css:config/http/notifications/websockets/http.json",
+    "css:config/http/notifications/websockets/subscription.json",
+    "css:config/http/notifications/webhooks/handler.json",
+    "css:config/http/notifications/webhooks/routes.json",
+    "css:config/http/notifications/webhooks/subscription.json"
+  ],
+  "@graph": [
+    {
+      "comment": [
+        "Supports all notification types, wired for cluster deployments, with a Redis pub/sub activity bus.",
+        "Import this file instead of http/notifications/all.json.",
+        "All instances of the cluster need to connect to the same Redis server,",
+        "which can be the one used by the Redis resource locker."
+      ],
+      "@id": "urn:solid-server:default:ClusterActivityBus",
+      "@type": "RedisActivityBus"
+    },
+    {
+      "@id": "urn:solid-server:default:CleanupInitializer",
+      "@type": "SequenceHandler",
+      "handlers": [
+        {
+          "comment": "Makes sure the bus is subscribed to the Redis channel when the application is started.",
+          "@type": "InitializableHandler",
+          "initializable": { "@id": "urn:solid-server:default:ClusterActivityBus" }
+        }
+      ]
+    },
+    {
+      "@id": "urn:solid-server:default:CleanupFinalizer",
+      "@type": "SequenceHandler",
+      "handlers": [
+        {
+          "comment": "Makes sure the Redis connections are closed when the application needs to stop.",
+          "@type": "FinalizableHandler",
+          "finalizable": { "@id": "urn:solid-server:default:ClusterActivityBus" }
+        }
+      ]
+    }
+  ]
+}

--- a/config/http/notifications/cluster/streaming-http.json
+++ b/config/http/notifications/cluster/streaming-http.json
@@ -1,0 +1,87 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "@id": "urn:solid-server:default:StreamingHTTP2023Route",
+      "@type": "RelativePathInteractionRoute",
+      "base": { "@id": "urn:solid-server:default:NotificationRoute" },
+      "relativePath": "/StreamingHTTPChannel2023/"
+    },
+    {
+      "comment": "Creates updatesViaStreamingHttp2023 Link relations",
+      "@id": "urn:solid-server:default:StreamingHttpMetadataWriter",
+      "@type": "StreamingHttpMetadataWriter",
+      "route": { "@id": "urn:solid-server:default:StreamingHTTP2023Route" }
+    },
+    {
+      "comment": "Allows discovery of the corresponding streaming HTTP channel",
+      "@id": "urn:solid-server:default:MetadataWriter",
+      "@type": "ParallelHandler",
+      "handlers": [
+        { "@id": "urn:solid-server:default:StreamingHttpMetadataWriter" }
+      ]
+    },
+    {
+      "comment": "Handles the request targeting a StreamingHTTPChannel2023 receiveFrom endpoint.",
+      "@id": "urn:solid-server:default:StreamingHttp2023Router",
+      "@type": "OperationRouterHandler",
+      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
+      "allowedMethods": [ "GET" ],
+      "allowedPathNames": [ "/StreamingHTTPChannel2023/" ],
+      "handler": {
+        "@id": "urn:solid-server:default:StreamingHttp2023RequestHandler",
+        "@type": "StreamingHttpRequestHandler",
+        "streamMap": { "@id": "urn:solid-server:default:StreamingHttpMap" },
+        "route": { "@id": "urn:solid-server:default:StreamingHTTP2023Route" },
+        "generator": { "@id": "urn:solid-server:default:BaseNotificationGenerator" },
+        "serializer": { "@id": "urn:solid-server:default:BaseNotificationSerializer" },
+        "credentialsExtractor": { "@id": "urn:solid-server:default:CredentialsExtractor" },
+        "permissionReader": { "@id": "urn:solid-server:default:PermissionReader" },
+        "authorizer": { "@id": "urn:solid-server:default:Authorizer" }
+      }
+    },
+    {
+      "comment": "Add the router to notification type handler",
+      "@id": "urn:solid-server:default:NotificationTypeHandler",
+      "@type": "WaterfallHandler",
+      "handlers": [
+        { "@id": "urn:solid-server:default:StreamingHttp2023Router" }
+      ]
+    },
+    {
+      "comment": "Opened response streams will be stored in this Map.",
+      "@id": "urn:solid-server:default:StreamingHttpMap",
+      "@type": "StreamingHttpMap"
+    },
+    {
+      "comment": "Emits serialized notifications through Streaming HTTP.",
+      "@id": "urn:solid-server:default:StreamingHttp2023Emitter",
+      "@type": "StreamingHttp2023Emitter",
+      "streamMap": { "@id": "urn:solid-server:default:StreamingHttpMap" }
+    },
+    {
+      "comment": "Streams are pinned to an instance, so, unlike its default counterpart, this handler listens to the changes of the entire cluster and delivers to the streams held by this instance.",
+      "@id": "urn:solid-server:default:StreamingHttpListeningActivityHandler",
+      "@type": "StreamingHttpListeningActivityHandler",
+      "emitter": { "@id": "urn:solid-server:default:ClusterActivityEmitter" },
+      "streamMap": { "@id": "urn:solid-server:default:StreamingHttpMap" },
+      "source": {
+        "comment": "Handles the generation and serialization of notifications for StreamingHTTPChannel2023",
+        "@id": "urn:solid-server:default:StreamingHttpNotificationHandler",
+        "@type": "ComposedNotificationHandler",
+        "generator": { "@id": "urn:solid-server:default:BaseNotificationGenerator" },
+        "serializer": { "@id": "urn:solid-server:default:BaseNotificationSerializer" },
+        "emitter": { "@id": "urn:solid-server:default:StreamingHttp2023Emitter" },
+        "eTagHandler": { "@id": "urn:solid-server:default:ETagHandler" }
+      }
+    },
+    {
+      "comment": "Add the activity handler to the primary initializer",
+      "@id": "urn:solid-server:default:PrimaryParallelInitializer",
+      "@type": "ParallelHandler",
+      "handlers": [
+        { "@id": "urn:solid-server:default:StreamingHttpListeningActivityHandler" }
+      ]
+    }
+  ]
+}

--- a/config/http/notifications/cluster/streaming-http.json
+++ b/config/http/notifications/cluster/streaming-http.json
@@ -60,7 +60,7 @@
       "streamMap": { "@id": "urn:solid-server:default:StreamingHttpMap" }
     },
     {
-      "comment": "Streams are pinned to an instance, so, unlike its default counterpart, this handler listens to the changes of the entire cluster and delivers to the streams held by this instance.",
+      "comment": "Streams are pinned to an instance, so this handler listens to the changes of the entire cluster and delivers to the streams held by this instance.",
       "@id": "urn:solid-server:default:StreamingHttpListeningActivityHandler",
       "@type": "StreamingHttpListeningActivityHandler",
       "emitter": { "@id": "urn:solid-server:default:ClusterActivityEmitter" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -402,6 +402,7 @@ export * from './server/notifications/serialize/NotificationSerializer';
 // Server/Notifications/WebhookChannel2023
 export * from './server/notifications/WebhookChannel2023/WebhookChannel2023Type';
 export * from './server/notifications/WebhookChannel2023/WebhookEmitter';
+export * from './server/notifications/WebhookChannel2023/WebhookListeningActivityHandler';
 export * from './server/notifications/WebhookChannel2023/WebhookWebId';
 
 // Server/Notifications/WebSocketChannel2023
@@ -412,6 +413,7 @@ export * from './server/notifications/WebSocketChannel2023/WebSocket2023Storer';
 export * from './server/notifications/WebSocketChannel2023/WebSocket2023Util';
 export * from './server/notifications/WebSocketChannel2023/WebSocketMap';
 export * from './server/notifications/WebSocketChannel2023/WebSocketChannel2023Type';
+export * from './server/notifications/WebSocketChannel2023/WebSocketListeningActivityHandler';
 
 // Server/Notifications/StreamingHTTPChannel2023
 export * from './server/notifications/StreamingHttpChannel2023/StreamingHttp2023Emitter';

--- a/src/server/notifications/ListeningActivityHandler.ts
+++ b/src/server/notifications/ListeningActivityHandler.ts
@@ -15,10 +15,6 @@ import type { NotificationHandler } from './NotificationHandler';
  *
  * Takes the `rate` feature into account so only channels that want a new notification will receive one.
  *
- * Subclasses dedicated to a single channel type can override `supports`
- * to filter out the channels that should be handled by a different instance of this class,
- * and `emit` to skip work entirely when no matching channel can exist.
- *
  * Extends {@link StaticHandler} so it can be more easily injected into a Components.js configuration.
  * No class takes this one as input, so to make sure Components.js instantiates it,
  * it needs to be added somewhere where its presence has no impact, such as the list of initializers.
@@ -88,10 +84,8 @@ export class ListeningActivityHandler extends StaticHandler {
 
   /**
    * Whether this handler is responsible for the given channel.
-   *
-   * The base implementation supports every channel.
-   * Subclasses dedicated to a single channel type should override this,
-   * so channels of other types are left, without error, to the handler dedicated to them.
+   * Subclasses dedicated to a single channel type can override this
+   * so channels of other types are silently left to the handler dedicated to them.
    */
   // eslint-disable-next-line unused-imports/no-unused-vars
   protected supports(channel: NotificationChannel): boolean {

--- a/src/server/notifications/ListeningActivityHandler.ts
+++ b/src/server/notifications/ListeningActivityHandler.ts
@@ -5,6 +5,7 @@ import { createErrorMessage } from '../../util/errors/ErrorUtil';
 import { StaticHandler } from '../../util/handlers/StaticHandler';
 import type { AS, VocabularyTerm } from '../../util/Vocabularies';
 import type { ActivityEmitter } from './ActivityEmitter';
+import type { NotificationChannel } from './NotificationChannel';
 import type { NotificationChannelStorage } from './NotificationChannelStorage';
 import type { NotificationHandler } from './NotificationHandler';
 
@@ -13,6 +14,10 @@ import type { NotificationHandler } from './NotificationHandler';
  * for every matching notification channel found.
  *
  * Takes the `rate` feature into account so only channels that want a new notification will receive one.
+ *
+ * Subclasses dedicated to a single channel type can override `supports`
+ * to filter out the channels that should be handled by a different instance of this class,
+ * and `emit` to skip work entirely when no matching channel can exist.
  *
  * Extends {@link StaticHandler} so it can be more easily injected into a Components.js configuration.
  * No class takes this one as input, so to make sure Components.js instantiates it,
@@ -36,7 +41,7 @@ export class ListeningActivityHandler extends StaticHandler {
     });
   }
 
-  private async emit(
+  protected async emit(
     topic: ResourceIdentifier,
     activity: VocabularyTerm<typeof AS>,
     metadata: RepresentationMetadata,
@@ -47,6 +52,11 @@ export class ListeningActivityHandler extends StaticHandler {
       const channel = await this.storage.get(id);
       if (!channel) {
         // Notification channel has expired
+        continue;
+      }
+
+      // Don't emit if a different handler is responsible for this channel
+      if (!this.supports(channel)) {
         continue;
       }
 
@@ -74,5 +84,17 @@ export class ListeningActivityHandler extends StaticHandler {
           this.logger.error(`Error trying to handle notification for ${id}: ${createErrorMessage(error)}`);
         });
     }
+  }
+
+  /**
+   * Whether this handler is responsible for the given channel.
+   *
+   * The base implementation supports every channel.
+   * Subclasses dedicated to a single channel type should override this,
+   * so channels of other types are left, without error, to the handler dedicated to them.
+   */
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  protected supports(channel: NotificationChannel): boolean {
+    return true;
   }
 }

--- a/src/server/notifications/WebSocketChannel2023/WebSocketListeningActivityHandler.ts
+++ b/src/server/notifications/WebSocketChannel2023/WebSocketListeningActivityHandler.ts
@@ -1,0 +1,57 @@
+import type { WebSocket } from 'ws';
+import type { RepresentationMetadata } from '../../../http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../../http/representation/ResourceIdentifier';
+import type { AS, VocabularyTerm } from '../../../util/Vocabularies';
+import type { SetMultiMap } from '../../../util/map/SetMultiMap';
+import type { ActivityEmitter } from '../ActivityEmitter';
+import { ListeningActivityHandler } from '../ListeningActivityHandler';
+import type { NotificationChannel } from '../NotificationChannel';
+import type { NotificationChannelStorage } from '../NotificationChannelStorage';
+import type { NotificationHandler } from '../NotificationHandler';
+import { isWebSocket2023Channel } from './WebSocketChannel2023Type';
+
+/**
+ * A {@link ListeningActivityHandler} dedicated to WebSocketChannel2023 channels.
+ *
+ * WebSockets are pinned to the instance that accepted them,
+ * so in a multi-instance deployment this handler should listen to an emitter
+ * that reports the resource changes of the entire cluster, such as a `ClusterActivityEmitter`:
+ * every instance can then deliver notifications to the sockets it holds,
+ * no matter which instance performed the change.
+ *
+ * For the same reason, all work can be skipped when this instance holds no matching socket:
+ * an instance without the socket of a channel could never deliver its notifications anyway.
+ * Events are ignored entirely when there are no local sockets at all,
+ * without even querying the channel storage,
+ * and individual channels are skipped when their socket lives on a different instance.
+ */
+export class WebSocketListeningActivityHandler extends ListeningActivityHandler {
+  private readonly socketMap: SetMultiMap<string, WebSocket>;
+
+  public constructor(
+    storage: NotificationChannelStorage,
+    emitter: ActivityEmitter,
+    handler: NotificationHandler,
+    socketMap: SetMultiMap<string, WebSocket>,
+  ) {
+    super(storage, emitter, handler);
+    this.socketMap = socketMap;
+  }
+
+  protected async emit(
+    topic: ResourceIdentifier,
+    activity: VocabularyTerm<typeof AS>,
+    metadata: RepresentationMetadata,
+  ): Promise<void> {
+    // Without local sockets no notification could be delivered, so no work needs to be done
+    if (this.socketMap.size === 0) {
+      return;
+    }
+    return super.emit(topic, activity, metadata);
+  }
+
+  protected supports(channel: NotificationChannel): boolean {
+    // The socket of a channel is stored using the channel identifier by the `WebSocket2023Storer`
+    return isWebSocket2023Channel(channel) && this.socketMap.has(channel.id);
+  }
+}

--- a/src/server/notifications/WebSocketChannel2023/WebSocketListeningActivityHandler.ts
+++ b/src/server/notifications/WebSocketChannel2023/WebSocketListeningActivityHandler.ts
@@ -15,15 +15,8 @@ import { isWebSocket2023Channel } from './WebSocketChannel2023Type';
  *
  * WebSockets are pinned to the instance that accepted them,
  * so in a multi-instance deployment this handler should listen to an emitter
- * that reports the resource changes of the entire cluster, such as a `ClusterActivityEmitter`:
- * every instance can then deliver notifications to the sockets it holds,
- * no matter which instance performed the change.
- *
- * For the same reason, all work can be skipped when this instance holds no matching socket:
- * an instance without the socket of a channel could never deliver its notifications anyway.
- * Events are ignored entirely when there are no local sockets at all,
- * without even querying the channel storage,
- * and individual channels are skipped when their socket lives on a different instance.
+ * that reports the resource changes of the entire cluster, such as a `ClusterActivityEmitter`,
+ * and only handles the channels whose socket is held by this instance.
  */
 export class WebSocketListeningActivityHandler extends ListeningActivityHandler {
   private readonly socketMap: SetMultiMap<string, WebSocket>;

--- a/src/server/notifications/WebhookChannel2023/WebhookListeningActivityHandler.ts
+++ b/src/server/notifications/WebhookChannel2023/WebhookListeningActivityHandler.ts
@@ -5,14 +5,9 @@ import { isWebhook2023Channel } from './WebhookChannel2023Type';
 /**
  * A {@link ListeningActivityHandler} dedicated to WebhookChannel2023 channels.
  *
- * Webhooks are not pinned to an instance:
- * any instance can read the channel from the shared storage and perform the outgoing HTTP request.
- * To prevent duplicate deliveries in a multi-instance deployment,
- * this handler should keep listening to the emitter of the local `ResourceStore`,
- * so only the instance where a change originates sends out the corresponding webhooks.
- *
- * If that instance stops before delivery finishes those notifications are lost,
- * which is identical to the failure behavior of a single-instance deployment.
+ * This handler should listen to the emitter of the local `ResourceStore`,
+ * so in a multi-instance deployment only the instance where a change originates
+ * sends out the corresponding webhooks, preventing duplicate deliveries.
  */
 export class WebhookListeningActivityHandler extends ListeningActivityHandler {
   protected supports(channel: NotificationChannel): boolean {

--- a/src/server/notifications/WebhookChannel2023/WebhookListeningActivityHandler.ts
+++ b/src/server/notifications/WebhookChannel2023/WebhookListeningActivityHandler.ts
@@ -1,0 +1,21 @@
+import { ListeningActivityHandler } from '../ListeningActivityHandler';
+import type { NotificationChannel } from '../NotificationChannel';
+import { isWebhook2023Channel } from './WebhookChannel2023Type';
+
+/**
+ * A {@link ListeningActivityHandler} dedicated to WebhookChannel2023 channels.
+ *
+ * Webhooks are not pinned to an instance:
+ * any instance can read the channel from the shared storage and perform the outgoing HTTP request.
+ * To prevent duplicate deliveries in a multi-instance deployment,
+ * this handler should keep listening to the emitter of the local `ResourceStore`,
+ * so only the instance where a change originates sends out the corresponding webhooks.
+ *
+ * If that instance stops before delivery finishes those notifications are lost,
+ * which is identical to the failure behavior of a single-instance deployment.
+ */
+export class WebhookListeningActivityHandler extends ListeningActivityHandler {
+  protected supports(channel: NotificationChannel): boolean {
+    return isWebhook2023Channel(channel);
+  }
+}

--- a/test/integration/ClusterNotifications.test.ts
+++ b/test/integration/ClusterNotifications.test.ts
@@ -37,12 +37,9 @@ async function readChunk(reader: ReadableStreamDefaultReader): Promise<Store> {
 }
 
 /**
- * These tests validate the opt-in cluster notification wiring of `http/notifications/cluster/memory.json`:
- * the split WebSocket/Webhook listening handlers and the `ClusterActivityEmitter` in front of the
- * connection-pinned channel types.
- * With the in-memory bus everything stays within this single process,
- * so every channel type is expected to behave exactly as it does with the default wiring,
- * receiving every notification exactly once.
+ * Test the cluster notification wiring of `http/notifications/cluster/memory.json`.
+ * With the in-memory bus every channel type should receive each notification exactly once,
+ * as it does with the default wiring.
  */
 describe('A server with cluster notifications using the in-memory bus', (): void => {
   let app: App;

--- a/test/integration/ClusterNotifications.test.ts
+++ b/test/integration/ClusterNotifications.test.ts
@@ -1,0 +1,187 @@
+import { createServer } from 'node:http';
+import type { Server } from 'node:http';
+import type { NamedNode } from 'n3';
+import { DataFactory, Parser, Store } from 'n3';
+import { WebSocket } from 'ws';
+import type { App } from '../../src/init/App';
+import { joinUrl } from '../../src/util/PathUtil';
+import { readJsonStream } from '../../src/util/StreamUtil';
+import { AS, NOTIFY, RDF } from '../../src/util/Vocabularies';
+import { expectNotification, subscribe } from '../util/NotificationUtil';
+import { getPort } from '../util/Util';
+import {
+  getDefaultVariables,
+  getPresetConfigPath,
+  getTestConfigPath,
+  getTestFolder,
+  instantiateFromConfig,
+  removeFolder,
+} from './Config';
+import quad = DataFactory.quad;
+import namedNode = DataFactory.namedNode;
+
+const port = getPort('ClusterNotifications');
+const baseUrl = `http://localhost:${port}/`;
+const clientPort = getPort('ClusterNotifications-client');
+const target = `http://localhost:${clientPort}/`;
+const webId = 'http://example.com/card/#me';
+
+const rootFilePath = getTestFolder('ClusterNotifications');
+
+async function readChunk(reader: ReadableStreamDefaultReader): Promise<Store> {
+  const decoder = new TextDecoder();
+  const parser = new Parser();
+  const { value } = await reader.read();
+  const notification = decoder.decode(value);
+  return new Store(parser.parse(notification));
+}
+
+/**
+ * These tests validate the opt-in cluster notification wiring of `http/notifications/cluster/memory.json`:
+ * the split WebSocket/Webhook listening handlers and the `ClusterActivityEmitter` in front of the
+ * connection-pinned channel types.
+ * With the in-memory bus everything stays within this single process,
+ * so every channel type is expected to behave exactly as it does with the default wiring,
+ * receiving every notification exactly once.
+ */
+describe('A server with cluster notifications using the in-memory bus', (): void => {
+  let app: App;
+  const topic = joinUrl(baseUrl, '/foo');
+  let storageDescriptionUrl: string;
+  let webSocketSubscriptionUrl: string;
+  let webhookSubscriptionUrl: string;
+  let clientServer: Server;
+  const webhookNotifications: unknown[] = [];
+
+  beforeAll(async(): Promise<void> => {
+    const variables = {
+      ...getDefaultVariables(port, baseUrl),
+      'urn:solid-server:default:variable:rootFilePath': rootFilePath,
+    };
+
+    // Create and start the server
+    const instances = await instantiateFromConfig(
+      'urn:solid-server:test:Instances',
+      [
+        getPresetConfigPath('storage/backend/memory.json'),
+        getPresetConfigPath('util/resource-locker/memory.json'),
+        getTestConfigPath('cluster-notifications.json'),
+      ],
+      variables,
+    ) as Record<string, any>;
+    ({ app } = instances);
+
+    await app.start();
+
+    // Start the client server that will receive the webhooks
+    clientServer = createServer((request, response): void => {
+      readJsonStream(request)
+        .then((json): void => {
+          webhookNotifications.push(json);
+          response.writeHead(200);
+          response.end();
+        })
+        .catch((): void => {
+          response.writeHead(500);
+          response.end();
+        });
+    });
+    clientServer.listen(clientPort);
+  });
+
+  afterAll(async(): Promise<void> => {
+    // Drop any keep-alive connections so `close` resolves instead of waiting for them to time out
+    clientServer.closeAllConnections();
+    await new Promise<void>((resolve): void => {
+      clientServer.close((): void => resolve());
+    });
+    await app.stop();
+    await removeFolder(rootFilePath);
+  });
+
+  it('exposes subscription services for both channel types.', async(): Promise<void> => {
+    let response = await fetch(baseUrl);
+    expect(response.status).toBe(200);
+    const linkHeader = response.headers.get('link');
+    expect(linkHeader).not.toBeNull();
+    const match = /<([^>]+)>; rel="http:\/\/www\.w3\.org\/ns\/solid\/terms#storageDescription"/u.exec(linkHeader!);
+    expect(match).not.toBeNull();
+    storageDescriptionUrl = match![1];
+
+    response = await fetch(storageDescriptionUrl, { headers: { accept: 'text/turtle' }});
+    expect(response.status).toBe(200);
+    const quads = new Store(new Parser().parse(await response.text()));
+    const subscriptions = quads.getObjects(null, NOTIFY.terms.subscription, null);
+
+    const webSocketSubscriptions = subscriptions.filter((channel): boolean => quads.has(
+      quad(channel as NamedNode, NOTIFY.terms.channelType, NOTIFY.terms.WebSocketChannel2023),
+    ));
+    expect(webSocketSubscriptions).toHaveLength(1);
+    webSocketSubscriptionUrl = webSocketSubscriptions[0].value;
+
+    const webhookSubscriptions = subscriptions.filter((channel): boolean => quads.has(
+      quad(channel as NamedNode, NOTIFY.terms.channelType, NOTIFY.terms.WebhookChannel2023),
+    ));
+    expect(webhookSubscriptions).toHaveLength(1);
+    webhookSubscriptionUrl = webhookSubscriptions[0].value;
+  });
+
+  it('delivers a change exactly once to each subscribed channel type.', async(): Promise<void> => {
+    const { receiveFrom } =
+      await subscribe(NOTIFY.WebSocketChannel2023, webId, webSocketSubscriptionUrl, topic) as any;
+    await subscribe(NOTIFY.WebhookChannel2023, webId, webhookSubscriptionUrl, topic, { [NOTIFY.sendTo]: target });
+
+    const socket = new WebSocket(receiveFrom);
+    const socketMessages: Buffer[] = [];
+    const firstMessage = new Promise<void>((resolve): any => socket.once('message', (): void => resolve()));
+    socket.on('message', (message): number => socketMessages.push(message as Buffer));
+    await new Promise<void>((resolve): any => socket.on('open', resolve));
+
+    const firstWebhook = new Promise<void>((resolve): any => clientServer.once('request', (): void => resolve()));
+
+    const response = await fetch(topic, {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain' },
+      body: 'abc',
+    });
+    expect(response.status).toBe(201);
+
+    await Promise.all([ firstMessage, firstWebhook ]);
+    // Leave some time for potential duplicates to arrive before counting
+    await new Promise<void>((resolve): any => setTimeout(resolve, 500));
+    socket.close();
+
+    expect(socketMessages).toHaveLength(1);
+    expectNotification(JSON.parse(socketMessages[0].toString()), topic, 'Create');
+
+    expect(webhookNotifications).toHaveLength(1);
+    expectNotification(webhookNotifications[0], topic, 'Create');
+  });
+
+  it('delivers changes to StreamingHTTPChannel2023 receiveFrom endpoints.', async(): Promise<void> => {
+    const receiveFrom = joinUrl(baseUrl, '.notifications/StreamingHTTPChannel2023', encodeURIComponent(topic));
+    const streamingResponse = await fetch(receiveFrom);
+    expect(streamingResponse.status).toBe(200);
+    const reader = streamingResponse.body!.getReader();
+
+    try {
+      // The topic was created in the previous test, so the initial notification is an Update
+      const initialQuads = await readChunk(reader);
+      expect(initialQuads.getObjects(null, RDF.terms.type, null)).toEqual([ AS.terms.Update ]);
+
+      const response = await fetch(topic, {
+        method: 'PUT',
+        headers: { 'content-type': 'text/plain' },
+        body: 'def',
+      });
+      expect(response.status).toBe(205);
+
+      const quads = await readChunk(reader);
+      expect(quads.getObjects(null, RDF.terms.type, null)).toEqual([ AS.terms.Update ]);
+      expect(quads.getObjects(null, AS.terms.object, null)).toEqual([ namedNode(topic) ]);
+    } finally {
+      reader.releaseLock();
+      await streamingResponse.body!.cancel();
+    }
+  });
+});

--- a/test/integration/config/cluster-notifications.json
+++ b/test/integration/config/cluster-notifications.json
@@ -1,0 +1,52 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "import": [
+    "css:config/app/init/initialize-root.json",
+    "css:config/app/main/default.json",
+    "css:config/http/handler/default.json",
+    "css:config/http/middleware/default.json",
+    "css:config/http/notifications/cluster/memory.json",
+    "css:config/http/server-factory/http.json",
+    "css:config/http/static/default.json",
+    "css:config/identity/access/public.json",
+    "css:config/identity/email/default.json",
+    "css:config/identity/handler/no-accounts.json",
+    "css:config/identity/oidc/default.json",
+    "css:config/identity/ownership/token.json",
+    "css:config/identity/pod/static.json",
+    "css:config/ldp/authentication/debug-auth-header.json",
+    "css:config/ldp/authorization/webacl.json",
+    "css:config/ldp/handler/default.json",
+    "css:config/ldp/metadata-parser/default.json",
+    "css:config/ldp/metadata-writer/default.json",
+    "css:config/ldp/modes/default.json",
+
+    "css:config/storage/key-value/resource-store.json",
+    "css:config/storage/location/root.json",
+    "css:config/storage/middleware/default.json",
+    "css:config/util/auxiliary/acl.json",
+    "css:config/util/identifiers/suffix.json",
+    "css:config/util/index/default.json",
+    "css:config/util/logging/winston.json",
+    "css:config/util/representation-conversion/default.json",
+
+    "css:config/util/variables/default.json"
+  ],
+  "@graph": [
+    {
+      "comment": "All notification types on the cluster wiring, with debug authentication.",
+      "@id": "urn:solid-server:test:Instances",
+      "@type": "RecordObject",
+      "record": [
+        {
+          "RecordObject:_record_key": "app",
+          "RecordObject:_record_value": { "@id": "urn:solid-server:default:App" }
+        },
+        {
+          "RecordObject:_record_key": "store",
+          "RecordObject:_record_value": { "@id": "urn:solid-server:default:ResourceStore" }
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/server/notifications/WebHookChannel2023/WebhookListeningActivityHandler.test.ts
+++ b/test/unit/server/notifications/WebHookChannel2023/WebhookListeningActivityHandler.test.ts
@@ -1,0 +1,76 @@
+import { EventEmitter } from 'node:events';
+import { RepresentationMetadata } from '../../../../../src/http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../../../../src/http/representation/ResourceIdentifier';
+import type { Logger } from '../../../../../src/logging/Logger';
+import { getLoggerFor } from '../../../../../src/logging/LogUtil';
+import type { ActivityEmitter } from '../../../../../src/server/notifications/ActivityEmitter';
+import type { NotificationChannel } from '../../../../../src/server/notifications/NotificationChannel';
+import type {
+  NotificationChannelStorage,
+} from '../../../../../src/server/notifications/NotificationChannelStorage';
+import type { NotificationHandler } from '../../../../../src/server/notifications/NotificationHandler';
+import {
+  WebhookListeningActivityHandler,
+} from '../../../../../src/server/notifications/WebhookChannel2023/WebhookListeningActivityHandler';
+import { AS, NOTIFY } from '../../../../../src/util/Vocabularies';
+import { flushPromises } from '../../../../util/Util';
+
+jest.mock('../../../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { error: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+
+describe('A WebhookListeningActivityHandler', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
+  const topic: ResourceIdentifier = { path: 'http://example.com/foo' };
+  const activity = AS.terms.Update;
+  const metadata = new RepresentationMetadata();
+  let channel: NotificationChannel;
+  let storage: jest.Mocked<NotificationChannelStorage>;
+  let emitter: ActivityEmitter;
+  let notificationHandler: jest.Mocked<NotificationHandler>;
+
+  beforeEach(async(): Promise<void> => {
+    jest.clearAllMocks();
+    channel = {
+      id: 'id',
+      topic: 'http://example.com/foo',
+      type: NOTIFY.WebhookChannel2023,
+    };
+
+    storage = {
+      getAll: jest.fn().mockResolvedValue([ channel.id ]),
+      get: jest.fn().mockResolvedValue(channel),
+      update: jest.fn(),
+    } as any;
+
+    emitter = new EventEmitter() as any;
+
+    notificationHandler = {
+      handleSafe: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    // eslint-disable-next-line no-new
+    new WebhookListeningActivityHandler(storage, emitter, notificationHandler);
+  });
+
+  it('calls the NotificationHandler for webhook channels.', async(): Promise<void> => {
+    emitter.emit('changed', topic, activity, metadata);
+
+    await flushPromises();
+
+    expect(notificationHandler.handleSafe).toHaveBeenCalledTimes(1);
+    expect(notificationHandler.handleSafe).toHaveBeenLastCalledWith({ channel, activity, topic, metadata });
+    expect(logger.error).toHaveBeenCalledTimes(0);
+  });
+
+  it('ignores channels of a different type.', async(): Promise<void> => {
+    channel.type = NOTIFY.WebSocketChannel2023;
+    emitter.emit('changed', topic, activity, metadata);
+
+    await flushPromises();
+
+    expect(notificationHandler.handleSafe).toHaveBeenCalledTimes(0);
+    expect(logger.error).toHaveBeenCalledTimes(0);
+  });
+});

--- a/test/unit/server/notifications/WebSocketChannel2023/WebSocketListeningActivityHandler.test.ts
+++ b/test/unit/server/notifications/WebSocketChannel2023/WebSocketListeningActivityHandler.test.ts
@@ -1,0 +1,105 @@
+import { EventEmitter } from 'node:events';
+import type { WebSocket } from 'ws';
+import { RepresentationMetadata } from '../../../../../src/http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../../../../src/http/representation/ResourceIdentifier';
+import type { Logger } from '../../../../../src/logging/Logger';
+import { getLoggerFor } from '../../../../../src/logging/LogUtil';
+import type { ActivityEmitter } from '../../../../../src/server/notifications/ActivityEmitter';
+import type { NotificationChannel } from '../../../../../src/server/notifications/NotificationChannel';
+import type {
+  NotificationChannelStorage,
+} from '../../../../../src/server/notifications/NotificationChannelStorage';
+import type { NotificationHandler } from '../../../../../src/server/notifications/NotificationHandler';
+import {
+  WebSocketListeningActivityHandler,
+} from '../../../../../src/server/notifications/WebSocketChannel2023/WebSocketListeningActivityHandler';
+import { WebSocketMap } from '../../../../../src/server/notifications/WebSocketChannel2023/WebSocketMap';
+import { AS, NOTIFY } from '../../../../../src/util/Vocabularies';
+import { flushPromises } from '../../../../util/Util';
+
+jest.mock('../../../../../src/logging/LogUtil', (): any => {
+  const logger: Logger = { error: jest.fn() } as any;
+  return { getLoggerFor: (): Logger => logger };
+});
+
+describe('A WebSocketListeningActivityHandler', (): void => {
+  const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
+  const topic: ResourceIdentifier = { path: 'http://example.com/foo' };
+  const activity = AS.terms.Update;
+  const metadata = new RepresentationMetadata();
+  const webSocket: WebSocket = { send: jest.fn() } as any;
+  let channel: NotificationChannel;
+  let storage: jest.Mocked<NotificationChannelStorage>;
+  let emitter: ActivityEmitter;
+  let notificationHandler: jest.Mocked<NotificationHandler>;
+  let socketMap: WebSocketMap;
+
+  beforeEach(async(): Promise<void> => {
+    jest.clearAllMocks();
+    channel = {
+      id: 'id',
+      topic: 'http://example.com/foo',
+      type: NOTIFY.WebSocketChannel2023,
+    };
+
+    storage = {
+      getAll: jest.fn().mockResolvedValue([ channel.id ]),
+      get: jest.fn().mockResolvedValue(channel),
+      update: jest.fn(),
+    } as any;
+
+    emitter = new EventEmitter() as any;
+
+    notificationHandler = {
+      handleSafe: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    socketMap = new WebSocketMap();
+
+    // eslint-disable-next-line no-new
+    new WebSocketListeningActivityHandler(storage, emitter, notificationHandler, socketMap);
+  });
+
+  it('calls the NotificationHandler for channels with a socket on this instance.', async(): Promise<void> => {
+    socketMap.add(channel.id, webSocket);
+    emitter.emit('changed', topic, activity, metadata);
+
+    await flushPromises();
+
+    expect(notificationHandler.handleSafe).toHaveBeenCalledTimes(1);
+    expect(notificationHandler.handleSafe).toHaveBeenLastCalledWith({ channel, activity, topic, metadata });
+    expect(logger.error).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not query the channel storage when this instance has no sockets at all.', async(): Promise<void> => {
+    emitter.emit('changed', topic, activity, metadata);
+
+    await flushPromises();
+
+    expect(storage.getAll).toHaveBeenCalledTimes(0);
+    expect(notificationHandler.handleSafe).toHaveBeenCalledTimes(0);
+    expect(logger.error).toHaveBeenCalledTimes(0);
+  });
+
+  it('ignores channels whose socket is held by a different instance.', async(): Promise<void> => {
+    socketMap.add('other-id', webSocket);
+    emitter.emit('changed', topic, activity, metadata);
+
+    await flushPromises();
+
+    expect(storage.getAll).toHaveBeenCalledTimes(1);
+    expect(notificationHandler.handleSafe).toHaveBeenCalledTimes(0);
+    expect(logger.error).toHaveBeenCalledTimes(0);
+  });
+
+  it('ignores channels of a different type.', async(): Promise<void> => {
+    channel.type = NOTIFY.WebhookChannel2023;
+    socketMap.add(channel.id, webSocket);
+    emitter.emit('changed', topic, activity, metadata);
+
+    await flushPromises();
+
+    expect(notificationHandler.handleSafe).toHaveBeenCalledTimes(0);
+    expect(logger.error).toHaveBeenCalledTimes(0);
+  });
+});

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -7,6 +7,8 @@ const portNames = [
   // Integration
   'Accounts',
   'AcpServer',
+  'ClusterNotifications',
+  'ClusterNotifications-client',
   'Conditions',
   'ContentNegotiation',
   'DynamicPods',


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### 📁 Related issues

None yet — an upstream issue describing the multi-instance notification gap must be created before this is
submitted to CommunitySolidServer (the PR template requires one).

Stacked on #107 (`feat/redis-activity-bus`), which is stacked on #106 (`feat/cluster-activity-bus`);
the diff here is this phase only. Needs restacking/retargeting once those land.

#### ✍️ Description

In a multi-instance deployment the notification channel types need opposite treatment. WebSockets and
StreamingHTTP streams are pinned to the instance that accepted them, while each instance only observes changes
made through its own `ResourceStore` — so subscribers connected to a different instance than the one performing
a change currently miss notifications. Webhooks have the inverse problem: any instance could deliver them, so
naively listening to a cluster-wide emitter would produce duplicate deliveries.

This PR splits the listening handlers by channel type and wires the `ClusterActivityBus` (#106) into the
notification path, opt-in only:

- `ListeningActivityHandler` gains a protected `supports(channel)` hook (the base returns `true`, so default
  behavior is unchanged) and its `emit` becomes `protected`. The split is implemented as subclasses so each
  handler filters to its own channel type, and the other type's channels are skipped silently instead of
  error-logging through a mismatched `TypedNotificationHandler`.
- The new `WebSocketListeningActivityHandler` listens (in cluster config) to the `ClusterActivityEmitter` —
  the changes of the whole cluster — and delivers only to sockets this instance holds. It skips all work,
  including the `SubscriptionStorage.getAll()` read, when the local socket map is empty, and skips individual
  channels whose socket lives on another instance (the socket map is keyed by channel id, filled by
  `WebSocket2023Storer`). A finer topic→socket index, so instances holding *some* sockets also skip storage
  reads for topics nobody watches locally, would require changes to `WebSocket2023Storer` and is left as a
  follow-up.
- The new `WebhookListeningActivityHandler` stays on the local `ResourceStore` emitter, so exactly one
  instance — the originating one — sends each webhook: deduplication by construction, no new coordination
  state. If that instance stops before delivery finishes those notifications are lost, which is identical to
  the failure behavior of a single-instance deployment today. Durable / at-least-once delivery (failover via
  the cluster emitter plus dedup state) was considered and deferred: it needs shared state and can be added
  later without touching this split.

The config surface is importable cluster files (`config/http/notifications/cluster/{memory,redis}.json`) that a
deployer imports **instead of** `config/http/notifications/all.json`, following the RedisLocker "swap the
import" precedent. The diff against the base branch modifies zero existing files under `config/` and nothing
imports the new directory by default, so the resolved default configuration is unchanged by construction. Two
reviewer notes:

- `cluster/streaming-http.json` duplicates `streaming-http/http.json` with a single changed reference
  (`emitter` → `ClusterActivityEmitter`). Components.js cannot override one parameter of an imported component
  instance, so a variant file is the only option that keeps the default file untouched; changes to the default
  file need mirroring here.
- `cluster/redis.json` reuses the `RedisActivityBus` (#107) and mirrors `config/util/resource-locker/redis.json`
  for the lifecycle hooks; deployers can point it at the same Redis instance the Redis locker uses.

Unit tests cover both new handlers and the `supports` hook, keeping `./src` at 100% coverage. A new integration
test boots `cluster/memory.json` and verifies a write is delivered exactly once to a WebSocket subscriber and
exactly once to a webhook receiver, and that StreamingHTTP receiveFrom endpoints still stream updates through
the cluster emitter. Real multi-instance end-to-end verification and deployment documentation are follow-up
phases.

This PR is not performance-motivated and no reproducible benchmark command exists for it; the one efficiency
claim (the zero-subscriber skip avoids the channel-storage read) is asserted deterministically by a unit test.

Intended semver level: **minor** — a backwards-compatible feature addition (the `private` → `protected`
widening of `emit` and the new `supports` hook change no default behavior). As a feature with class-signature
changes it should target the latest `versions/*` branch upon upstream submission, per the contribution guide.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
