### PR TITLE
fix: Return the result when the last allowed retry attempt succeeds

### DIFF
--- a/src/util/LockUtils.ts
+++ b/src/util/LockUtils.ts
@@ -47,8 +47,8 @@ export async function retryFunction<T>(fn: () => Promise<T>, settings: Required<
     tries += 1;
   }
 
-  // Max tries was reached: throw first!
-  if (tries >= maxTries) {
+  // Max tries was reached without a result
+  if (typeof result === 'undefined') {
     const err = `The operation did not succeed after the set maximum of tries (${maxTries}).`;
     logger.warn(err);
     throw new InternalServerError(err);

--- a/test/unit/util/LockUtil.test.ts
+++ b/test/unit/util/LockUtil.test.ts
@@ -1,4 +1,5 @@
-import { setJitterTimeout } from '../../../src/util/LockUtils';
+import type { AttemptSettings } from '../../../src/util/LockUtils';
+import { retryFunction, setJitterTimeout } from '../../../src/util/LockUtils';
 
 jest.useFakeTimers();
 
@@ -26,6 +27,31 @@ describe('LockUtil', (): void => {
       expect(elapsed).toBe(1100);
       // Clean up
       jest.spyOn(globalThis.Math, 'random').mockRestore();
+    });
+  });
+
+  describe('#retryFunction', (): void => {
+    const settings: Required<AttemptSettings> = { retryCount: 4, retryDelay: 100, retryJitter: 0 };
+
+    it('returns the value when the last allowed attempt succeeds.', async(): Promise<void> => {
+      const fn = jest.fn()
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce('result');
+      const promise = retryFunction(fn, { ...settings, retryCount: 1 });
+      await jest.runAllTimersAsync();
+      await expect(promise).resolves.toBe('result');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('errors when the maximum amount of tries is reached without a result.', async(): Promise<void> => {
+      const fn = jest.fn().mockResolvedValue(undefined);
+      const promise = retryFunction(fn, settings);
+      // Prevent the rejection from being treated as unhandled while the timers are being advanced
+      promise.catch(jest.fn());
+      await jest.runAllTimersAsync();
+      await expect(promise).rejects
+        .toThrow('The operation did not succeed after the set maximum of tries (5).');
+      expect(fn).toHaveBeenCalledTimes(5);
     });
   });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready). Opened against the fork so it can be reviewed before upstreaming.

#### 📁 Related issues

- Split out of #23 per review there, so that PR stays minimal. This PR carries only the `retryFunction` last-attempt fix.
- No upstream issue yet: one must be created on CommunitySolidServer/CommunitySolidServer before submission (the upstream PR template requires a linked issue).

#### ✍️ Description

`retryFunction` threw "The operation did not succeed after the set maximum of tries" whenever the attempt counter reached the maximum, even when that final attempt had succeeded — and since the underlying lock operation had succeeded, the lock file was left acquired on disk while the caller saw an error. The check is now based on whether a result was produced rather than on the attempt counter. The regression test (`returns the value when the last allowed attempt succeeds.`) fails on `main`.

As raised in the #23 review, the `InternalServerError` thrown here couples a util to an HTTP status code. It is deliberately left untouched in this PR to keep the diff minimal: replacing it with a transport-neutral error (e.g. `ErrMaxTriesReached`) that the lockers map to an HTTP error changes the observable error contract of both `FileSystemResourceLocker` and `RedisLocker`, so that refactor is proposed as its own follow-up PR.

Intended semver level (labels cannot be set by contributors): **semver.patch**.

Independent of #23 and #110; the `LockUtil.test.ts` additions overlap textually with #110, so whichever of the two lands last needs a trivial rebase.

`npm run build`, `npm run lint`, `npm run test:ts` are green on this branch. `npm run test:unit` (with the 100 % `./src` coverage thresholds) is green apart from the pre-existing `A FileSystemResourceLocker › blocks lock acquisition until they are released.` race, which fails at the same rate (2 in 4 solo runs) on unmodified `main` on the same machine — it races three concurrent first acquisition attempts and is unrelated to this diff, which only changes behaviour when the final allowed retry succeeds.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
