### PR TITLE
feat: Support exponential backoff between lock retries

### DIFF
--- a/src/util/LockUtils.ts
+++ b/src/util/LockUtils.ts
@@ -24,6 +24,13 @@ export interface AttemptSettings {
   retryDelay?: number;
   /** Add a fraction of jitter to the original delay each attempt (in ms). */
   retryJitter?: number;
+  /**
+   * Rate of exponential backoff. 1 keeps the delay constant,
+   * greater than 1 backs off for longer and longer. Should never be less than 1.
+   */
+  retryBackoffFactor?: number;
+  /** The upper bound for the delay between attempts (in ms). */
+  retryDelayMax?: number;
 }
 
 /**
@@ -36,13 +43,15 @@ export interface AttemptSettings {
  * @param settings - The options on how to retry the function
  */
 export async function retryFunction<T>(fn: () => Promise<T>, settings: Required<AttemptSettings>): Promise<T> {
-  const { retryCount, retryDelay, retryJitter } = settings;
+  const { retryCount, retryDelay, retryJitter, retryBackoffFactor, retryDelayMax } = settings;
   const maxTries = retryCount === -1 ? Number.POSITIVE_INFINITY : retryCount + 1;
   let tries = 1;
+  let delay = retryDelay;
   let result = await fn();
 
   while (typeof result === 'undefined' && tries < maxTries) {
-    await setJitterTimeout(retryDelay, retryJitter);
+    await setJitterTimeout(delay, retryJitter);
+    delay = Math.min(delay * retryBackoffFactor, retryDelayMax);
     result = await fn();
     tries += 1;
   }

--- a/src/util/locking/FileSystemResourceLocker.ts
+++ b/src/util/locking/FileSystemResourceLocker.ts
@@ -29,7 +29,13 @@ const defaultUnlockOptions: UnlockOptions = {
   realpath: false,
 };
 
-const attemptDefaults: Required<AttemptSettings> = { retryCount: -1, retryDelay: 50, retryJitter: 30 };
+const attemptDefaults: Required<AttemptSettings> = {
+  retryCount: -1,
+  retryDelay: 50,
+  retryJitter: 30,
+  retryBackoffFactor: 2,
+  retryDelayMax: 1000,
+};
 
 /**
  * Argument interface of the FileSystemResourceLocker constructor.

--- a/src/util/locking/RedisLocker.ts
+++ b/src/util/locking/RedisLocker.ts
@@ -11,7 +11,13 @@ import type { ResourceLocker } from './ResourceLocker';
 import type { RedisAnswer, RedisReadWriteLock, RedisResourceLock } from './scripts/RedisLuaScripts';
 import { fromResp2ToBool, REDIS_LUA_SCRIPTS } from './scripts/RedisLuaScripts';
 
-const attemptDefaults: Required<AttemptSettings> = { retryCount: -1, retryDelay: 50, retryJitter: 30 };
+const attemptDefaults: Required<AttemptSettings> = {
+  retryCount: -1,
+  retryDelay: 50,
+  retryJitter: 30,
+  retryBackoffFactor: 1,
+  retryDelayMax: 1000,
+};
 
 // Internal prefix for Redis keys;
 const PREFIX_RW = '__RW__';

--- a/test/unit/util/LockUtil.test.ts
+++ b/test/unit/util/LockUtil.test.ts
@@ -1,4 +1,6 @@
-import { setJitterTimeout } from '../../../src/util/LockUtils';
+import type { AttemptSettings } from '../../../src/util/LockUtils';
+import { retryFunction, setJitterTimeout } from '../../../src/util/LockUtils';
+import { InternalServerError } from '../../../src/util/errors/InternalServerError';
 
 jest.useFakeTimers();
 
@@ -26,6 +28,55 @@ describe('LockUtil', (): void => {
       expect(elapsed).toBe(1100);
       // Clean up
       jest.spyOn(globalThis.Math, 'random').mockRestore();
+    });
+  });
+
+  describe('#retryFunction', (): void => {
+    const settings: Required<AttemptSettings> = {
+      retryCount: 4,
+      retryDelay: 100,
+      retryJitter: 0,
+      retryBackoffFactor: 1,
+      retryDelayMax: 1000,
+    };
+    let timeoutSpy: jest.SpyInstance;
+
+    beforeEach(async(): Promise<void> => {
+      timeoutSpy = jest.spyOn(globalThis, 'setTimeout');
+    });
+
+    afterEach(async(): Promise<void> => {
+      timeoutSpy.mockRestore();
+    });
+
+    it('returns the value of the function immediately when it succeeds.', async(): Promise<void> => {
+      const fn = jest.fn().mockResolvedValue('result');
+      await expect(retryFunction(fn, settings)).resolves.toBe('result');
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(timeoutSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it('retries with a constant delay when the backoff factor is 1.', async(): Promise<void> => {
+      const fn = jest.fn()
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce('result');
+      const promise = retryFunction(fn, settings);
+      await jest.runAllTimersAsync();
+      await expect(promise).resolves.toBe('result');
+      expect(fn).toHaveBeenCalledTimes(3);
+      expect(timeoutSpy.mock.calls.map((call): number => call[1] as number)).toEqual([ 100, 100 ]);
+    });
+
+    it('increases the delay by the backoff factor up to the configured maximum.', async(): Promise<void> => {
+      const fn = jest.fn().mockResolvedValue(undefined);
+      const promise = retryFunction(fn, { ...settings, retryBackoffFactor: 2, retryDelayMax: 500 });
+      // Prevent the rejection from being treated as unhandled while the timers are being advanced
+      promise.catch(jest.fn());
+      await jest.runAllTimersAsync();
+      await expect(promise).rejects.toThrow(InternalServerError);
+      expect(fn).toHaveBeenCalledTimes(5);
+      expect(timeoutSpy.mock.calls.map((call): number => call[1] as number)).toEqual([ 100, 200, 400, 500 ]);
     });
   });
 });

--- a/test/unit/util/locking/FileSystemResourceLocker.test.ts
+++ b/test/unit/util/locking/FileSystemResourceLocker.test.ts
@@ -13,7 +13,10 @@ describe('A FileSystemResourceLocker', (): void => {
   const identifier = { path: 'http://test.com/foo' };
 
   beforeEach(async(): Promise<void> => {
-    locker = new FileSystemResourceLocker({ rootFilePath, attemptSettings: { retryCount: 19, retryDelay: 100 }});
+    locker = new FileSystemResourceLocker({
+      rootFilePath,
+      attemptSettings: { retryCount: 19, retryDelay: 100, retryBackoffFactor: 1 },
+    });
     await locker.initialize();
   });
 


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

- Split out of #23 per review there: the exponential backoff and the restricted error swallowing should be separate PRs. This PR carries only the backoff.
- No upstream issue yet: one must be created on CommunitySolidServer/CommunitySolidServer before submission (the upstream PR template requires a linked issue).

#### ✍️ Description

Every request waiting on a held file system lock polls the disk (`mkdir` + `stat` on `.internal/locks/<md5>`) at a fixed 50 ms interval (plus up to 30 ms jitter) — 12–20 times per second per waiter — for as long as the lock is held.

`AttemptSettings` gains optional `retryBackoffFactor` and `retryDelayMax`. `FileSystemResourceLocker` defaults to factor 2 capped at 1000 ms, so a long-waiting acquisition decays to one disk poll per second while the first retries stay at 50 ms. `RedisLocker` keeps factor 1, preserving its behaviour exactly.

The retry-schedule change is deterministic (per waiting acquisition, default settings, ignoring jitter):

| | Delays between attempts | Attempts in the first 10 s | Steady state |
| --- | --- | --- | --- |
| before | 50 ms, 50 ms, 50 ms, … | ~200 | 20/s |
| after | 50, 100, 200, 400, 800 ms, then 1 s | ~14 | 1/s |

Trade-off: under long contention a waiter can now oversleep a release by up to `retryDelayMax` (1 s); contention shorter than ~1 s is virtually unaffected. Both knobs are configurable per instance via `attemptSettings`.

The `retryBackoffFactor` JSDoc uses the wording suggested in the #23 review, adjusted to "Should never be less than 1" because `RedisLocker` deliberately keeps factor 1 for a constant delay.

Intended semver level (labels cannot be set by contributors): **semver.minor** — the new `AttemptSettings` fields are optional. Note for the maintainer's judgement: call sites typed as `Required<AttemptSettings>` need the new fields, and the file locker's default retry pacing changes, which may weigh towards major. On upstream submission this should target the latest versions branch rather than `main`; it targets the fork's `main` here only for review.

Independent of #23; the `LockUtil.test.ts` additions overlap textually with the last-attempt fix PR, so whichever of the two lands last needs a trivial rebase.

`npm run build`, `npm run lint`, `npm run test:ts` and `npm run test:unit` (with the 100 % `./src` coverage thresholds) are green on this branch.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
